### PR TITLE
Add validators for manifest fields.

### DIFF
--- a/apps/apps_test.go
+++ b/apps/apps_test.go
@@ -1,21 +1,19 @@
 package apps_test
 
 import (
-	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"tidbyt.dev/community/apps"
 )
-
-// TODO(mark): add tests to validate all applet fields. We should check casing,
-// spelling, and length.
 
 // TODO(mark): add a test that tests the actual starlark
 
 // TODO(mark): add the ability to use our unit test module.
-func TestGetManifests(t *testing.T) {
+func TestManifestsValidate(t *testing.T) {
 	applets := apps.GetManifests()
 	for _, app := range applets {
-		fmt.Println(app.Name)
+		err := app.Validate()
+		assert.NoError(t, err)
 	}
 }

--- a/apps/manifest/manifest.go
+++ b/apps/manifest/manifest.go
@@ -19,6 +19,8 @@ type Manifest struct {
 	Source []byte `json:"-"`
 }
 
+// Validate ensures all fields of the manifest are valid and returns an error
+// if they are not.
 func (m Manifest) Validate() error {
 	err := ValidateName(m.Name)
 	if err != nil {

--- a/apps/manifest/validate.go
+++ b/apps/manifest/validate.go
@@ -5,21 +5,87 @@ import (
 	"strings"
 )
 
+const (
+	// Our longest app name to date. This can be updated, but it will need to
+	// be tested in the mobile app.
+	MaxNameLength = 16
+
+	// Our longest app summary to date. This can be updated, but it will need to
+	// be tested in the mobile app.
+	MaxSummaryLength = 27
+)
+
+var punctuation []string = []string{
+	".",
+	"!",
+	"?",
+}
+
+// ValidateName ensures the app name provided adheres to the standards for app
+// names. We're picky here because these will display in the Tidbyt mobile app
+// and need to display properly.
 func ValidateName(name string) error {
 	if name != strings.Title(name) {
-		return fmt.Errorf("%s should be title case, 'Fuzzy Clock' for example", name)
+		return fmt.Errorf("'%s' should be title case, 'Fuzzy Clock' for example", name)
 	}
+
+	if len(name) > MaxNameLength {
+		return fmt.Errorf("app names need to be less then %d characters", MaxNameLength)
+	}
+
 	return nil
 }
 
+// ValidateSummary ensures the app summary provided adheres to the standards
+// for app summaries. We're picky here because these will display in the Tidbyt
+// mobile app and need to display properly.
 func ValidateSummary(summary string) error {
+	if len(summary) > MaxSummaryLength {
+		return fmt.Errorf("app summaries need to be less then %d characters", MaxSummaryLength)
+	}
+
+	for _, punct := range punctuation {
+		if strings.HasSuffix(summary, punct) {
+			return fmt.Errorf("app summaries should not end in punctuation")
+		}
+	}
+
+	words := strings.Split(summary, " ")
+	if len(words) > 0 && words[0] != strings.Title(words[0]) {
+		return fmt.Errorf("app summaries should start with an uppercased character")
+	}
+
 	return nil
 }
 
+// ValidateDesc ensures the app description provided adheres to the standards
+// for app descriptions. We're picky here because these will display in the
+// Tidbyt mobile app and need to display properly.
 func ValidateDesc(desc string) error {
+	found := false
+	for _, punct := range punctuation {
+		if strings.HasSuffix(desc, punct) {
+			found = true
+		}
+	}
+	if !found {
+		return fmt.Errorf("app descriptions should end in punctuation")
+	}
+
+	words := strings.Split(desc, " ")
+	if len(words) > 0 && words[0] != strings.Title(words[0]) {
+		return fmt.Errorf("app descriptions should start with an uppercased character")
+	}
+
 	return nil
 }
 
+// ValidateAuthor ensures the app author provided adheres to the standards
+// for app author. We're picky here because these will display in the
+// Tidbyt mobile app and need to display properly.
 func ValidateAuthor(author string) error {
+	// I don't know what validation where need here just yet. We're going to
+	// have to eyeball it in pull requests until we get a sense of what doesn't
+	// work.
 	return nil
 }

--- a/apps/manifest/validate_test.go
+++ b/apps/manifest/validate_test.go
@@ -1,0 +1,83 @@
+package manifest_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"tidbyt.dev/community/apps/manifest"
+)
+
+func TestValidateName(t *testing.T) {
+	type test struct {
+		input     string
+		shouldErr bool
+	}
+
+	tests := []test{
+		{input: "Cool App", shouldErr: false},
+		{input: "Cool app", shouldErr: true},
+		{input: "cool app", shouldErr: true},
+		{input: "coolApp", shouldErr: true},
+		{input: "Really Really Long App Name", shouldErr: true},
+	}
+
+	for _, tc := range tests {
+		err := manifest.ValidateName(tc.input)
+
+		if tc.shouldErr {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+		}
+	}
+}
+
+func TestValidateSummary(t *testing.T) {
+	type test struct {
+		input     string
+		shouldErr bool
+	}
+
+	tests := []test{
+		{input: "A cool app", shouldErr: false},
+		{input: "A really really really cool app", shouldErr: true},
+		{input: "A cool app.", shouldErr: true},
+		{input: "A cool app!", shouldErr: true},
+		{input: "A cool app?", shouldErr: true},
+		{input: "a cool app", shouldErr: true},
+		{input: "NYC Subway departures", shouldErr: false},
+	}
+
+	for _, tc := range tests {
+		err := manifest.ValidateSummary(tc.input)
+
+		if tc.shouldErr {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+		}
+	}
+}
+
+func TestValidateDesc(t *testing.T) {
+	type test struct {
+		input     string
+		shouldErr bool
+	}
+
+	tests := []test{
+		{input: "A really cool app that does really cool app things.", shouldErr: false},
+		{input: "a really cool app that does really cool app things.", shouldErr: true},
+		{input: "A really cool app that does really cool app things", shouldErr: true},
+	}
+
+	for _, tc := range tests {
+		err := manifest.ValidateDesc(tc.input)
+
+		if tc.shouldErr {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+		}
+	}
+}


### PR DESCRIPTION
This commit adds more validation logic to manifest fields and updates
the apps_test to inclide them. This way, we validate both during `make
app` and during unit tests in the PR process.