### PR TITLE
Fix big clock summary.

### DIFF
--- a/apps/bigclock/big_clock.star
+++ b/apps/bigclock/big_clock.star
@@ -3,7 +3,7 @@ Applet: Big Clock
 Summary: Display a large retro-style clock
 Description: Display a large retro-style clock; the clock can change color
   at night based on sunrise and sunset times for a given location, supports
-  24-hour and 12-hour variants and optionally flashes the seperator.
+  24-hour and 12-hour variants and optionally flashes the separator.
 Author: Joey Hoer
 """
 

--- a/apps/bigclock/bigclock.go
+++ b/apps/bigclock/bigclock.go
@@ -17,7 +17,7 @@ func New() manifest.Manifest {
 		Name:        "Big Clock",
 		Author:      "Joey Hoer",
 		Summary:     "A large retro-style clock",
-		Desc:        "Display a large retro-style clock; the clock can change color at night based on sunrise and sunset times for a given location, supports 24-hour and 12-hour variants and optionally flashes the seperator.",
+		Desc:        "Display a large retro-style clock; the clock can change color at night based on sunrise and sunset times for a given location, supports 24-hour and 12-hour variants and optionally flashes the separator.",
 		FileName:    "big_clock.star",
 		PackageName: "bigclock",
 		Source:      source,


### PR DESCRIPTION
This commit shortens big clocks summary. The build didn't run on the PR
(my fault, the action was misconfigured) that would have caught this.
The reason it has a max length is a problem is it shows up directly in
the UI. We may be able to support longer then 27 characters, but we'd
need to test it on multiple devices to see how it looked.