### PR TITLE
big-clock: Fix timezone and preview issues.

### DIFF
--- a/apps/bigclock/bigclock.go
+++ b/apps/bigclock/bigclock.go
@@ -17,7 +17,7 @@ func New() manifest.Manifest {
 		Name:        "Big Clock",
 		Author:      "Joey Hoer",
 		Summary:     "A large retro-style clock",
-		Desc:        "Display a large retro-style clock; the clock can change color at night based on sunrise and sunset times for a given location, supports 24-hour and 12-hour variants and optionally flashes the separator.",
+		Desc:        "Display a large retro-style clock; the clock can change color at night based on sunrise and sunset times for a given location, supports 24-hour and 12-hour variants and optionally flashes the separator. Sunrise/sunset times provided by sunrise-sunset.org.",
 		FileName:    "big_clock.star",
 		PackageName: "bigclock",
 		Source:      source,


### PR DESCRIPTION
# Overview
There were a few issues reported around sunrise/sunset timings and rendering previews that were too dark. #49 didn't entirely resolve the sunrise/sunset issues so I thought I would help out.

# Changes
- big-clock: Fix timezone and preview issues.
    - This commit resolves a few issues with the timezone and rendering previews that are too dark.
    
# Fixes
- I added `formatted=0` to get the full UTC timestamp and updated the parsing. I also updated the comparison to compare all timestamps against UTC to ensure the comparison works as expected. This should resolve all issues around calculating day or night times.
- Sunrise/sunset requires that attribution is given, so I added it to the description
- Folks mentioned the preview was hard to read at nighttime, so I set the default color at nighttime to white so the previews render with white text at all hours
- Truncate location. This does two things: one it improves the cache hit rate, but two it prevents leaking location data to third party APIs. One decimal place is still ~10km which means sunrise/sunset times will still be fairly accurate.

# Tests
I updated the location/timezone to Honolulu and the Howland Island as spot checks. I also double checked that Richmond still works as expected.