### PR TITLE
Workaround for they_said_so.star SSL certificate expiration

### DIFF
--- a/apps/theysaidso/they_said_so.star
+++ b/apps/theysaidso/they_said_so.star
@@ -35,7 +35,7 @@ load('cache.star', 'cache')
 load('encoding/base64.star', 'base64')
 load('encoding/json.star', 'json')
 
-URL = 'https://quotes.rest/qod.json?category='
+URL = 'http://quotes.rest/qod.json?category='
 
 WIDTH = 64
 HEIGHT = 32
@@ -68,7 +68,7 @@ CATEGORIES = [
 
 # Takes category (value from CATEGORIES)
 def main(config):
-    category = config.get('category') or 'inspire'
+    category = config.get('category') or 'fake'
 
     if category in CATEGORIES:
         key = 'qod:' + category


### PR DESCRIPTION
Switched to http to get around the certificate expiration since the data is not particularly private anyway.
Modified so that an HTTP request is not made when run without parameters (e.g., when running tests) so as not to eat into the rate limits.