### PR TITLE
readme: Fix build icon.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Community Apps
-![Main Workflow](https://github.com/tidbyt/community/actions/workflows/pull-request.yml/badge.svg)
+![Main Workflow](https://github.com/tidbyt/community/actions/workflows/main.yml/badge.svg)
 
 Community Apps is a publishing platform for apps developed by the [Tidbyt community][3] 🚀 
 


### PR DESCRIPTION
This commit points the icon against main instead of a PR build.