### PR TITLE
Wait a couple days to lock pull requests

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -26,3 +26,4 @@ jobs:
           path-to-signatures: signatures.json
 
           signed-commit-message: "$contributorName has signed the CLA in tidbyt/community#$pullRequestNo"
+          lock-pullrequest-aftermerge: false

--- a/.github/workflows/lock-prs.yaml
+++ b/.github/workflows/lock-prs.yaml
@@ -1,0 +1,21 @@
+name: Lock closed pull requests
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+
+concurrency:
+  group: lock
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v3
+        with:
+          github-token: ${{ secrets.TIDBYT_GITHUB_TOKEN }}
+          process-only: prs
+          pr-inactive-days: '2'


### PR DESCRIPTION
Bot was locking pull requests immediately after they were merged.
Instead, wait for a couple days of inactivity. This allows people to
follow up and respond to comments.