### PR TITLE
Made they_said_so cache error responses so as not to hammer the API.

### DIFF
--- a/apps/theysaidso/they_said_so.star
+++ b/apps/theysaidso/they_said_so.star
@@ -91,6 +91,7 @@ def main(config):
                     'quote': 'Forsooth, the server quoteth "%s".' % content.status_code,
                     'author': 'Anonymous',
                 }
+                cache.set(key, json.encode(content), TTL)
         else:
             #print("using cache for " + category)
             content = json.decode(content)


### PR DESCRIPTION
I don't want to hammer the API when it's returning errors, so I think the app should cache the error response for an hour.