### PR TITLE
Add Bouncing DVD Logo app

### DIFF
--- a/apps/apps.go
+++ b/apps/apps.go
@@ -7,9 +7,10 @@ package apps
 import (
 	"tidbyt.dev/community/apps/bigclock"
 	"tidbyt.dev/community/apps/digitalrain"
+	"tidbyt.dev/community/apps/dvdlogo"
 	"tidbyt.dev/community/apps/fuzzyclock"
 	"tidbyt.dev/community/apps/manifest"
-  "tidbyt.dev/community/apps/nyancat"
+	"tidbyt.dev/community/apps/nyancat"
 	"tidbyt.dev/community/apps/theysaidso"
 	"tidbyt.dev/community/apps/twitterfollows"
 )
@@ -20,8 +21,9 @@ func GetManifests() []manifest.Manifest {
 	return []manifest.Manifest{
 		bigclock.New(),
 		digitalrain.New(),
+		dvdlogo.New(),
 		fuzzyclock.New(),
-    nyancat.New(),
+		nyancat.New(),
 		theysaidso.New(),
 		twitterfollows.New(),
 	}

--- a/apps/dvdlogo/dvd_logo.star
+++ b/apps/dvdlogo/dvd_logo.star
@@ -1,0 +1,110 @@
+"""
+Applet: DVD Logo
+Summary: Bouncing DVD Logo
+Description: A screensaver from before the streaming era. Will it hit the corner this time?
+Author: Mack Ward
+"""
+
+load("encoding/base64.star", "base64")
+load("math.star", "math")
+load("render.star", "render")
+load("schema.star", "schema")
+load("time.star", "time")
+
+
+FRAME_WIDTH = 64
+FRAME_HEIGHT = 32
+
+IMAGE_WIDTH = 15
+IMAGE_HEIGHT = 9
+
+IMAGE = """iVBORw0KGgoAAAANSUhEUgAAAA8AAAAJCAYAAADtj3ZXAAAAQUlEQVQokWNgwA3+I2Fc8hgK/iPR//HwMWxhYMBuEDZDcSpCNwiX4VhdgK4AlxiKBnRMUB5fiBJyIUHnE6WQZJsBSnw7xZmNBscAAAAASUVORK5CYII="""
+
+COLORS = [
+    "#0ef",  # light blue
+    "#f70",  # orange
+    "#02f",  # dark blue
+    "#fe0",  # yellow
+    "#f20",  # red
+    "#f08",  # pink
+    "#b0f",  # purple
+]
+
+NUM_X_POSITIONS = FRAME_WIDTH - IMAGE_WIDTH
+NUM_Y_POSITIONS = FRAME_HEIGHT - IMAGE_HEIGHT
+NUM_STATES = NUM_X_POSITIONS * NUM_Y_POSITIONS * len(COLORS) * 2
+
+
+def get_schema():
+    return schema.Schema(
+        version = "1",
+        fields = [],
+    )
+
+
+def main(config):
+    delay = 100 * time.millisecond
+    frames_per_second = time.second / delay
+
+    now = time.now().unix_nano / (1000 * 1000 * 1000)
+    frames_since_epoch = int(now * frames_per_second)
+    index = int(frames_since_epoch % NUM_STATES)
+
+    app_cycle_speed = 30 * time.second
+    num_frames = math.ceil(app_cycle_speed / delay)
+
+    frames = [
+        get_frame(get_state(i))
+        for i in range(index, index + num_frames)
+    ]
+
+    return render.Root(
+        delay=delay.milliseconds,
+        child=render.Animation(frames)
+    )
+
+
+def get_state(index):
+    num_x_hits = index // NUM_X_POSITIONS
+    vel_x = num_x_hits % 2 == 0 and 1 or -1
+
+    num_y_hits = index // NUM_Y_POSITIONS
+    vel_y = num_y_hits % 2 == 0 and 1 or -1
+
+    num_x_states = NUM_X_POSITIONS * 2
+    pos_x = index % num_x_states + 1
+    if vel_x != 1:
+        pos_x = num_x_states - pos_x
+
+    num_y_states = NUM_Y_POSITIONS * 2
+    pos_y = index % num_y_states + 1
+    if vel_y != 1:
+        pos_y = num_y_states - pos_y
+
+    num_corner_hits = index // (NUM_X_POSITIONS * NUM_Y_POSITIONS)
+    num_hits = num_x_hits + num_y_hits - num_corner_hits
+    color = COLORS[num_hits % len(COLORS)]
+
+    return struct(
+        pos_x=pos_x,
+        pos_y=pos_y,
+        vel_x=vel_x,
+        vel_y=vel_y,
+        color=color,
+    )
+
+
+def get_frame(state):
+    return render.Padding(
+        pad=(state.pos_x, state.pos_y, 0, 0),
+        child=render.Stack(
+            children=[
+                render.Box(
+                    width=IMAGE_WIDTH,
+                    height=IMAGE_HEIGHT,
+                    color=state.color,
+                ),
+                render.Image(base64.decode(IMAGE)),
+            ]
+        )
+    )

--- a/apps/dvdlogo/dvd_logo.star
+++ b/apps/dvdlogo/dvd_logo.star
@@ -11,7 +11,6 @@ load("render.star", "render")
 load("schema.star", "schema")
 load("time.star", "time")
 
-
 FRAME_WIDTH = 64
 FRAME_HEIGHT = 32
 
@@ -34,13 +33,11 @@ NUM_X_POSITIONS = FRAME_WIDTH - IMAGE_WIDTH
 NUM_Y_POSITIONS = FRAME_HEIGHT - IMAGE_HEIGHT
 NUM_STATES = NUM_X_POSITIONS * NUM_Y_POSITIONS * len(COLORS) * 2
 
-
 def get_schema():
     return schema.Schema(
         version = "1",
         fields = [],
     )
-
 
 def main(config):
     delay = 100 * time.millisecond
@@ -59,10 +56,9 @@ def main(config):
     ]
 
     return render.Root(
-        delay=delay.milliseconds,
-        child=render.Animation(frames)
+        delay = delay.milliseconds,
+        child = render.Animation(frames),
     )
-
 
 def get_state(index):
     num_x_hits = index // NUM_X_POSITIONS
@@ -86,25 +82,24 @@ def get_state(index):
     color = COLORS[num_hits % len(COLORS)]
 
     return struct(
-        pos_x=pos_x,
-        pos_y=pos_y,
-        vel_x=vel_x,
-        vel_y=vel_y,
-        color=color,
+        pos_x = pos_x,
+        pos_y = pos_y,
+        vel_x = vel_x,
+        vel_y = vel_y,
+        color = color,
     )
-
 
 def get_frame(state):
     return render.Padding(
-        pad=(state.pos_x, state.pos_y, 0, 0),
-        child=render.Stack(
-            children=[
+        pad = (state.pos_x, state.pos_y, 0, 0),
+        child = render.Stack(
+            children = [
                 render.Box(
-                    width=IMAGE_WIDTH,
-                    height=IMAGE_HEIGHT,
-                    color=state.color,
+                    width = IMAGE_WIDTH,
+                    height = IMAGE_HEIGHT,
+                    color = state.color,
                 ),
                 render.Image(base64.decode(IMAGE)),
-            ]
-        )
+            ],
+        ),
     )

--- a/apps/dvdlogo/dvdlogo.go
+++ b/apps/dvdlogo/dvdlogo.go
@@ -1,0 +1,25 @@
+// Package dvdlogo provides details for the DVD Logo applet.
+package dvdlogo
+
+import (
+	_ "embed"
+
+	"tidbyt.dev/community/apps/manifest"
+)
+
+//go:embed dvd_logo.star
+var source []byte
+
+// New creates a new instance of the DVD Logo applet.
+func New() manifest.Manifest {
+	return manifest.Manifest{
+		ID:          "dvd-logo",
+		Name:        "DVD Logo",
+		Author:      "Mack Ward",
+		Summary:     "Bouncing DVD Logo",
+		Desc:        "A screensaver from before the streaming era. Will it hit the corner this time?",
+		FileName:    "dvd_logo.star",
+		PackageName: "dvdlogo",
+		Source:  source,
+	}
+}


### PR DESCRIPTION
This PR introduces the Bouncing DVD Logo app to the community repo! The app was created with the `make app` command and the code was copied from [`mackorone/tidbyt-bouncing-dvd-logo`](https://github.com/mackorone/tidbyt-bouncing-dvd-logo). The app computes and renders 30 seconds worth of frames, and the starting state is a function of the current time.

![dvd_logo](https://user-images.githubusercontent.com/3769813/149638702-fbcbf7ac-495f-4423-b466-dd6ba922a6ab.gif)

