### PR TITLE
sunrise-sunset: Fix bool for 24 hour time.

### DIFF
--- a/apps/sunrisesunset/sunrise_sunset.star
+++ b/apps/sunrisesunset/sunrise_sunset.star
@@ -63,7 +63,7 @@ def main(config):
     sunsetTime = sunrise.sunset(lat, lng, now)
 
     # Get whether to display in 24h format
-    display24Hour = config.get("24_hour", DEFAULT_24_HOUR)
+    display24Hour = config.bool("24_hour", DEFAULT_24_HOUR)
 
     if sunriseTime == None:
         sunriseText = "  None"


### PR DESCRIPTION
This commit fixes an issue where the default for config.get() is to
return a string, which is always truthy. Now we are using config.bool()
which will handle the type cast for us to ensure the string "False" will
actually return as `False`.