### PR TITLE
Don't cache error responses

### DIFF
--- a/apps/jokesjokeapi/jokes_jokeapi.star
+++ b/apps/jokesjokeapi/jokes_jokeapi.star
@@ -51,9 +51,11 @@ def main():
             else:
                 joke = [re.sub('"\"|"\n"', "", rep.json()["joke"])]
 
-        #cache the data
-        cache.set("joke_rate", json.encode(joke), ttl_seconds = 43200)  #grabs it twice a day
+            #cache the data
+            cache.set("joke_rate", json.encode(joke), ttl_seconds = 43200)  #grabs it twice a day
+
         joke_txt = format_text(joke, font)  #render the text
+
     return render.Root(
         delay = 200,  #speed up scroll text
         child = render.Column(

--- a/apps/nationaltoday/nationaltoday.star
+++ b/apps/nationaltoday/nationaltoday.star
@@ -11,12 +11,8 @@ Author: rs7q5 (RIS)
 
 load("render.star", "render")
 load("http.star", "http")
-load("encoding/base64.star", "base64")
 load("encoding/json.star", "json")
 load("cache.star", "cache")
-
-#load("schema.star","schema")
-load("math.star", "math")
 
 #load("time.star","time")
 load("re.star", "re")
@@ -61,11 +57,12 @@ def main():
                 date_split[0] = date_split[0][:3]
 
             holiday_txt.insert(0, " ".join(date_split))
+
+            #cache the data
+            cache.set("holiday_rate", json.encode(holiday_txt), ttl_seconds = 1800)  # cache for 30 min
         else:
             holiday_txt = ["Error", "Could not get holidays!!!!"]
 
-        #cache the data
-        cache.set("holiday_rate", json.encode(holiday_txt), ttl_seconds = 1800)  # cache for 30 min
         holiday_fmt = format_text(holiday_txt, font)
 
     return render.Root(


### PR DESCRIPTION
If servers respond with errors, don't cache them. Otherwise we never try
to fetch again until the cache expires, which for these apps takes quite
a while.