### PR TITLE
[Date Progress] Hide progress labels

### DIFF
--- a/apps/dateprogress/date_progress.star
+++ b/apps/dateprogress/date_progress.star
@@ -191,7 +191,7 @@ def render_progress_bar(state, label, percent, col1, col2, col3, animprogress):
             color = label2color,
             font = "tom-thumb",
         )
-    
+
     return render.Row(
         expanded = True,
         main_align = "space_evenly",

--- a/apps/dateprogress/date_progress.star
+++ b/apps/dateprogress/date_progress.star
@@ -184,8 +184,14 @@ def render_progress_bar(state, label, percent, col1, col2, col3, animprogress):
             ],
         )
 
-    label2 = "{}%".format(int(percent * animprogress / 100))
-
+    label2component = None
+    if state["show_values"] == True:
+        label2component = render.Text(
+            content = "{}%".format(int(percent * animprogress / 100)),
+            color = label2color,
+            font = "tom-thumb",
+        )
+    
     return render.Row(
         expanded = True,
         main_align = "space_evenly",
@@ -209,11 +215,7 @@ def render_progress_bar(state, label, percent, col1, col2, col3, animprogress):
                         expanded = True,
                         children = [
                             render.Box(width = 1, height = 8),
-                            render.Text(
-                                content = label2,
-                                color = label2color,
-                                font = "tom-thumb",
-                            ),
+                            label2component,
                         ],
                     ),
                 ],


### PR DESCRIPTION
While testing the configuration, I noticed that the "Show percentages" option was not hiding the percentage labels.

Before:
![date_progress](https://user-images.githubusercontent.com/72890/152617476-4d80cf9e-d1f9-44b7-ae9e-4eb3c2996fc9.gif)

After:
![date_progress](https://user-images.githubusercontent.com/72890/152617529-f48a4231-08c5-4a86-a0ee-e93872f76f99.gif)

