### PR TITLE
bigclock: Set defaults for schema.

### DIFF
--- a/apps/bigclock/big_clock.star
+++ b/apps/bigclock/big_clock.star
@@ -227,18 +227,21 @@ def get_schema():
                 name = "24 hour format",
                 icon = "clock",
                 desc = "Display the time in 24 hour format.",
+                default = DEFAULT_IS_24_HOUR_FORMAT,
             ),
             schema.Toggle(
                 id = "has_leading_zero",
                 name = "Add leading zero",
                 icon = "creativeCommonsZero",
                 desc = "Ensure the clock always displays with a leading zero.",
+                default = DEFAULT_HAS_LEADING_ZERO,
             ),
             schema.Toggle(
                 id = "has_flashing_seperator",
                 name = "Enable flashing separator",
                 icon = "cog",
                 desc = "Ensure the clock always displays with a leading zero.",
+                default = DEFAULT_HAS_FLASHING_SEPERATOR,
             ),
             schema.Dropdown(
                 id = "color_daytime",


### PR DESCRIPTION
This commit adds defaults for schema toggless. The issue is, we don't know where
the toggle should be by default if these are not set. For most toggles,
the default is False, and config.get("foo", False) typically defaults to
False. But in this case, the default is False but the config value
defaults to True in some cases.