### PR TITLE
Add devcontainer configuration for Github Codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,24 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.222.0/containers/go/.devcontainer/base.Dockerfile
+
+# [Choice] Go version (use -bullseye variants on local arm64/Apple Silicon): 1, 1.16, 1.17, 1-bullseye, 1.16-bullseye, 1.17-bullseye, 1-buster, 1.16-buster, 1.17-buster
+ARG VARIANT="1.17-bullseye"
+FROM mcr.microsoft.com/vscode/devcontainers/go:0-${VARIANT}
+
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
+ARG NODE_VERSION="16"
+RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+
+# [Optional] Uncomment this section to install additional OS packages.
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+     && apt-get -y install --no-install-recommends libwebp-dev 
+
+# [Optional] Uncomment the next lines to use go get to install anything else you need
+WORKDIR /home/vscode
+
+USER vscode
+RUN git clone https://github.com/tidbyt/pixlet.git && cd pixlet && npm install && npm run build && make build \
+     && mkdir -p /home/vscode/.local/bin/ && mv pixlet /home/vscode/.local/bin/
+
+
+# [Optional] Uncomment this line to install global node packages.
+# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,7 +25,8 @@
 
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
-		"golang.Go"
+		"golang.Go",
+		"BazelBuild.vscode-bazel"
 	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
@@ -37,5 +38,10 @@
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode",
 	"features": {
+	},
+	"portsAttributes": {
+		"8080": {
+			"label": "pixlet serve"
+		}
 	}
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,41 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.222.0/containers/go
+{
+	"name": "Go",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			// Update the VARIANT arg to pick a version of Go: 1, 1.16, 1.17
+			// Append -bullseye or -buster to pin to an OS version.
+			// Use -bullseye variants on local arm64/Apple Silicon.
+			"VARIANT": "1.17",
+			// Options
+			"NODE_VERSION": "lts/*"
+		}
+	},
+	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"go.toolsManagement.checkForUpdates": "local",
+		"go.useLanguageServer": true,
+		"go.gopath": "/go",
+		"go.goroot": "/usr/local/go"
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"golang.Go"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "go version",
+
+	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode",
+	"features": {
+	}
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,7 +26,7 @@
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"golang.Go",
-		"BazelBuild.vscode-bazel"
+		"stackbuild.bazel-stack-vscode"
 	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.


### PR DESCRIPTION
This PR adds a [devcontainer](https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/configuring-codespaces-for-your-project) configuration for [Github Codespaces](https://github.com/features/codespaces) to the Community repo.

It configures a Go dev environment, clones and builds the latest version of Pixlet and makes it available in the user's `$PATH`. The Bazel and Go VSCode extensions are installed automatically as well.

This allows anyone to click on Codespaces in the community repo and be creating apps right in the browser with no set up required. When they go to commit it tells them they don’t have permissions to push to the repo and asks to make a fork. If the user chooses to fork, Github makes a new fork and then offers to create a PR automatically.

Running `pixlet serve` in a terminal opens a port which can be opened in the embedded browser for awesome split-screen development:
<img width="2325" alt="Screen-Shot-2022-02-19-19-37-57 93" src="https://user-images.githubusercontent.com/72890/155415983-017648b7-3729-4c7a-862c-b4ab2d66c029.png">

Note: I've noticed that public sharing doesn’t work because Github serves over HTTP, so we’d have to use wss for the web socket connection.
