### PR TITLE
Widget to display a random NFT associated with an Ethereum Public Address

### DIFF
--- a/apps/apps.go
+++ b/apps/apps.go
@@ -27,6 +27,7 @@ import (
 	"tidbyt.dev/community/apps/mbta"
 	"tidbyt.dev/community/apps/nationaltoday"
 	"tidbyt.dev/community/apps/nearearthobjs"
+	"tidbyt.dev/community/apps/nft"
 	"tidbyt.dev/community/apps/nightscout"
 	"tidbyt.dev/community/apps/noaabuoy"
 	"tidbyt.dev/community/apps/nyancat"
@@ -66,6 +67,7 @@ func GetManifests() []manifest.Manifest {
 		mbta.New(),
 		nationaltoday.New(),
 		nearearthobjs.New(),
+		nft.New(),
 		nightscout.New(),
 		noaabuoy.New(),
 		nyancat.New(),

--- a/apps/nft/nft.go
+++ b/apps/nft/nft.go
@@ -1,0 +1,25 @@
+// Package nft provides details for the NFT applet.
+package nft
+
+import (
+	_ "embed"
+
+	"tidbyt.dev/community/apps/manifest"
+)
+
+//go:embed nft.star
+var source []byte
+
+// New creates a new instance of the NFT applet.
+func New() manifest.Manifest {
+	return manifest.Manifest{
+		ID:          "nft",
+		Name:        "NFT",
+		Author:      "nipterink",
+		Summary:     "Random Opensea NFT",
+		Desc:        "Displays a random NFT associated with an Ethereum public address.",
+		FileName:    "nft.star",
+		PackageName: "nft",
+		Source:  source,
+	}
+}

--- a/apps/nft/nft.star
+++ b/apps/nft/nft.star
@@ -14,7 +14,6 @@ load("schema.star", "schema")
 load("secret.star", "secret")
 load("time.star", "time")
 
-
 ASSETS_URL = "https://api.opensea.io/api/v1/assets?format=json&owner={}"
 
 def main(config):
@@ -27,12 +26,12 @@ def main(config):
     return render.Root(
         child = render.Box(
             child = render.Column(
-                cross_align  = "center",
+                cross_align = "center",
                 children = [
                     render.Marquee(
-                        offset_start=64,
-                        width=64,
-                        child = render.Text(nft_name)
+                        offset_start = 64,
+                        width = 64,
+                        child = render.Text(nft_name),
                     ),
                     render.Row(
                         children = [
@@ -41,11 +40,11 @@ def main(config):
                                 height = 24,
                                 width = 24,
                             ),
-                        ]
+                        ],
                     ),
-                ]
-            )
-        )
+                ],
+            ),
+        ),
     )
 
 def fetch_opensea_assets(public_address, api_key):
@@ -56,13 +55,13 @@ def fetch_opensea_assets(public_address, api_key):
     else:
         fetch_url = ASSETS_URL.format(public_address)
         print("Miss! Fetching OpenSea Assets for", public_address)
-        assets_resp = http.get(fetch_url, headers={"X-API-KEY": api_key})
+        assets_resp = http.get(fetch_url, headers = {"X-API-KEY": api_key})
         if (assets_resp.status_code != 200):
-           fail("OpenSea request failed with status", assets_resp.status_code)
+            fail("OpenSea request failed with status", assets_resp.status_code)
 
         nfts = assets_resp.json()["assets"]
-        cache.set("public_address=%s" % public_address, json.encode(nfts), ttl_seconds=3600)
-    
+        cache.set("public_address=%s" % public_address, json.encode(nfts), ttl_seconds = 3600)
+
     return nfts
 
 def fetch_nft_thumbnail(nft):
@@ -77,7 +76,7 @@ def fetch_nft_thumbnail(nft):
         thumbnail_resp = http.get(thumbnail_url)
         if (thumbnail_resp.status_code != 200):
             fail("Failed to fetch thumbnail with status", thumbnail_resp.status_code)
-        cache.set("thumbnail=%s" % thumbnail_url, base64.encode(thumbnail_resp.body()), ttl_seconds=3600)
+        cache.set("thumbnail=%s" % thumbnail_url, base64.encode(thumbnail_resp.body()), ttl_seconds = 3600)
         return (nft_name, thumbnail_resp.body())
 
 def random(max):
@@ -93,7 +92,7 @@ def get_schema():
                 name = "Public Address",
                 desc = "Ethereum Public Address",
                 icon = "ethereum",
-                default = "0xd387a6e4e84a6c86bd90c158c6028a58cc8ac459",
-            )
-        ]
+                default = "0xd6a984153acb6c9e2d788f08c2465a1358bb89a7",
+            ),
+        ],
     )

--- a/apps/nft/nft.star
+++ b/apps/nft/nft.star
@@ -1,0 +1,99 @@
+"""
+Applet: NFT
+Summary: Random Opensea NFT
+Description: Displays a random NFT associated with an Ethereum public address.
+Author: nipterink
+"""
+
+load("cache.star", "cache")
+load("encoding/base64.star", "base64")
+load("encoding/json.star", "json")
+load("http.star", "http")
+load("render.star", "render")
+load("schema.star", "schema")
+load("secret.star", "secret")
+load("time.star", "time")
+
+
+ASSETS_URL = "https://api.opensea.io/api/v1/assets?format=json&owner={}"
+
+def main(config):
+    api_key = secret.decrypt("AV6+xWcEAJh6U3VcNQPxFbXfOyADTC0TQJxUEtd9xUoWMJNEvLLSsLgvXxnpECEEVCuYVK0fQLUDot4yz5PPs8jIuCXlmfFs0BrSjfPSs0eS8RYgM6ZQfoMSo6Oo3Vs6RyuVW7U2P5jS5VhdyqipdJ1bQHcyoRT67JiARa6TuuaWzOmXHrU=") or config.get("opensea-api-key") or ""
+    public_address = config.get("public_address") or "0xd6a984153acb6c9e2d788f08c2465a1358bb89a7"
+    nfts = fetch_opensea_assets(public_address, api_key)
+    nft = nfts[random(len(nfts))]
+    (nft_name, nft_thumbnail) = fetch_nft_thumbnail(nft)
+
+    return render.Root(
+        child = render.Box(
+            child = render.Column(
+                cross_align  = "center",
+                children = [
+                    render.Marquee(
+                        offset_start=64,
+                        width=64,
+                        child = render.Text(nft_name)
+                    ),
+                    render.Row(
+                        children = [
+                            render.Image(
+                                src = nft_thumbnail,
+                                height = 24,
+                                width = 24,
+                            ),
+                        ]
+                    ),
+                ]
+            )
+        )
+    )
+
+def fetch_opensea_assets(public_address, api_key):
+    cached_nfts = cache.get("public_address=%s" % public_address)
+    if cached_nfts != None:
+        print("Hit! Using cached Opensea response for", public_address)
+        nfts = json.decode(cached_nfts)
+    else:
+        fetch_url = ASSETS_URL.format(public_address)
+        print("Miss! Fetching OpenSea Assets for", public_address)
+        assets_resp = http.get(fetch_url, headers={"X-API-KEY": api_key})
+        if (assets_resp.status_code != 200):
+           fail("OpenSea request failed with status", assets_resp.status_code)
+
+        nfts = assets_resp.json()["assets"]
+        cache.set("public_address=%s" % public_address, json.encode(nfts), ttl_seconds=3600)
+    
+    return nfts
+
+def fetch_nft_thumbnail(nft):
+    nft_name = nft["name"]
+    thumbnail_url = nft["image_thumbnail_url"]
+    cached_thumbnail = cache.get("thumbnail=%s" % thumbnail_url)
+    if cached_thumbnail != None:
+        print("Hit! Using cached thumbnail for", nft_name)
+        return (nft_name, base64.decode(cached_thumbnail))
+    else:
+        print("Miss! Fetching image thumbnail for", nft_name)
+        thumbnail_resp = http.get(thumbnail_url)
+        if (thumbnail_resp.status_code != 200):
+            fail("Failed to fetch thumbnail with status", thumbnail_resp.status_code)
+        cache.set("thumbnail=%s" % thumbnail_url, base64.encode(thumbnail_resp.body()), ttl_seconds=3600)
+        return (nft_name, thumbnail_resp.body())
+
+def random(max):
+    """Return a pseudo-random number in [0, max)"""
+    return int(time.now().nanosecond % max)
+
+def get_schema():
+    return schema.Schema(
+        version = "1",
+        fields = [
+            schema.Text(
+                id = "public_address",
+                name = "Public Address",
+                desc = "Ethereum Public Address",
+                icon = "ethereum",
+                default = "0xd387a6e4e84a6c86bd90c158c6028a58cc8ac459",
+            )
+        ]
+    )


### PR DESCRIPTION
This widget connects to the Opensea api and fetches a random NFT to display for a given public address. The default address configured is for https://opensea.io/GaryVee

![nfts](https://user-images.githubusercontent.com/55990898/155452571-c0acb4b4-6f1c-4e27-84c8-3b20183e0778.gif)

