### PR TITLE
Add GA Pilot Buddy app

### DIFF
--- a/apps/apps.go
+++ b/apps/apps.go
@@ -21,6 +21,7 @@ import (
 	"tidbyt.dev/community/apps/espnnews"
 	"tidbyt.dev/community/apps/fishbyt"
 	"tidbyt.dev/community/apps/fuzzyclock"
+	"tidbyt.dev/community/apps/gapilotbuddy"
 	"tidbyt.dev/community/apps/googletraffic"
 	"tidbyt.dev/community/apps/hvvdepartures"
 	"tidbyt.dev/community/apps/jokesjokeapi"
@@ -61,6 +62,7 @@ func GetManifests() []manifest.Manifest {
 		espnnews.New(),
 		fishbyt.New(),
 		fuzzyclock.New(),
+		gapilotbuddy.New(),
 		googletraffic.New(),
 		hvvdepartures.New(),
 		jokesjokeapi.New(),

--- a/apps/gapilotbuddy/ga_pilot_buddy.star
+++ b/apps/gapilotbuddy/ga_pilot_buddy.star
@@ -45,7 +45,7 @@ FLIGHT_RULES_COLOR_MAP = {
 
 def get_avwx_headers(config):
     return {
-        "Authorization": "Token {}".format(secret.decrypt(AVWX_TOKEN) or config.get("avwx_token"))
+        "Authorization": "Token {}".format(secret.decrypt(AVWX_TOKEN) or config.get("avwx_token")),
     }
 
 def get_nearby_aerodromes(location, config):
@@ -61,8 +61,8 @@ def get_nearby_aerodromes(location, config):
 
         # Although we only show three, this grabs extras in case some get filtered
         # out such as military or private aerodromes
-        params = { "n": "10" }
-        resp = http.get(url, params=params, headers=get_avwx_headers(config))
+        params = {"n": "10"}
+        resp = http.get(url, params = params, headers = get_avwx_headers(config))
         if resp.status_code != 200:
             print(resp)
             return None
@@ -73,7 +73,7 @@ def get_nearby_aerodromes(location, config):
     # Caches the response for a week -- aerodromes *really* do not change often
     # This may even be too generous
     # Sets the cache before filtering in case the config changes
-    cache.set(str_geo, json.encode(aerodromes), ttl_seconds=86400)
+    cache.set(str_geo, json.encode(aerodromes), ttl_seconds = 86400)
 
     show_all_aerodromes = config.bool("show_all_aerodromes")
     return [aerodrome for aerodrome in aerodromes if show_all_aerodromes or aerodrome["station"]["operator"] == "PUBLIC"]
@@ -83,7 +83,7 @@ def get_aerodrome_metar(aerodrome, config):
     metar = cache.get(aerodrome_id)
     if metar == None:
         url = "https://avwx.rest/api/metar/{}".format(aerodrome_id)
-        resp = http.get(url, params={}, headers=get_avwx_headers(config))
+        resp = http.get(url, params = {}, headers = get_avwx_headers(config))
         if resp.status_code != 200:
             print(resp)
             return None
@@ -99,7 +99,7 @@ def get_aerodrome_metar(aerodrome, config):
         ttl = int(3600 - time_ago.seconds)
         if ttl < 0:
             ttl = 180
-        cache.set(aerodrome_id, resp.body(), ttl_seconds=ttl)
+        cache.set(aerodrome_id, resp.body(), ttl_seconds = ttl)
     else:
         metar = json.decode(metar)
     return metar
@@ -115,48 +115,48 @@ def render_aerodrome_row(aerodrome, config):
     if metar == None:
         return None
     return render.Padding(
-        pad=(2, 2, 0, 0),
-        child=render.Row(
-            cross_align="center",
-            children=[
+        pad = (2, 2, 0, 0),
+        child = render.Row(
+            cross_align = "center",
+            children = [
                 render.Padding(
-                    pad=(0, 0, 2, 0),
-                    child=render.Circle(
-                        color=FLIGHT_RULES_COLOR_MAP[metar["flight_rules"]] or DEFAULT_FLIGHT_RULES_COLOR,
-                        diameter=6,
+                    pad = (0, 0, 2, 0),
+                    child = render.Circle(
+                        color = FLIGHT_RULES_COLOR_MAP[metar["flight_rules"]] or DEFAULT_FLIGHT_RULES_COLOR,
+                        diameter = 6,
                     ),
                 ),
                 render.Padding(
-                    pad=(0, 0, 2, 0),
-                    child=render.Box(
-                        width=20,
-                        height=8,
-                        child=render.Text(content=aerodrome["station"]["icao"]),
+                    pad = (0, 0, 2, 0),
+                    child = render.Box(
+                        width = 20,
+                        height = 8,
+                        child = render.Text(content = aerodrome["station"]["icao"]),
                     ),
                 ),
                 render.Marquee(
-                    width=50,
-                    offset_start=40,
-                    offset_end=50,
-                    child=render.Text(content=format_weather_short(metar)),
-                )
-            ]
-        )
+                    width = 50,
+                    offset_start = 40,
+                    offset_end = 50,
+                    child = render.Text(content = format_weather_short(metar)),
+                ),
+            ],
+        ),
     )
 
 def render_error():
     return render.Root(
-        child=render.Box(
+        child = render.Box(
             render.Row(
-                expanded=True,
-                main_align="space_evenly",
-                cross_align="center",
-                children=[
-                    render.Image(src=ERROR_ICON),
+                expanded = True,
+                main_align = "space_evenly",
+                cross_align = "center",
+                children = [
+                    render.Image(src = ERROR_ICON),
                     render.Text("Error :("),
                 ],
-            )
-        )
+            ),
+        ),
     )
 
 def main(config):
@@ -175,8 +175,8 @@ def main(config):
         return render_error()
 
     return render.Root(
-        child=render.Column(
-            children=rows,
+        child = render.Column(
+            children = rows,
         ),
     )
 
@@ -191,11 +191,11 @@ def get_schema():
                 icon = "place",
             ),
             schema.Toggle(
-              id = "show_all_aerodromes",
-              name = "Show All Aerodromes",
-              desc = "Enables showing all aerodromes including military, private, etc.",
-              icon = "cog",
-              default = False,
+                id = "show_all_aerodromes",
+                name = "Show All Aerodromes",
+                desc = "Enables showing all aerodromes including military, private, etc.",
+                icon = "cog",
+                default = False,
             ),
         ],
     )

--- a/apps/gapilotbuddy/ga_pilot_buddy.star
+++ b/apps/gapilotbuddy/ga_pilot_buddy.star
@@ -1,0 +1,182 @@
+"""
+Applet: GA Pilot Buddy
+Summary: Local flight rules and wx
+Description: See local aerodrome flight rules and current abbreviated METAR information.
+Author: icdevin
+"""
+
+load("cache.star", "cache")
+load("encoding/base64.star", "base64")
+load("encoding/json.star", "json")
+load("http.star", "http")
+load("humanize.star", "humanize")
+load("render.star", "render")
+load("schema.star", "schema")
+load("secret.star", "secret")
+
+AVWX_TOKEN = """
+AV6+xWcEMClLASnRjwefBSKdSfw7sY2iH8i5AqAiR07g6hb1tptkeFwK31hnx4Y0tdUUBNZ+4zFkhz
+TgMw38WzY+XrFGx2TVG0Aif1XERXmutNCIc9PMLuW4vv2penHt100RwCWglurpqNf0T8ZPLvEUg816
+PG3iHrOD00eIMlxaI8LcEABZYgmutmPWxUXmyg==
+"""
+DEFAULT_LOCATION = """
+{
+    "lat": "33.6295968",
+    "lng": "-117.8862308",
+    "description": "Newport Beach, CA, USA",
+    "locality": "Newport Beach",
+    "place_id": "ChIJ3whWdFnf3IARUV7GZxqUpjs",
+    "timezone": "America/Los_Angeles"
+}
+"""
+DEFAULT_FLIGHT_RULES_COLOR = "#C3C3C3"
+ERROR_ICON = base64.decode("""
+iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAAATElEQVQoU2P8L8L8n/HNX0YGAgCmDq
+yQkCZkebjJuDShi6M4BV0SmyEYbocpwmUjVs/i8xNlNpDkB5JCiaR4IKQYlgBQYppQskCWBwCgNlQN
+phkLigAAAABJRU5ErkJggg==
+""")
+FLIGHT_RULES_COLOR_MAP = {
+    "VFR": "#01CF00",
+    "MVFR": "#0061E7",
+    "IFR": "#EB0000",
+    "LIFR": "#D300D3",
+}
+
+def get_avwx_headers(config):
+    return {
+        "Authorization": "Token {}".format(secret.decrypt(AVWX_TOKEN) or config.get("avwx_token"))
+    }
+
+def get_nearby_aerodromes(location, config):
+    # Truncates the precise lat/lng for data privacy since this will be sent out
+    # to a third party API
+    lat = humanize.float("#.#", float(location["lat"]))
+    lng = humanize.float("#.#", float(location["lng"]))
+    str_geo = "{},{}".format(lat, lng)
+
+    aerodromes = cache.get(str_geo)
+    if aerodromes == None:
+        url = "https://avwx.rest/api/station/near/{}".format(str_geo)
+
+        # Although we only show three, this grabs extras in case some get filtered
+        # out such as military or private aerodromes
+        params = { "n": "10" }
+        resp = http.get(url, params=params, headers=get_avwx_headers(config))
+        if resp.status_code != 200:
+            print(resp)
+            return None
+        aerodromes = resp.json()
+    else:
+        aerodromes = json.decode(aerodromes)
+
+    # Caches the response for a week -- aerodromes *really* do not change often
+    # This may even be too generous
+    # Sets the cache before filtering in case the config changes
+    cache.set(str_geo, json.encode(aerodromes), ttl_seconds=86400)
+
+    show_all_aerodromes = config.bool("show_all_aerodromes")
+    return [aerodrome for aerodrome in aerodromes if show_all_aerodromes or aerodrome["station"]["operator"] == "PUBLIC"]
+
+def get_aerodrome_metar(aerodrome, config):
+    url = "https://avwx.rest/api/metar/{}".format(aerodrome["station"]["icao"])
+    resp = http.get(url, params={}, headers=get_avwx_headers(config))
+    if resp.status_code != 200:
+        print(resp)
+        return None
+    return resp.json()
+
+def format_weather_short(metar):
+    wind = "Wind {}@{}".format(metar["wind_direction"]["repr"], metar["wind_speed"]["repr"])
+    vis = "Vis {}".format(metar["visibility"]["repr"])
+    alt = "Alt {}".format(humanize.float("##.##", metar["altimeter"]["value"]))
+    return "{}, {}, {}".format(wind, vis, alt)
+
+def render_aerodrome_row(aerodrome, config):
+    metar = get_aerodrome_metar(aerodrome, config)
+    if metar == None:
+        return None
+    return render.Padding(
+        pad=(2, 2, 0, 0),
+        child=render.Row(
+            cross_align="center",
+            children=[
+                render.Padding(
+                    pad=(0, 0, 2, 0),
+                    child=render.Circle(
+                        color=FLIGHT_RULES_COLOR_MAP[metar["flight_rules"]] or DEFAULT_FLIGHT_RULES_COLOR,
+                        diameter=6,
+                    ),
+                ),
+                render.Padding(
+                    pad=(0, 0, 2, 0),
+                    child=render.Box(
+                        width=20,
+                        height=8,
+                        child=render.Text(content=aerodrome["station"]["icao"]),
+                    ),
+                ),
+                render.Marquee(
+                    width=50,
+                    offset_start=40,
+                    offset_end=50,
+                    child=render.Text(content=format_weather_short(metar)),
+                )
+            ]
+        )
+    )
+
+def render_error():
+    return render.Root(
+        child=render.Box(
+            render.Row(
+                expanded=True,
+                main_align="space_evenly",
+                cross_align="center",
+                children=[
+                    render.Image(src=ERROR_ICON),
+                    render.Text("Error :("),
+                ],
+            )
+        )
+    )
+
+def main(config):
+    location = config.get("location", DEFAULT_LOCATION)
+    loc = json.decode(location)
+    nearby_aerodromes = get_nearby_aerodromes(loc, config)
+
+    if nearby_aerodromes == None:
+        return render_error()
+    else:
+        nearby_aerodromes = nearby_aerodromes[0:3]
+
+    rows = [render_aerodrome_row(aerodrome, config) for aerodrome in nearby_aerodromes]
+    rows = [row for row in rows if row != None]
+    if len(rows) == 0:
+        return render_error()
+
+    return render.Root(
+        child=render.Column(
+            children=rows,
+        ),
+    )
+
+def get_schema():
+    return schema.Schema(
+        version = "1",
+        fields = [
+            schema.Location(
+                id = "location",
+                name = "Location",
+                desc = "Location for which to display nearby aerodromes",
+                icon = "place",
+            ),
+            schema.Toggle(
+              id = "show_all_aerodromes",
+              name = "Show All Aerodromes",
+              desc = "Enables showing all aerodromes including military, private, etc.",
+              icon = "cog",
+              default = False,
+            ),
+        ],
+    )

--- a/apps/gapilotbuddy/gapilotbuddy.go
+++ b/apps/gapilotbuddy/gapilotbuddy.go
@@ -1,0 +1,25 @@
+// Package gapilotbuddy provides details for the GA Pilot Buddy applet.
+package gapilotbuddy
+
+import (
+	_ "embed"
+
+	"tidbyt.dev/community/apps/manifest"
+)
+
+//go:embed ga_pilot_buddy.star
+var source []byte
+
+// New creates a new instance of the GA Pilot Buddy applet.
+func New() manifest.Manifest {
+	return manifest.Manifest{
+		ID:          "ga-pilot-buddy",
+		Name:        "GA Pilot Buddy",
+		Author:      "icdevin",
+		Summary:     "Local flight rules and wx",
+		Desc:        "See local aerodrome flight rules and current abbreviated METAR information.",
+		FileName:    "ga_pilot_buddy.star",
+		PackageName: "gapilotbuddy",
+		Source:  source,
+	}
+}


### PR DESCRIPTION
This app uses a user-chosen location and a third-party API for nearby aerodromes and their current flight rules and METAR (weather) information. For General Aviation pilots, having this information available at a glance is invaluable as it's the first step in making a go-no go flight decision. I did not include full METAR information as it would probably be a bit too long-form for horizontal marqueeing but the chosen fields are the most relevant.

The app only has one other option other than location, which is "Show All Aerodromes". By default, non-public aerodromes are filtered out; however, if this is enabled, non-public ones such as military or private will also be shown.

Just FYI, flight rules color coding goes like this:
![Color-coding-chart](https://user-images.githubusercontent.com/16701021/155573957-684e8d76-b91c-48e6-ab1b-b80c8ebcdabb.jpg)

So in this example, all 3 local airports are VFR (just how I like it!)

![ga_pilot_buddy](https://user-images.githubusercontent.com/16701021/155573998-063b20d3-790c-4fe7-a0eb-9a1e3cb9b749.gif)

Here's somewhere on the edge of some worse weather:
![ga_pilot_buddy](https://user-images.githubusercontent.com/16701021/155575941-83bfc482-c8b1-4c2f-85e0-21ef6d1e89d9.gif)



