### PR TITLE
Re-encrypt secrets based on app package name

### DIFF
--- a/apps/gapilotbuddy/ga_pilot_buddy.star
+++ b/apps/gapilotbuddy/ga_pilot_buddy.star
@@ -16,9 +16,9 @@ load("secret.star", "secret")
 load("time.star", "time")
 
 AVWX_TOKEN = """
-AV6+xWcEKYzxZW0GV208J4ciOKsI+MwdVGJX35e/kIX89A2rB+cgMBLvNxs11tmh3KhUL++yhf4+KpnQ
-EuosSejtSn9IROb4F0uHYRz+aTrj0j1SbFnC6goUT328pyxSBXZ1Lu0v1OhzFMVkUX4mlSYE+JZVhL0d
-ERwOTPhdbI2LkkAGyWiLyEeNVKvsLTKsLg==
+AV6+xWcExhV/86cLj2rRID9NtWmsaHrdquWQRdLMUDxsODRYS6rvPX++GlGbSkUtrxtHJGPdd+LaW62E
+3kNxH7j9KB1ey9CPUI/ez81m7FaV7uyLdie5CLoV9ri5gSJ91dGnQ6cUsI2bBci073rKHTpwi+JLZdXV
+0NkDAbU/WyV2nbl4cyJAwd20XI4XkBV5KA==
 """
 DEFAULT_LOCATION = """
 {

--- a/apps/googletraffic/google_traffic.star
+++ b/apps/googletraffic/google_traffic.star
@@ -226,7 +226,7 @@ def main(config):
     destinationFull = config.get("destination")
     destinationJSON = json.decode(destinationFull) if destinationFull else DEFAULT_DESTINATION
     destination = "%s,%s" % (destinationJSON.get("lat"), destinationJSON.get("lng"))
-    apikey = secret.decrypt("AV6+xWcEKcu8TenAfiwgtgo9YdGTaE2bVJI2BT08Zvb9GZwzl8m6Pb2RudfILMRj0UH/pZaSh9tCFAlHzFwQ2CPaDcyLAEcuHcJYq6bMrMDuR2z7QjNCkaIvabOE9Db5lNwDqGv+yMr2QFWHffBxvwLWfqOOpDViS4KlLuFUwb/29V2dr/v6OBaEJz3w") or config.get("apikey") or ""
+    apikey = secret.decrypt("AV6+xWcEe+Z+u1tkOzpPxwiDwyS3AYWaC/WfxADDW7/dExL/oGfNbH914X2DlOn/OAvKJA0ozTXuhUN1/X8+JCbONjqNgYUtHh8avdG4/tTGeXwA01XDXAvxAHp/haUESF1vKpTRAmGdFk8VxYDNhnDh2Qnni2fVHIelVElrlfTUUATVAkQUpqPy97/U") or config.get("apikey") or ""
     transportationmode = TRANSPORTATION_MODES.get(config.get("transportationmode", "Car"))
     showDistance = config.bool("showDistance", False)
     distanceUnit = DISTANCE_UNIT.get(config.get("distanceUnit", "Kilometer"))

--- a/apps/nycbus/nyc_bus.star
+++ b/apps/nycbus/nyc_bus.star
@@ -22,7 +22,7 @@ EXAMPLE_LOCATION = """
     "lng": "-73.931708"
 }
 """
-ENCRYPTED_API_KEY = "AV6+xWcEO4D+Eaj8daXafFDw3wdd6mXCdoXM4e31dPGK/CBog+fYSe07ORUjm4TdVGe4fWv5mPIbnY3dNYZNm93URlEL8KsmGsRGPTuNIP4uVnn/mvekUGBhzngbVldPA5cGY3zXt/Rbv325gs2DCbRvQUCb6qgovZMCp4WLz+/1GHn1CYmAT3zb"
+ENCRYPTED_API_KEY = "AV6+xWcEsr4R4d680czLc/RnfvU1ZpOx7ofrv0uAb8j7KoKa/Mw9Apbv6dfRFBPPu1oGMxIOSUhdEJV8IdBSwrRHvoOhfSPMmyYzcTJsSdDOoPT0p1KfvAcsyixqdCsYGJcif2+HL4W/qnX6X1hdDZV8pfaQzgswXFmvgnkoFPOWuL9dpc7drUDA"
 BUSTIME_STOP_TIMES_URL = "http://bustime.mta.info/api/siri/stop-monitoring.json"
 BUSTIME_STOP_INFO_URL = "http://bustime.mta.info/api/where/stop/%s.json"
 BUSTIME_STOPS_FOR_LOCATION_URL = "http://bustime.mta.info/api/where/stops-for-location.json"


### PR DESCRIPTION
We're standardizing on encrypting secrets using the app package name
rather than the filename. So whereas before you would do this:

```
pixlet encrypt nyc_bus ...
```

Now we do this:

```
pixlet encrypt nycbus ...
```

Hopefully this should cause less confusion down the road.