### PR TITLE
feat(devcontainer): Enable buildifier formatting on save

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,10 @@
 		"go.toolsManagement.checkForUpdates": "local",
 		"go.useLanguageServer": true,
 		"go.gopath": "/go",
-		"go.goroot": "/usr/local/go"
+		"go.goroot": "/usr/local/go",
+		"[starlark]": { 
+			"editor.formatOnSave": true
+		}
 	},
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [


### PR DESCRIPTION
This PR adds support to format using buildifier when starlark files are saved.

This uses the Bazel extension's buildifier support which enables`Format Document` command to work on Starlark files.