### PR TITLE
drop decimal of temperature as it is always 0

### DIFF
--- a/apps/tempest/tempest.star
+++ b/apps/tempest/tempest.star
@@ -72,7 +72,7 @@ def main(config):
     timezone = station_res["timezone"]
     now = time.now().in_location(timezone)
 
-    temp = "%g°" % conditions["air_temperature"]
+    temp = "%d°" % conditions["air_temperature"]
     humidity = "%d%%" % conditions["relative_humidity"]
     wind = "%s %d %s" % (
         conditions["wind_direction_cardinal"],


### PR DESCRIPTION
The API returns air_temperature always as a whole number so don't force it to be a float with a 0 decimal part