### PR TITLE
New Applet: US Yield Curve

### DIFF
--- a/apps/apps.go
+++ b/apps/apps.go
@@ -72,6 +72,7 @@ import (
 	"tidbyt.dev/community/apps/transsee"
 	"tidbyt.dev/community/apps/twitterfollows"
 	"tidbyt.dev/community/apps/unsplash"
+	"tidbyt.dev/community/apps/usyieldcurve"
 	"tidbyt.dev/community/apps/verticalmessage"
 	"tidbyt.dev/community/apps/warframecycles"
 	"tidbyt.dev/community/apps/weathermap"
@@ -147,6 +148,7 @@ func GetManifests() []manifest.Manifest {
 		transsee.New(),
 		twitterfollows.New(),
 		unsplash.New(),
+		usyieldcurve.New(),
 		verticalmessage.New(),
 		warframecycles.New(),
 		weathermap.New(),

--- a/apps/usyieldcurve/us_yield_curve.star
+++ b/apps/usyieldcurve/us_yield_curve.star
@@ -35,8 +35,8 @@ def round(num, precision):
     """Round a float to the specified number of significant digits"""
     return math.round(num * math.pow(10, precision)) / math.pow(10, precision)
 
-def rgb_to_hex(r,g,b):
-    """Return 6-character hexadecimal color code from R/G/B values provided in a tuple"""
+def rgb_to_hex(r, g, b):
+    """Return 6-character hexadecimal color code from R/G/B values given as integers"""
     ret = ""
     for i in (r, g, b):
         this = "%X" % i
@@ -76,6 +76,7 @@ def main(config):
     else:
         print("Displaying cached data.")
         dates = json.decode(dates)
+
         # force all to float for plotting
         for i, d in enumerate(dates):
             for k, v in d.items():
@@ -93,7 +94,7 @@ def main(config):
         rgb = (
             max(min_color, int(c * 0.2)),
             max(min_color, int(c * 0.2)),
-            max(min_color, int(c))
+            max(min_color, int(c)),
         )
         color = rgb_to_hex(*rgb)
         if i == len(dates) - 1:
@@ -108,7 +109,7 @@ def main(config):
                 (24.0, entry["2YEAR"]),
                 (36.0, entry["3YEAR"]),
                 (60.0, entry["5YEAR"]),
-                (74.0, entry["7YEAR"]),
+                (84.0, entry["7YEAR"]),
                 (120.0, entry["10YEAR"]),
                 (240.0, entry["20YEAR"]),
                 (360.0, entry["30YEAR"]),
@@ -131,7 +132,8 @@ def main(config):
         color = "#fb8b1e"
         if title == "":
             color = "#444"
-        stat_table.append(render.Box(
+        stat_table.append(
+            render.Box(
                 height = 6,
                 child = render.Row(
                     expanded = True,
@@ -142,7 +144,7 @@ def main(config):
                         render.Text(str(value), font = "CG-pixel-3x5-mono", color = color),
                     ],
                 ),
-            )
+            ),
         )
 
     plots.append(render.Column(

--- a/apps/usyieldcurve/us_yield_curve.star
+++ b/apps/usyieldcurve/us_yield_curve.star
@@ -197,7 +197,7 @@ def get_schema():
                 id = "graph_color",
                 name = "Color",
                 desc = "Color of the historical curves.",
-                icon = "paintbrush",
+                icon = "paintBrush",
                 options = [schema.Option(value = c, display = c) for c in COLOR_VECTORS.keys()],
                 default = "Blue",
             ),

--- a/apps/usyieldcurve/us_yield_curve.star
+++ b/apps/usyieldcurve/us_yield_curve.star
@@ -1,0 +1,170 @@
+"""
+Applet: US Yield Curve
+Summary: Plots treasury rates
+Description: Track changes to the yield curve over different US Treasury maturities.
+Author: Rob Kimball
+"""
+
+load("http.star", "http")
+load("math.star", "math")
+load("time.star", "time")
+load("cache.star", "cache")
+load("xpath.star", "xpath")
+load("render.star", "render")
+load("schema.star", "schema")
+load("encoding/json.star", "json")
+
+DATEFMT = "2006-01-02T15:04:05"
+DATA_LOCS = {
+    3: "date",
+    4: "1MONTH",
+    5: "2MONTH",
+    6: "3MONTH",
+    7: "6MONTH",
+    8: "1YEAR",
+    9: "2YEAR",
+    10: "3YEAR",
+    11: "5YEAR",
+    12: "7YEAR",
+    13: "10YEAR",
+    14: "20YEAR",
+    15: "30YEAR",
+}
+
+def round(num, precision):
+    """Round a float to the specified number of significant digits"""
+    return math.round(num * math.pow(10, precision)) / math.pow(10, precision)
+
+def rgb_to_hex(r,g,b):
+    """Return 6-character hexadecimal color code from R/G/B values provided in a tuple"""
+    ret = ""
+    for i in (r, g, b):
+        this = "%X" % i
+        if len(this) == 1:
+            this = "0" + this
+        ret = ret + this
+    return ret
+
+def main(config):
+    timezone = config.get("$tz", "America/New_York")
+    year = time.now().in_location(timezone).year
+    cache_id = "%s/%s" % ("us-yield-curve", year)
+
+    dates = cache.get(cache_id)
+    if not dates:
+        url = "https://home.treasury.gov/resource-center/data-chart-center/interest-rates/pages/xml?data=daily_treasury_yield_curve&field_tdr_date_value=%s" % year
+        print("Getting latest data from treasury.gov, %s" % url)
+        response = http.get(url)
+        raw = response.body()
+        xml = xpath.loads(raw)
+        rows = xml.query_all("/feed/entry/content")
+        dates = []
+        min_yield, max_yield = 0.0, 0.0
+        for entry in rows:
+            items = entry.split("\n")
+            this = {DATA_LOCS[i]: value for i, value in enumerate(items) if i in DATA_LOCS.keys()}
+            yields = []
+            for key in this.keys():
+                if key != "date":
+                    this[key] = float(this[key])
+                    yields.append(this[key])
+            max_yield = max(max_yield, max(yields))
+            min_yield = min(min_yield, min(yields))
+            dates.append(this)
+
+        cache.set(cache_id, json.encode(dates), ttl_seconds = 60 * 60 * 12)
+    else:
+        print("Displaying cached data.")
+        dates = json.decode(dates)
+        # force all to float for plotting
+        for i, d in enumerate(dates):
+            for k, v in d.items():
+                if k != "date":
+                    dates[i][k] = float(v)
+        min_yield, max_yield = 0.0, 0.0
+        yields = [v for d in dates for k, v in d.items() if k != "date"]
+        max_yield = max(max_yield, max(yields))
+        min_yield = min(min_yield, min(yields))
+
+    plots = []
+    min_color = 15
+    for i, entry in enumerate(dates):
+        c = 255 * (math.pow(1.07, i) / math.pow(1.07, len(dates)))
+        rgb = (
+            max(min_color, int(c * 0.2)),
+            max(min_color, int(c * 0.2)),
+            max(min_color, int(c))
+        )
+        color = rgb_to_hex(*rgb)
+        if i == len(dates) - 1:
+            color = "fff"
+        plots.append(render.Plot(
+            data = [
+                (1.0, entry["1MONTH"]),
+                (2.0, entry["2MONTH"]),
+                (3.0, entry["3MONTH"]),
+                (6.0, entry["6MONTH"]),
+                (12.0, entry["1YEAR"]),
+                (24.0, entry["2YEAR"]),
+                (36.0, entry["3YEAR"]),
+                (60.0, entry["5YEAR"]),
+                (74.0, entry["7YEAR"]),
+                (120.0, entry["10YEAR"]),
+                (240.0, entry["20YEAR"]),
+                (360.0, entry["30YEAR"]),
+            ],
+            width = 64,
+            height = 32,
+            color = "#" + color,
+            ylim = (min_yield - 0.25, max_yield + 0.25),
+            fill = False,
+        ))
+
+    stats = {
+        "US 10Y ": round(dates[-1]["10YEAR"], 3),
+        "10Y-2Y ": round(dates[-1]["10YEAR"] - dates[-1]["2YEAR"], 3),
+        "": time.parse_time(dates[-1]["date"], format = DATEFMT).in_location(timezone).format("Jan-02 3:04 PM"),
+    }
+
+    stat_table = []
+    for title, value in stats.items():
+        color = "#fb8b1e"
+        if title == "":
+            color = "#444"
+        stat_table.append(render.Box(
+                height = 6,
+                child = render.Row(
+                    expanded = True,
+                    main_align = "end",
+                    cross_align = "end",
+                    children = [
+                        render.Text(title, font = "CG-pixel-3x5-mono"),
+                        render.Text(str(value), font = "CG-pixel-3x5-mono", color = color),
+                    ],
+                ),
+            )
+        )
+
+    plots.append(render.Column(
+        expanded = True,
+        main_align = "end",
+        cross_align = "end",
+        children = stat_table,
+    ))
+
+    return render.Root(
+        child = render.Column(
+            expanded = True,
+            children = [
+                render.Stack(
+                    children = plots,
+                ),
+            ],
+        ),
+    )
+
+def get_schema():
+    return schema.Schema(
+        version = "1",
+        fields = [],
+    )

--- a/apps/usyieldcurve/us_yield_curve.star
+++ b/apps/usyieldcurve/us_yield_curve.star
@@ -79,7 +79,7 @@ def piecewise_log(x):
     if x < 12:
         x = math.log(x) * 5
     else:
-        x = x/12 + 11
+        x = x / 12 + 11
     return math.round(x)
 
 def linear_scale(x):

--- a/apps/usyieldcurve/us_yield_curve.star
+++ b/apps/usyieldcurve/us_yield_curve.star
@@ -30,6 +30,7 @@ DATA_LOCS = {
     14: "20YEAR",
     15: "30YEAR",
 }
+
 # RGB Coefficients
 COLOR_VECTORS = {
     "Red": (1.0, 0.1, 0.1),

--- a/apps/usyieldcurve/us_yield_curve.star
+++ b/apps/usyieldcurve/us_yield_curve.star
@@ -63,7 +63,7 @@ def main(config):
     timezone = config.get("$tz", "America/New_York")
     year = time.now().in_location(timezone).year
     cache_id = "%s/%s" % ("us-yield-curve", year)
-    color_choice = config.get("graph_color")
+    color_choice = config.get("graph_color", "Blue")
     color_vector = COLOR_VECTORS[color_choice]
 
     dates = cache.get(cache_id)

--- a/apps/usyieldcurve/us_yield_curve.star
+++ b/apps/usyieldcurve/us_yield_curve.star
@@ -155,7 +155,7 @@ def main(config):
             )
         color = rgb_to_hex(*rgb)
         if i == len(dates) - 1:
-            color = "fff"
+            color = "999"
 
         curve = [(scale_axis(X_AXIS[k]), entry.get(k, 0.0)) for k in X_AXIS.keys()]
         plots.append(render.Plot(

--- a/apps/usyieldcurve/usyieldcurve.go
+++ b/apps/usyieldcurve/usyieldcurve.go
@@ -1,0 +1,25 @@
+// Package usyieldcurve provides details for the US Yield Curve applet.
+package usyieldcurve
+
+import (
+	_ "embed"
+
+	"tidbyt.dev/community/apps/manifest"
+)
+
+//go:embed us_yield_curve.star
+var source []byte
+
+// New creates a new instance of the US Yield Curve applet.
+func New() manifest.Manifest {
+	return manifest.Manifest{
+		ID:          "us-yield-curve",
+		Name:        "US Yield Curve",
+		Author:      "Rob Kimball",
+		Summary:     "Plots treasury rates",
+		Desc:        "Track changes to the yield curve over different US Treasury maturities.",
+		FileName:    "us_yield_curve.star",
+		PackageName: "usyieldcurve",
+		Source:  source,
+	}
+}


### PR DESCRIPTION
Hi Tidbyt team,

This PR adds a new applet to the library that displays the daily yield curve, similar to how one might monitor it in a Bloomberg terminal. The data is retrieved without authentication from treasury.gov via XML and no configuration is required. The white line shown represents the latest yields, while the fading blue lines represent historical curves going back to the beginning of the year - I find this display offers a very intuitive read on the direction of the curve's movement and helps me visually assess whether it is steepening/flattening.

Finally, I include the current value of the 10-year note and the spread between the 10-year and the 2-year; two closely monitored data points by investors since they represent the base cost of long term debt financing (e.g. mortgages) and short term risk of a recession (particularly high when 10y-2y is negative).

![image](https://user-images.githubusercontent.com/7003930/159961647-8ed8003e-0348-443b-aad3-c1c4397517be.png)

Happy to address any questions or concerns about the app, thanks for reviewing!