### PR TITLE
Strava: Replace app fail with error message

### DIFF
--- a/apps/strava/strava.star
+++ b/apps/strava/strava.star
@@ -149,7 +149,8 @@ def progress_chart(config, refresh_token, sport, units):
                 print("Getting %s month activities. %s" % (query, url))
                 response = http.get(url, headers = headers)
                 if response.status_code != 200:
-                    print("Strava API call failed with status %d" % response.status_code)
+                    text = "code %d, %s" % (response.status_code, json.decode(response.body()).get("message", ""))
+                    return display_failure("Strava API failed, %s" % text)
                 data = response.json()
                 cache.set(cache_id, json.encode(data), ttl_seconds = CACHE_TTL)
             else:
@@ -384,7 +385,8 @@ def athlete_stats(config, refresh_token, period, sport, units):
             url = "%s/athlete" % STRAVA_BASE
             response = http.get(url, headers = headers)
             if response.status_code != 200:
-                print("Strava API call failed with status %d" % response.status_code)
+                text = "code %d, %s" % (response.status_code, json.decode(response.body()).get("message", ""))
+                return display_failure("Strava API failed, %s" % text)
 
             data = response.json()
             athlete = int(float(data["id"]))
@@ -400,7 +402,8 @@ def athlete_stats(config, refresh_token, period, sport, units):
             print("Calling Strava API: " + url)
             response = http.get(url, headers = headers)
             if response.status_code != 200:
-                fail("Strava API call failed with status %d" % response.status_code)
+                text = "code %d, %s" % (response.status_code, json.decode(response.body()).get("message", ""))
+                return display_failure("Strava API failed, %s" % text)
             data = response.json()
 
             for item in stats.keys():


### PR DESCRIPTION
Hey @rohansingh and team,

This PR is something of a proposal; per #299 the API rate limits are causing apps to show a black screen on device and in the phone app. While this is technically a valid failure, it isn't very informative for the user who may feel they've set something up incorrectly. I assume you guys have logging for `fail` calls on your side, but it's hard for me infer the cause of problems like this when there isn't an error I can easily introspect (maybe a developer logs section of the app would help here?).

When receiving a non-200 status code, this PR displays the code and error message instead of causing an app failure. The hope is that users who run into API-related failures would include this information in future bug reports and help us sort out issues more quickly. Happy to discuss/revise as you guys see fit.

![proposed screen](https://i.imgur.com/5uX25ij.gif)