### PR TITLE
Strava: Extend cache life, reduce number of API calls

### DIFF
--- a/apps/strava/strava.star
+++ b/apps/strava/strava.star
@@ -24,14 +24,14 @@ DEFAULT_SPORT = "ride"
 DEFAULT_SCREEN = "all"
 
 PREVIEW_DATA = {
-    "count": 108,
+    "count": 1408,
     "distance": 56159815,
     "moving_time": 2318919,
     "elapsed_time": 2615958,
-    "elevation_gain": 11800,
+    "elevation_gain": 125800,
 }
 
-CACHE_TTL = 60 * 60 * 1  # updates once hourly
+CACHE_TTL = 60 * 60 * 24  # updates once daily
 
 STRAVA_ICON = base64.decode("""
 iVBORw0KGgoAAAANSUhEUgAAACgAAAAICAYAAACLUr1bAAAAAXNSR0IArs4c6QAAAJ1JREFUOE+
@@ -134,15 +134,18 @@ def progress_chart(config, refresh_token, sport, units):
             "Authorization": "Bearer %s" % access_token,
         }
 
+        # To help reduce the number of API calls we need, I'm querying both months together (current/prev commented)
+        # The consequence here is if the athlete completed more than 200 activities in the last 2 months we'll miss some
         urls = {
-            "current": "%s/athlete/activities?after=%s&per_page=%s" % (STRAVA_BASE, beg_curr_month.unix, MAX_ACTIVITIES),
-            "previous": "%s/athlete/activities?after=%s&before=%s&per_page=%s" % (STRAVA_BASE, beg_prev_month.unix, end_prev_month.unix, MAX_ACTIVITIES),
+            "last-2": "%s/athlete/activities?after=%s&per_page=%s" % (STRAVA_BASE, beg_prev_month.unix, MAX_ACTIVITIES),
+            # "current": "%s/athlete/activities?after=%s&per_page=%s" % (STRAVA_BASE, beg_curr_month.unix, MAX_ACTIVITIES),
+            # "previous": "%s/athlete/activities?after=%s&before=%s&per_page=%s" % (STRAVA_BASE, beg_prev_month.unix, end_prev_month.unix, MAX_ACTIVITIES),
         }
 
         activities = {}
 
         for query, url in urls.items():
-            cache_id = "%s/%s/activity/%s/%s-%s" % (refresh_token, sport, query, now.year, now.month)
+            cache_id = "%s/activity/%s/%s-%s" % (refresh_token, query, now.year, now.month)
             data = cache.get(cache_id)
 
             if not data:
@@ -165,6 +168,11 @@ def progress_chart(config, refresh_token, sport, units):
     # Sort each list chronologically
     for query in activities.keys():
         activities[query] = sorted(activities[query], key = lambda x: x["start_date"])
+
+    # Per above, split list into current and previous month
+    activities["current"] = [a for a in activities["last-2"] if time.parse_time(a["start_date"]) >= beg_curr_month]
+    activities["previous"] = [a for a in activities["last-2"] if time.parse_time(a["start_date"]) < beg_curr_month]
+    activities.pop("last-2", None)
 
     # Iterate through each activity from the current and previous month and extract the relevant data, adding it
     # to our cumulative totals as we go, which are later used in our plot.
@@ -410,10 +418,17 @@ def athlete_stats(config, refresh_token, period, sport, units):
                 return display_failure("Strava API failed, %s" % text)
             data = response.json()
 
-            for item in stats.keys():
-                stats[item] = data["%s_%s_totals" % (period, sport)][item]
-                cache.set(cache_prefix + item, str(stats[item]), ttl_seconds = CACHE_TTL)
-                #print("saved item %s "%s" in the cache for %d seconds" % (item, str(stats[item]), CACHE_TTL))
+            for per in ("ytd", "all"):
+                for sport_code in ("ride", "run", "swim"):
+                    this_cache_prefix = "%s/%s/%s/" % (refresh_token, sport_code, per)
+                    for item in stats.keys():
+                        if sport_code == sport:
+                            stats[item] = data["%s_%s_totals" % (per, sport_code)][item]
+                        cache.set(
+                            this_cache_prefix + item,
+                            str(data["%s_%s_totals" % (per, sport_code)][item]),
+                            ttl_seconds = CACHE_TTL
+                        )
 
     # Configure the display to the user's preferences
     elevu = "m"

--- a/apps/strava/strava.star
+++ b/apps/strava/strava.star
@@ -427,7 +427,7 @@ def athlete_stats(config, refresh_token, period, sport, units):
                         cache.set(
                             this_cache_prefix + item,
                             str(data["%s_%s_totals" % (per, sport_code)][item]),
-                            ttl_seconds = CACHE_TTL
+                            ttl_seconds = CACHE_TTL,
                         )
 
     # Configure the display to the user's preferences


### PR DESCRIPTION
Due to the popularity of this app, we're currently exceeding Strava's default allotted API usage limits. This PR does a few things to help mitigate this:

- Reduce API calls on summary screens by caching data for all periods and sports when we first receive it (no downside here, we should've done this anyway)
- Reduce API calls on monthly screen by combining the previous and current month activities into a single query (the downside here is the max number of activities - if the athlete has completed >200 activities in the last two months, their monthly chart will be inaccurate)
- Save all activities when querying for the monthly screen rather than just the sport selected - also no downside here, something I should have been doing but this only affects cases where people choose the monthly screen and change the sport, or display multiple monthly screens for each sport
- Increase cache TTL from 1 hour to 24 hours. Technically the data will expire after only 6 hours since it is keyed to the refresh token. Refresh tokens expire after 6 hours so the device will lose access to its cache when this is updated (is there a better way to identify the device than the refresh token? if so, we could extend this to 24 hours or longer)

I also made a cosmetic change to the preview data to make it more realistic, no impact to the cache issue though.