### PR TITLE
Adding platforms and fixing caching

### DIFF
--- a/apps/warframecycles/warframe_cycles.star
+++ b/apps/warframecycles/warframe_cycles.star
@@ -19,7 +19,7 @@ def time_dict_conversion(timedict):
             timedict["m"] = "0" + timedict["m"]
             return "0:%s" % timedict["m"]
         else:
-            return "0:00"        
+            return "0:00"
     else:
         timedict["m"] = str(int(timedict["m"]) - 1)
         if len(timedict["m"]) == 1 and int(timedict["m"]) > 0:
@@ -138,7 +138,7 @@ def main(config):
             cambiontime["h"] = part.replace("h", "")
     cambionremaining = time_dict_conversion(cambiontime)
     cambion = "%s - %s" % (cambionremaining, cambionactive)
-    
+
     vallistime = {}
     for part in vallisremaining:
         if "s" in part:
@@ -208,7 +208,7 @@ def get_schema():
             value = "swi",
         ),
     ]
-    
+
     return schema.Schema(
         version = "1",
         fields = [

--- a/apps/warframecycles/warframe_cycles.star
+++ b/apps/warframecycles/warframe_cycles.star
@@ -10,113 +10,145 @@ load("schema.star", "schema")
 load("http.star", "http")
 load("cache.star", "cache")
 
-WF_STATUS_URL = "https://api.warframestat.us/pc"
-REFRESH_CACHE = False
-
 def time_dict_conversion(timedict):
     if timedict.get("h") == None and timedict.get("m") == None:
-        if len(timedict["s"]) == 1:
-            timedict["s"] = "0" + timedict["s"]
-        return "%ss" % timedict["s"]
+        return "0s"
     if timedict.get("h") == None and timedict.get("m") != None:
-        if len(timedict["m"]) == 1:
+        timedict["m"] = str(int(timedict["m"]) - 1)
+        if len(timedict["m"]) == 1 and int(timedict["m"]) > 0:
             timedict["m"] = "0" + timedict["m"]
-        return "0:%s" % timedict["m"]
+            return "0:%s" % timedict["m"]
+        else:
+            return "0:00"        
     else:
-        if len(timedict["m"]) == 1:
+        timedict["m"] = str(int(timedict["m"]) - 1)
+        if len(timedict["m"]) == 1 and int(timedict["m"]) > 0:
             timedict["m"] = "0" + timedict["m"]
+        if int(timedict["m"]) < 0:
+            timedict["h"] = str(int(timedict["h"]) - 1)
+            timedict["m"] = str(60 + int(timedict["m"]))
         return "%s:%s" % (timedict["h"], timedict["m"])
     return ""
 
 def main(config):
-    wf_cetus_cached = cache.get("cetus")
-    wf_earth_cached = cache.get("earth")
-    wf_cambion_cached = cache.get("cambion")
-    wf_vallis_cached = cache.get("vallis")
-    if wf_cetus_cached != None:
+    platform = config.str("platform", "pc")
+
+    _wf_status_url = "https://api.warframestat.us/%s" % platform
+
+    REFRESH_CACHE = True
+
+    cetus_active_cache_key = "wf_%s_cetus_active_cached" % platform
+    cetus_active_cached = cache.get(cetus_active_cache_key)
+    earth_active_cache_key = "wf_%s_earth_active_cached" % platform
+    earth_active_cached = cache.get(earth_active_cache_key)
+    cambion_active_cache_key = "wf_%s_cambion_active_cached" % platform
+    cambion_active_cached = cache.get(cambion_active_cache_key)
+    vallis_active_cache_key = "wf_%s_vallis_active_cached" % platform
+    vallis_active_cached = cache.get(vallis_active_cache_key)
+    cetus_remaining_cache_key = "wf_%s_cetus_remaining_cached" % platform
+    cetus_remaining_cached = cache.get(cetus_remaining_cache_key)
+    earth_remaining_cache_key = "wf_%s_earth_remaining_cached" % platform
+    earth_remaining_cached = cache.get(earth_remaining_cache_key)
+    cambion_remaining_cache_key = "wf_%s_cambion_remaining_cached" % platform
+    cambion_remaining_cached = cache.get(cambion_remaining_cache_key)
+    vallis_remaining_cache_key = "wf_%s_vallis_remaining_cached" % platform
+    vallis_remaining_cached = cache.get(vallis_remaining_cache_key)
+
+    if cetus_active_cached != None and cetus_remaining_cached != None:
         print("Hit! Displaying cached data.")
-        cetus = int(wf_cetus_cached) - 1  # Subtract because cache could be up to 1 minute old
+        cetusactive = cetus_active_cached
+        cetusremaining = cetus_remaining_cached
     else:
         REFRESH_CACHE = True
 
-    if wf_earth_cached != None:
+    if earth_active_cached != None and earth_remaining_cached != None:
         print("Hit! Displaying cached data.")
-        earth = str(int(wf_earth_cached) - 1)  # Subtract because cache could be up to 1 minute old
+        earthactive = earth_active_cached
+        earthremaining = earth_remaining_cached
     else:
         REFRESH_CACHE = True
 
-    if wf_cambion_cached != None:
+    if cambion_active_cached != None and cambion_remaining_cached != None:
         print("Hit! Displaying cached data.")
-        cambion = str(int(wf_cambion_cached) - 1)  # Subtract because cache could be up to 1 minute old
+        cambionactive = cambion_active_cached
+        cambionremaining = cambion_remaining_cached
     else:
         REFRESH_CACHE = True
 
-    if wf_vallis_cached != None:
+    if vallis_active_cached != None and vallis_remaining_cached != None:
         print("Hit! Displaying cached data.")
-        vallis = str(int(wf_vallis_cached) - 1)  # Subtract because cache could be up to 1 minute old
+        vallisactive = vallis_active_cached
+        vallisremaining = vallis_remaining_cached
     else:
         REFRESH_CACHE = True
 
     if REFRESH_CACHE == True:
-        rep = http.get(WF_STATUS_URL)
+        rep = http.get(_wf_status_url)
         if rep.status_code != 200:
             fail("Warframe request failed with status %d", rep.status_code)
-
-        cetustime = {}
         cetusactive = rep.json()["cetusCycle"]["state"].title()
         cetusremaining = rep.json()["cetusCycle"]["timeLeft"].split()
-        for part in cetusremaining:
-            if "s" in part:
-                cetustime["s"] = part.replace("s", "")
-            if "m" in part:
-                cetustime["m"] = part.replace("m", "")
-            if "h" in part:
-                cetustime["h"] = part.replace("h", "")
-        cetusremaining = time_dict_conversion(cetustime)
-        cetus = "%s - %s" % (cetusremaining, cetusactive)
-        cache.set("wf_cetus_cached", str(cetus), ttl_seconds = 60)
+        cache.set(cetus_active_cache_key, str(cetusactive), ttl_seconds = 60)
+        cache.set(cetus_remaining_cache_key, str(cetusremaining), ttl_seconds = 60)
 
-        earthtime = {}
         earthactive = rep.json()["earthCycle"]["state"].title()
         earthremaining = rep.json()["earthCycle"]["timeLeft"].split()
-        for part in earthremaining:
-            if "s" in part:
-                earthtime["s"] = part.replace("s", "")
-            if "m" in part:
-                earthtime["m"] = part.replace("m", "")
-            if "h" in part:
-                earthtime["h"] = part.replace("h", "")
-        earthremaining = time_dict_conversion(earthtime)
-        earth = "%s - %s" % (earthremaining, earthactive)
-        cache.set("wf_earth_cached", str(earth), ttl_seconds = 60)
+        cache.set(earth_active_cache_key, str(earthactive), ttl_seconds = 60)
+        cache.set(earth_remaining_cache_key, str(earthremaining), ttl_seconds = 60)
 
-        cambiontime = {}
         cambionactive = rep.json()["cambionCycle"]["active"].title()
         cambionremaining = rep.json()["cambionCycle"]["timeLeft"].split()
-        for part in cambionremaining:
-            if "s" in part:
-                cambiontime["s"] = part.replace("s", "")
-            if "m" in part:
-                cambiontime["m"] = part.replace("m", "")
-            if "h" in part:
-                cambiontime["h"] = part.replace("h", "")
-        cambionremaining = time_dict_conversion(cambiontime)
-        cambion = "%s - %s" % (cambionremaining, cambionactive)
-        cache.set("wf_cambion_cached", str(cambion), ttl_seconds = 60)
+        cache.set(cambion_active_cache_key, str(cambionactive), ttl_seconds = 60)
+        cache.set(cambion_remaining_cache_key, str(cambionremaining), ttl_seconds = 60)
 
-        vallistime = {}
         vallisactive = rep.json()["vallisCycle"]["state"].title()
         vallisremaining = rep.json()["vallisCycle"]["timeLeft"].split()
-        for part in vallisremaining:
-            if "s" in part:
-                vallistime["s"] = part.replace("s", "")
-            if "m" in part:
-                vallistime["m"] = part.replace("m", "")
-            if "h" in part:
-                vallistime["h"] = part.replace("h", "")
-        vallisremaining = time_dict_conversion(vallistime)
-        vallis = "%s - %s" % (vallisremaining, vallisactive)
-        cache.set("wf_vallis_cached", str(vallis), ttl_seconds = 60)
+        cache.set(vallis_active_cache_key, str(vallisactive), ttl_seconds = 60)
+        cache.set(vallis_remaining_cache_key, str(vallisremaining), ttl_seconds = 60)
+
+    cetustime = {}
+    for part in cetusremaining:
+        if "s" in part:
+            cetustime["s"] = part.replace("s", "")
+        if "m" in part:
+            cetustime["m"] = part.replace("m", "")
+        if "h" in part:
+            cetustime["h"] = part.replace("h", "")
+    cetusremaining = time_dict_conversion(cetustime)
+    cetus = "%s - %s" % (cetusremaining, cetusactive)
+
+    earthtime = {}
+    for part in earthremaining:
+        if "s" in part:
+            earthtime["s"] = part.replace("s", "")
+        if "m" in part:
+            earthtime["m"] = part.replace("m", "")
+        if "h" in part:
+            earthtime["h"] = part.replace("h", "")
+    earthremaining = time_dict_conversion(earthtime)
+    earth = "%s - %s" % (earthremaining, earthactive)
+
+    cambiontime = {}
+    for part in cambionremaining:
+        if "s" in part:
+            cambiontime["s"] = part.replace("s", "")
+        if "m" in part:
+            cambiontime["m"] = part.replace("m", "")
+        if "h" in part:
+            cambiontime["h"] = part.replace("h", "")
+    cambionremaining = time_dict_conversion(cambiontime)
+    cambion = "%s - %s" % (cambionremaining, cambionactive)
+    
+    vallistime = {}
+    for part in vallisremaining:
+        if "s" in part:
+            vallistime["s"] = part.replace("s", "")
+        if "m" in part:
+            vallistime["m"] = part.replace("m", "")
+        if "h" in part:
+            vallistime["h"] = part.replace("h", "")
+    vallisremaining = time_dict_conversion(vallistime)
+    vallis = "%s - %s" % (vallisremaining, vallisactive)
 
     color_toggle = config.bool("warframe_cycles_color", False)
     if color_toggle:
@@ -158,6 +190,25 @@ def main(config):
     )
 
 def get_schema():
+    options = [
+        schema.Option(
+            display = "PC",
+            value = "pc",
+        ),
+        schema.Option(
+            display = "Playstation 4",
+            value = "ps4",
+        ),
+        schema.Option(
+            display = "XBox",
+            value = "xb1",
+        ),
+        schema.Option(
+            display = "Nintendo Switch",
+            value = "swi",
+        ),
+    ]
+    
     return schema.Schema(
         version = "1",
         fields = [
@@ -166,6 +217,14 @@ def get_schema():
                 name = "Color Display",
                 icon = "eye",
                 desc = "Toggle on to display in color",
+            ),
+            schema.Dropdown(
+                id = "platform",
+                name = "Platform",
+                desc = "Choose the platform you play Warframe on.",
+                icon = "gamepad",
+                default = options[0].value,
+                options = options,
             ),
         ],
     )


### PR DESCRIPTION
Warframe is played on four different platforms, PC, Xbox, PS4, and Switch, so I've added a schema to allow connections to the API for each of these. Even though currently the times are synchronized across all four platforms, they may not be in the future.

I also had the wrong cache keys before, including one that probably wasn't unique ("earth"). In fixing those, I discovered that if they had ever hit, it would have broken the rest of the app because of what I was storing in those keys, so I've had to separate each of the 4 original keys into 2 keys each, for a total of 8 per platform, times 4 total platforms, means 36 for the whole app.