### PR TITLE
Finevent: minor enhancement

### DIFF
--- a/apps/finevent/finevent.star
+++ b/apps/finevent/finevent.star
@@ -481,7 +481,8 @@ def main(config):
     name = event.get("Event")
 
     # Localize UTC time
-    display_time = event.get("ReleaseTime", NULL).format("03:04 PM")
+    release_time_format = "03:04 PM" if event.get("TimeFromNow") < (60 * 60 * 24 - 1) else "1/2 PM"
+    display_time = event.get("ReleaseTime", NULL).format(release_time_format)
     if display_time[0] == "0":
         display_time = display_time[1:]
 
@@ -514,6 +515,9 @@ def main(config):
         child = render.Column(
             children = [
                 render.Row(
+                    expanded = True,
+                    cross_align = "center",
+                    main_align = "space_around",
                     children = [
                         render.Image(IMPORTANCE_ICONS[importance], width = 10, height = 10),
                         render.Image(flag, width = 15, height = 10),

--- a/apps/finevent/finevent.star
+++ b/apps/finevent/finevent.star
@@ -481,10 +481,8 @@ def main(config):
     name = event.get("Event")
 
     # Localize UTC time
-    release_time_format = "03:04 PM" if event.get("TimeFromNow") < (60 * 60 * 24 - 1) else "1/2 PM"
+    release_time_format = "3:04 PM" if event.get("TimeFromNow") < (60 * 60 * 24 - 1) else "1/2 PM"
     display_time = event.get("ReleaseTime", NULL).format(release_time_format)
-    if display_time[0] == "0":
-        display_time = display_time[1:]
 
     survey = str(event.get("Forecast", NULL) or event.get("TEForecast", NULL))
     if survey == "":


### PR DESCRIPTION
Currently, if someone is not limiting the displayed events to those occurring within 90 minutes we might be showing events that are far in the future. This PR includes a small improvement - when an event is not within 24 hours we display the date instead:

<img src="https://user-images.githubusercontent.com/7003930/162326787-8ab817b6-3f46-45da-94ed-ad296382824d.png" width="250">

Upcoming events that occur the following day will still show the time:
<img src="https://user-images.githubusercontent.com/7003930/162327303-3402a770-485f-4875-909e-3b06e8180fb5.png" width="250">

Thanks to David from the discord community for the suggestion!