### PR TITLE
Slackmoji: maintain image aspect ratio + use random module

### DIFF
--- a/apps/randomslackmoji/README.md
+++ b/apps/randomslackmoji/README.md
@@ -4,8 +4,6 @@ Made by: [btjones](https://github.com/btjones/)
 
 Displays a random image from [slackmojis.com](https://slackmojis.com/) on your Tidbyt using the Slackmojis API which includes over 50,000 potential images! Some are static and some animate.
 
-Note: Because the API does not return image sizes, this app assumes all images square (most are).
-
 ## Slackmojis API
 
 The Slackmojis API doesn't provide many options. It returns an array of 500 images at a time and takes only a single `page` parameter. That's it.
@@ -14,8 +12,8 @@ Example: https://slackmojis.com/emojis.json?page=25
 
 ## Potential Future Improvements
 
-- If the Slackmojis API adds a search parameter this app could be customizable and allow users to enter a search phrase and only display images from those results.
-- Dynamically determine the dimensions of an image so that non-square images are not stretched.
+- [ ] If the Slackmojis API adds a search parameter this app could be customizable and allow users to enter a search phrase and only display images from those results.
+- [x] Maintain aspect ratio of an image so that non-square images are not stretched.
 
 ## Screenshots
 

--- a/apps/randomslackmoji/random_slackmoji.star
+++ b/apps/randomslackmoji/random_slackmoji.star
@@ -62,7 +62,7 @@ def get_image(url):
             cache_name = "slackmoji_image_" + url
             cached_image = cache.get(cache_name)
             if cached_image != None:
-                return {"file": base64.decode(cached_image), "width": 32, "height": 32}
+                return base64.decode(cached_image)
 
         # no cache, fetch new image
         response = http.get(url)
@@ -71,10 +71,10 @@ def get_image(url):
             if file:
                 if USE_CACHE:
                     cache.set(cache_name, base64.encode(file), ttl_seconds = CACHE_SECONDS_IMAGE)
-                return {"file": file, "width": 32, "height": 32}
+                return file
 
     # something went wrong, return the fail image
-    return {"file": base64.decode(FAIL_IMAGE), "width": 64, "height": 32}
+    return base64.decode(FAIL_IMAGE)
 
 # generates a pseudo-random number between min and max
 # this is based on the current time in nanoseconds
@@ -91,9 +91,8 @@ def main():
     return render.Root(
         render.Box(
             child = render.Image(
-                src = image["file"],
-                width = image["width"],
-                height = image["height"],
+                src = image,
+                height = 32,
             ),
         ),
     )

--- a/apps/randomslackmoji/random_slackmoji.star
+++ b/apps/randomslackmoji/random_slackmoji.star
@@ -20,6 +20,7 @@ load("time.star", "time")
 load("encoding/json.star", "json")
 load("encoding/base64.star", "base64")
 load("cache.star", "cache")
+load("random.star", "random")
 
 SLACKMOJI_PAGE_COUNT = 106
 SLACKMOJI_IMAGES_PER_PAGE = 499
@@ -38,13 +39,13 @@ def get_slackmoji_url():
             return cached_url
 
     # no cache, fetch new url
-    page_url = "https://slackmojis.com/emojis.json?page=" + str(random(0, SLACKMOJI_PAGE_COUNT))
+    page_url = "https://slackmojis.com/emojis.json?page=" + str(random.number(0, SLACKMOJI_PAGE_COUNT))
     response = http.get(page_url)
     if response.status_code == 200:
         body = response.body()
         data = json.decode(body) if body else None
         if data:
-            slackmoji = data[random(0, SLACKMOJI_IMAGES_PER_PAGE)]
+            slackmoji = data[random.number(0, SLACKMOJI_IMAGES_PER_PAGE)]
             if slackmoji and slackmoji["image_url"]:
                 url = slackmoji["image_url"]
                 if USE_CACHE:
@@ -75,13 +76,6 @@ def get_image(url):
 
     # something went wrong, return the fail image
     return base64.decode(FAIL_IMAGE)
-
-# generates a pseudo-random number between min and max
-# this is based on the current time in nanoseconds
-def random(min, max):
-    now = time.now()
-    rand = int(str(now.nanosecond)[-6:-3]) / 1000
-    return int(rand * (max - min) + min)
 
 def main():
     # download a random slackmoji


### PR DESCRIPTION
- Previously this app assumed all images were square and set the size to 32 x 32. They were not in fact all square but we didn't have a way of knowing the true dimensions of the images. But, now [Pixlet supports resizing one side of an image and maintaining aspect ratio](https://github.com/tidbyt/pixlet/pull/224). With this PR we no longer set the width of images instead relying on pixlet to maintain aspect ratio by only setting the height.
- Replaces our pseudo random number generator with the new official random number module.