### PR TITLE
NYC Bus: Formatting suggestions

### DIFF
--- a/apps/nycbus/nyc_bus.star
+++ b/apps/nycbus/nyc_bus.star
@@ -136,7 +136,7 @@ def build_row(journey):
         anim = []
         for part in parts:
             anim.extend(
-                [render.Text(part, color = "#000", font = "CG-pixel-4x5-mono")] * 20
+                [render.Text(part, color = "#000", font = "CG-pixel-4x5-mono")] * 20,
             )
 
         line_name = render.Animation(children = anim)

--- a/apps/nycbus/nyc_bus.star
+++ b/apps/nycbus/nyc_bus.star
@@ -5,6 +5,7 @@ Description: Real time bus departures for your preferred stop.
 Author: samandmoore
 """
 
+load("re.star", "re")
 load("cache.star", "cache")
 load("encoding/base64.star", "base64")
 load("encoding/json.star", "json")
@@ -98,15 +99,16 @@ def main(config):
         )
 
     return render.Root(
+        delay = 75,
         child = render.Column(
             expanded = True,
-            main_align = "space_evenly",
+            main_align = "start",
             children = [
                 build_row(journeys[0]),
                 render.Box(
                     width = 64,
                     height = 1,
-                    color = "#aaa",
+                    color = "#666",
                 ),
                 build_row(journeys[1]),
             ],
@@ -114,24 +116,63 @@ def main(config):
     )
 
 def build_row(journey):
+    # Only match names of bus lines that we know won't fit
+    multi_line = re.compile("([A-Za-z]+)([0-9]+)([\\/ -])([A-Za-z0-9]+)")
+    match = multi_line.match(journey["line_name"])
+    if len(journey["line_name"]) > 4 and len(match):
+        _, borough, first, sep, second = match[0]
+
+        # Lines like "M55/56" should translate to -> M55, M56
+        if sep in ("\\", "/"):
+            parts = [borough + first, borough + second]
+        elif sep == "-":
+            # Lines like "Bx41-SBS"
+            parts = journey["line_name"].split("-")
+        else:
+            # Lines like "M44 Ltd"
+            parts = journey["line_name"].split(sep)
+
+        # Add 20 frames for each part, * 75ms root delay = 1.5 seconds each
+        anim = []
+        for part in parts:
+            anim.extend(
+                [render.Text(part, color = "#000", font = "CG-pixel-4x5-mono")] * 20
+            )
+
+        line_name = render.Animation(children = anim)
+    else:
+        line_name = render.Text(journey["line_name"], color = "#000", font = "CG-pixel-4x5-mono")
+
     return render.Row(
         expanded = True,
         main_align = "space_evenly",
         cross_align = "center",
         children = [
-            render.Box(
-                color = "#%s" % journey["line_color"],
-                width = 22,
-                height = 11,
-                child = render.Text(journey["line_name"], color = "#000", font = "CG-pixel-4x5-mono"),
-            ),
+            render.Stack(children = [
+                render.Box(
+                    color = "#%s" % journey["line_color"],
+                    width = 22,
+                    height = 11,
+                ),
+                render.Box(
+                    color = "#0000",
+                    width = 22,
+                    height = 11,
+                    child = line_name,
+                ),
+            ]),
             render.Column(
                 children = [
                     render.Marquee(
                         width = 36,
-                        child = render.Text(journey["destination_name"]),
+                        child = render.Text(
+                            journey["destination_name"],
+                            font = "Dina_r400-6",
+                            offset = -2,
+                            height = 7,
+                        ),
                     ),
-                    render.Text(journey["eta_text"], color = "#c1773e", font = "tom-thumb"),
+                    render.Text(journey["eta_text"], color = "#f3ab3f"),
                 ],
             ),
         ],


### PR DESCRIPTION
Hey all! As someone who lives much closer to a bus stop than a subway, I really love @samandmoore's NYC Bus app. One of the stops I've configured has buses from an express SBS line, so the name of the bus overflows within the box:

![ezgif-5-4af7bc9820](https://user-images.githubusercontent.com/7003930/163740435-ad4fb901-eb31-4a55-ac8c-d6635be2cb80.gif)

Technically I still know which bus it is, but figured this could be cleaned up a bit! With Sam's blessing, this enhancement will split any bus codes exceeding 4 characters into two parts and alternate between them:

![ezgif-5-47764d3f71](https://user-images.githubusercontent.com/7003930/163740912-ad563c34-6bb7-40f2-97e0-54214564798a.gif)

You may also notice that I took a moment to realign the text and fonts to match the official Tidbyt Subway & Ferry apps and make the whole experience feel a bit more cohesive. If you compare side-by-side (and when they are alternating on the device), there are a few minor differences that this PR resolves: border position (-1px) and color, marquee font, marquee speed, ETA font and ETA color:

## Original
![image](https://user-images.githubusercontent.com/7003930/163740566-f1a12407-1bae-489f-a124-85a096090a79.png)

## Revised
![image](https://user-images.githubusercontent.com/7003930/163740821-9fc02135-5796-414d-9f01-4932cb3ba44b.png)

Hope this contribution is welcome, though I understand if Sam would prefer to keep things the way they are. Love the app either way - thanks for considering!