### PR TITLE
US Yield Curve: Add zoom feature

### DIFF
--- a/apps/usyieldcurve/us_yield_curve.star
+++ b/apps/usyieldcurve/us_yield_curve.star
@@ -1,6 +1,6 @@
 """
 Applet: US Yield Curve
-Summary: Plots treasury rates
+Summary: Plots the US yield curve
 Description: Track changes to the yield curve over different US Treasury maturities.
 Author: Rob Kimball
 """
@@ -29,6 +29,13 @@ DATA_LOCS = {
     13: "10YEAR",
     14: "20YEAR",
     15: "30YEAR",
+}
+
+ZOOMS = {
+    "All": "0",
+    "Short (1-12m)": "1,2,3,6,12",
+    "Medium (1-7y)": "12,24,36,60,84",
+    "Long (7-30y)": "84,120,240,360",
 }
 
 # RGB Coefficients
@@ -91,6 +98,8 @@ def main(config):
     cache_id = "%s/%s" % ("us-yield-curve", year)
     color_choice = config.get("graph_color", "Blue")
     color_vector = COLOR_VECTORS[color_choice]
+    zoom = config.get("zoom", "0")
+    zoom = [] if zoom == "0" else [float(x) for x in zoom.split(",")]
 
     scale_axis = {
         "linear": linear_scale,
@@ -137,6 +146,7 @@ def main(config):
         min_yield = min(min_yield, min(yields))
 
     plots = []
+    stats = {}
     min_color = 15
     for i, entry in enumerate(dates):
         c = 255 * (math.pow(1.07, i) / math.pow(1.07, len(dates)))
@@ -157,20 +167,41 @@ def main(config):
         if i == len(dates) - 1:
             color = "999"
 
-        curve = [(scale_axis(X_AXIS[k]), entry.get(k, 0.0)) for k in X_AXIS.keys()]
+        if len(zoom):
+            axis = {z: a for a, z in enumerate(zoom)}
+            print(axis)
+            if "linear" in str(scale_axis):
+                curve = [(scale_axis(X_AXIS[k]), entry.get(k, 0.0)) for k, v in X_AXIS.items() if v in zoom]
+            else:
+                curve = [(axis[v], entry.get(k, 0.0)) for k, v in X_AXIS.items() if v in zoom]
+            long = max(zoom)
+            short = min(zoom)
+            max_unit = "M" if long < 12 else "Y"
+            min_unit = "M" if short < 12 else "Y"
+            if long >= 12:
+                long //= 12
+            if short >= 12:
+                short //= 12
+            stats = {
+                "US %d%s " % (long, max_unit): round(curve[-1][1], 3),
+                "%d%s-%d%s " % (long, max_unit, short, min_unit): round(curve[-1][1] - curve[0][1], 3),
+            }
+            min_yield = min([v[1] for v in curve])
+            max_yield = max([v[1] for v in curve])
+        else:
+            curve = [(scale_axis(X_AXIS[k]), entry.get(k, 0.0)) for k in X_AXIS.keys()]
+            stats = {
+                "US 10Y ": round(dates[-1]["10YEAR"], 3),
+                "10Y-2Y ": round(dates[-1]["10YEAR"] - dates[-1]["2YEAR"], 3),
+            }
         plots.append(render.Plot(
             data = curve,
             width = 64,
             height = 32,
             color = "#" + color,
-            ylim = (min_yield - 0.25, max_yield + 0.25),
+            y_lim = (min_yield - 0.25, max_yield + 0.25),
             fill = False,
         ))
-
-    stats = {
-        "US 10Y ": round(dates[-1]["10YEAR"], 3),
-        "10Y-2Y ": round(dates[-1]["10YEAR"] - dates[-1]["2YEAR"], 3),
-    }
 
     if updated_date:
         stats[""] = time.parse_time(updated_date, format = DATEFMT + "Z").format("Jan-2 3:04 PM")
@@ -235,6 +266,14 @@ def get_schema():
                 icon = "paintBrush",
                 options = [schema.Option(value = c, display = c) for c in COLOR_VECTORS.keys()],
                 default = "Blue",
+            ),
+            schema.Dropdown(
+                id = "zoom",
+                name = "Zoom",
+                desc = "Display a subset of the curve.",
+                icon = "magnifyingGlass",
+                options = [schema.Option(value = v, display = k) for k, v in ZOOMS.items()],
+                default = "0",
             ),
         ],
     )

--- a/apps/usyieldcurve/usyieldcurve.go
+++ b/apps/usyieldcurve/usyieldcurve.go
@@ -16,7 +16,7 @@ func New() manifest.Manifest {
 		ID:          "us-yield-curve",
 		Name:        "US Yield Curve",
 		Author:      "Rob Kimball",
-		Summary:     "Plots treasury rates",
+		Summary:     "Plots the US yield curve",
 		Desc:        "Track changes to the yield curve over different US Treasury maturities.",
 		FileName:    "us_yield_curve.star",
 		PackageName: "usyieldcurve",


### PR DESCRIPTION
Hi!

Following some community feedback here, this simple PR adds a zoomed-in view of the US yield curve for short, medium and long term bonds, following industry conventions for ranges. Each display shows the spread across visible maturities only, as well as the current yield of the longest maturity bond in view.

This requires no additional data, and the default display is unchanged; the "All" view will still show the 10 year yield and 10Y-2Y spread since this is the most popular indicator.

![image](https://user-images.githubusercontent.com/7003930/164942842-0d73ba5d-3673-4ca5-8df3-cdb766b8d151.png)

Thanks to golashes from Discord for the suggestion!