### PR TITLE
ESPN News: Fixed Vertical scroll

### DIFF
--- a/apps/espnnews/espn_news.star
+++ b/apps/espnnews/espn_news.star
@@ -6,7 +6,7 @@ Author: rs7q5
 """
 #espn_news.star
 #Created 20211231 RIS
-#Last Modified 20220424 RIS
+#Last Modified 20220430 RIS
 
 load("render.star", "render")
 load("http.star", "http")
@@ -88,7 +88,7 @@ def main(config):
         for title_tmp in title:
             title_tmp2 = split_sentence(title_tmp.rstrip(), 9, join_word = True).rstrip()
 
-            title_format.append(render.Box(height = title_max_line * 7, child = render.WrappedText(content = title_tmp2, font = font, linespacing = 1, height = title_max_line * 6)))
+            title_format.append(render.Padding(child = render.WrappedText(content = title_tmp2, font = font, linespacing = 1), pad = (0, 0, 0, 6)))
 
         title_format2 = render.Marquee(
             height = 32,

--- a/apps/espnnews/espn_news.star
+++ b/apps/espnnews/espn_news.star
@@ -6,7 +6,7 @@ Author: rs7q5
 """
 #espn_news.star
 #Created 20211231 RIS
-#Last Modified 20220430 RIS
+#Last Modified 20220501 RIS
 
 load("render.star", "render")
 load("http.star", "http")
@@ -97,8 +97,8 @@ def main(config):
                 cross_align = "start",
                 children = title_format,
             ),
-            offset_start = 0,
-            offset_end = 0,
+            offset_start = 32,
+            offset_end = 32,
         )
 
     else:
@@ -112,8 +112,8 @@ def main(config):
                 expanded = True,
                 children = title_format,
             ),
-            offset_start = 0,
-            offset_end = 0,
+            offset_start = 64,
+            offset_end = 64,
         )
     return render.Root(
         delay = int(config.str("speed", "30")),  #speed up scroll text

--- a/apps/espnnews/espn_news.star
+++ b/apps/espnnews/espn_news.star
@@ -10,7 +10,6 @@ Author: rs7q5
 
 load("render.star", "render")
 load("http.star", "http")
-load("encoding/base64.star", "base64")
 load("cache.star", "cache")
 load("schema.star", "schema")
 

--- a/apps/espnnews/espnnews.go
+++ b/apps/espnnews/espnnews.go
@@ -15,7 +15,7 @@ func New() manifest.Manifest {
 	return manifest.Manifest{
 		ID:          "espn-news",
 		Name:        "ESPN News",
-		Author:      "rs7q5 (RIS)",
+		Author:      "rs7q5",
 		Summary:     "Get top headlines from ESPN",
 		Desc:        "Displays the top three headlines from the Top Headlines section on ESPN or a specific user-selected sport.",
 		FileName:    "espn_news.star",


### PR DESCRIPTION
So vertical scroll was initially having issues with cutting off headlines, so made it so a max of 12 lines can be seen in each headline and all headline has an equal width of space, so there will be a variable width between headlines some large, but figure it is better to be consistent if anything.

Also removed the fail and will return an error message if data cannot be obtained