### PR TITLE
New App: Verge Taglines

### DIFF
--- a/apps/apps.go
+++ b/apps/apps.go
@@ -83,6 +83,7 @@ import (
 	"tidbyt.dev/community/apps/twitterfollows"
 	"tidbyt.dev/community/apps/unsplash"
 	"tidbyt.dev/community/apps/usyieldcurve"
+	"tidbyt.dev/community/apps/vergetaglines"
 	"tidbyt.dev/community/apps/verticalmessage"
 	"tidbyt.dev/community/apps/warframecycles"
 	"tidbyt.dev/community/apps/weathermap"
@@ -169,6 +170,7 @@ func GetManifests() []manifest.Manifest {
 		twitterfollows.New(),
 		unsplash.New(),
 		usyieldcurve.New(),
+		vergetaglines.New(),
 		verticalmessage.New(),
 		warframecycles.New(),
 		weathermap.New(),

--- a/apps/vergetaglines/ReadMe.md
+++ b/apps/vergetaglines/ReadMe.md
@@ -1,0 +1,9 @@
+# Verge Taglines
+
+This app makes a request to the main page of popular tech news site, [The Verge](https://theverge.com), in order to display the latest tagline at the top of the page.
+
+- No configuration is required.
+- Requests are cached for 15min.
+- Taglines 13 characters are shorter are centered while longer ones are scrolled using a marquee.
+
+This app is inspired by the [Twitter bot](https://github.com/TylerCarberry/VergeTaglines) with the same purpose.

--- a/apps/vergetaglines/verge_taglines.star
+++ b/apps/vergetaglines/verge_taglines.star
@@ -1,0 +1,93 @@
+"""
+Applet: Verge Taglines
+Summary: The Verge's latest tagline
+Description: Displays the latest tagline from the top of popular tech news site The Verge (dot com).
+Author: joevgreathead
+"""
+
+load("render.star", "render")
+load("http.star", "http")
+load("html.star", "html")
+load("encoding/base64.star", "base64")
+load("cache.star", "cache")
+
+# 16x16
+VERGE_LOGO = base64.decode("""
+iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAABGd
+BTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdT
+AAAOpgAAA6mAAAF3CculE8AAABfVBMVEXU1NTsAIw1K5AAAAA5M
+JI5MJI5MJI2MZKyD47vDI3kU6M0KpA2LZE2LZE4LpE3MJJPKpHS
+BYznOJ/Xu8x6dK7U19XU1NTV1dTV0NPV1dTW1tXIyM9cWKLVzdL
+U1dTU1NTU1tXlOqDWwM3U1tXU1NTb3NdkXqTU19XU1dTU0tPtAI
+rtAIozKY80L5HU09TU1NTU19XsAIvvAIwAT5Y4MJLU1NTU1tXsA
+43xAIwzMpI3MZLU1NTU1tXpAItUKZHU1NTU19WXFo+YFo/U1dTV
+z9LU1NTU19XU1NTU1NTU1NTU1NTU1dXU1tXU1NTU1dTU1dTU1NT
+U1NR3cqx3cq14c61YUZ84L5KRGI/rCI7cjrzV0dPWydBYJZDZA4
+zlSKTXusvlP6E+MZOoEY7sEpLZpsThX6xrIpDjAoziYa3XucvoI
+pdDLZK9C43rIpfefLaAHZDpBI3Wxs/mNp5NK5HOBozoNp7blb/r
+Co/sCo/kTqbkAIvZq8bqFZPgaK////+CX/OAAAAAUnRSTlMAAAA
+ABxgZGRkYB2vT1dXV1dXSatjZj/z38fH0/vyPHsrAPDY2NJzKXf
+jwRyXY+AyyuhACkEHt+mQ76wSU1sIp3P7+df0Xxlf2VgqrqznLy
+gMWolv+0AAAAAFiS0dEfj+4QXMAAAAHdElNRQfgCwESLy7ElKXq
+AAAA3UlEQVQY02NgYWWDA3YOTi4Gbh5eKODjFxAUEmYQCQoKBoO
+Q0LDwiEhRBjHxqGgJSUlJKWmZmNg4WTkGeYX4BEUlZRVVtcSk5B
+R1eQYGDc1ULW1GJh3dtPQMPQ0GBgZ9g8wsQyNjk+yc3EwDfaAAg
+6lZnrmFpVV+QZ6ZKZDLzGBtU1hka1dcUlpoYw3kMjMw2DuUlTs6
+VZQ52IPkmYEizi6VVVWVLs4MIB4zELu6VdfUVLu5gjkgzODuUVv
+r4ckAE2Bm8PIuLPTxgrDBBIOvn78vA0KAmSEgMDAAwgQA0Zcrny
+RT7DEAAAAldEVYdGRhdGU6Y3JlYXRlADIwMTYtMTEtMDFUMTg6N
+Dc6NDYrMDE6MDDeSimFAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE2
+LTExLTAxVDE4OjQ3OjQ2KzAxOjAwrxeROQAAAFd6VFh0UmF3IHB
+yb2ZpbGUgdHlwZSBpcHRjAAB4nOPyDAhxVigoyk/LzEnlUgADIw
+suYwsTIxNLkxQDEyBEgDTDZAMjs1Qgy9jUyMTMxBzEB8uASKBKL
+gDqFxF08kI1lQAAAABJRU5ErkJggg==
+""")
+
+SITE = "https://www.theverge.com"
+TAGLINE_CACHE_KEY = "tagline"
+TAAGLINE_SELECTOR = "span.c-masthead__tagline > a"
+
+def main():
+    resp = http.get(SITE)
+    html_body = html(resp.body())
+    tagline = cache.get(TAGLINE_CACHE_KEY)
+
+    if tagline == None:
+        tagline = html_body.find(TAAGLINE_SELECTOR).text()
+        cache.set(TAGLINE_CACHE_KEY, tagline, ttl_seconds = 900)
+
+    return render.Root(
+        child = render.Column(
+            expanded = True,
+            main_align = "space_evenly",
+            cross_align = "center",
+            children = content(tagline),
+        ),
+    )
+
+def content(value):
+    if len(value) > 13:
+        return [
+            render.Image(src = VERGE_LOGO),
+            render.Marquee(
+                height = 8,
+                width = 64,
+                scroll_direction = "horizontal",
+                child = render.Text(
+                    content = value,
+                ),
+            ),
+        ]
+    else:
+        return [
+            render.Padding(
+                pad = 3,
+                child = render.Image(src = VERGE_LOGO),
+            ),
+            render.Box(
+                child = render.Text(
+                    height = 8,
+                    content = value,
+                ),
+            ),
+        ]

--- a/apps/vergetaglines/vergetaglines.go
+++ b/apps/vergetaglines/vergetaglines.go
@@ -1,0 +1,25 @@
+// Package vergetaglines provides details for the Verge Taglines applet.
+package vergetaglines
+
+import (
+	_ "embed"
+
+	"tidbyt.dev/community/apps/manifest"
+)
+
+//go:embed verge_taglines.star
+var source []byte
+
+// New creates a new instance of the Verge Taglines applet.
+func New() manifest.Manifest {
+	return manifest.Manifest{
+		ID:          "verge-taglines",
+		Name:        "Verge Taglines",
+		Author:      "@joevgreathead",
+		Summary:     "The Verge's latest tagline",
+		Desc:        "Displays the latest tagline from the top of popular tech news site The Verge (dot com).",
+		FileName:    "verge_taglines.star",
+		PackageName: "vergetaglines",
+		Source:  source,
+	}
+}


### PR DESCRIPTION
## What is it?

This is a new app submission which displays the latest tagline from the top of [The Verge](https://theverge.com). Inspired by a [Twitter bot](https://github.com/TylerCarberry/VergeTaglines) with a similar purpose.

## How does it work?

The app displays a 16x16 version of The Verge's logo and the tagline below it.

The app does the following when run:
- Check the cache for any existing tagline stored - these expire every 15min.
- If no tagline is cached, then request the main page from theverge.com
- Uses a simple selector query to find the tagline element and extract the text.
- Prints the text either as Text (so it can be centered) or using a Marquee depending on the length.

## Checklist

- [x] I ran `make app` to generate template files.
- [x] I ran `make lint` and received no error messages.
- [x] I have included a sample screenshot of the app in action.

## Example

Pixlet render
![verge_taglines](https://user-images.githubusercontent.com/1731429/165869369-dba827b2-c60f-4230-8e3e-91b30b692f4f.gif)

Local dev render
<img width="1488" alt="Screen Shot 2022-04-28 at 5 16 28 PM" src="https://user-images.githubusercontent.com/1731429/165869403-09438dd0-866d-446a-97ff-ea795daeb219.png">

