### PR TITLE
Optimization: Verge Taglines app

### DIFF
--- a/apps/vergetaglines/verge_taglines.star
+++ b/apps/vergetaglines/verge_taglines.star
@@ -44,16 +44,16 @@ gDqFxF08kI1lQAAAABJRU5ErkJggg==
 """)
 
 SITE = "https://www.theverge.com"
-TAGLINE_CACHE_KEY = "tagline"
-TAAGLINE_SELECTOR = "span.c-masthead__tagline > a"
+TAGLINE_CACHE_KEY = "verge-dot-com-tagline"
+TAGLINE_SELECTOR = "span.c-masthead__tagline > a"
 
 def main():
-    resp = http.get(SITE)
-    html_body = html(resp.body())
     tagline = cache.get(TAGLINE_CACHE_KEY)
 
     if tagline == None:
-        tagline = html_body.find(TAAGLINE_SELECTOR).text()
+        resp = http.get(SITE)
+        html_body = html(resp.body())
+        tagline = html_body.find(TAGLINE_SELECTOR).text()
         cache.set(TAGLINE_CACHE_KEY, tagline, ttl_seconds = 900)
 
     return render.Root(


### PR DESCRIPTION
## What's the fix?

This change moves the http call inside the cache miss (caught in https://github.com/tidbyt/community/pull/374). This also fixes a typo and makes the cache key a bit more descriptive.

- [x] I ran `make lint` and received no error messages.