### PR TITLE
fixing image hold - lasts longer than app switch

### DIFF
--- a/apps/redditrplace/reddit_r_place.star
+++ b/apps/redditrplace/reddit_r_place.star
@@ -46,7 +46,7 @@ def main():
         x_end = scroll_x,
         y_end = scroll_y,
         delay = 10,
-        hold = 1500,
+        hold = 1,
     )
 
     return render.Root(


### PR DESCRIPTION
changing the image hold time from 1500 to 1 to allow for correct app switching - the it appears as if the `animation.AnimatedPositioned` `hold`  (and likely but not tested `duration`) property overrides the app switch delay