### PR TITLE
mbta: Fix mbta stop options.

### DIFF
--- a/apps/mbta/mbta.star
+++ b/apps/mbta/mbta.star
@@ -23,12 +23,13 @@ T_ABBREV = {
 }
 
 def main(config):
-    stop = config.get("stop") or "place-sstat"
+    option = config.get("stop", '{"display": "South Station", "value": "place-sstat"}')
+    stop = json.decode(option)
 
     params = {
         "sort": "arrival_time",
         "include": "route",
-        "filter[stop]": stop,
+        "filter[stop]": stop["value"],
     }
     if API_KEY:
         params["api_key"] = API_KEY


### PR DESCRIPTION
# Overview
This hasn't been launched for too long! So sorry @marcusb for the back and fourth and the really long delay on this one. The underlying issue is that options are passed into config as a json blob, which made the stop parameter work in preview but not when a stop was selected. More info can be found [here](https://github.com/tidbyt/pixlet/blob/main/docs/schema/schema.md#locationbased), which I don't believe existed when this app was submitted.

# Changes
- [mbta: Fix mbta stop options.](https://github.com/tidbyt/community/commit/f51757ea5df051137517539e083b63db8784456d)
    - This commit resolves an issue where the stop is returned as an option. There are two issues on the Tidbyt side that we need to address. One is that we need to support location options in the dev tools. The second is it's really confusing that one returns a schema.Option and gets back a JSON string.
    
# Considerations
We really need to get `LocationBased` and `Location` available in the dev tools. It will eliminate this entire class of issue. Another thing we might consider is to provide a `config.option()` that returns an option object and takes an option to use as a default. 