### PR TITLE
Traffic: Add Bing Maps API

### DIFF
--- a/apps/traffic/traffic.go
+++ b/apps/traffic/traffic.go
@@ -17,9 +17,9 @@ func New() manifest.Manifest {
 		Name:        "Traffic",
 		Author:      "Rob Kimball",
 		Summary:     "Time to your destination",
-		Desc:        "Shows the duration to get from an origin to a destination by using traffic information from MapQuest.",
+		Desc:        "Shows your estimated travel duration using traffic information from Bing/MapQuest.",
 		FileName:    "traffic.star",
 		PackageName: "traffic",
-		Source:  source,
+		Source:      source,
 	}
 }

--- a/apps/traffic/traffic.star
+++ b/apps/traffic/traffic.star
@@ -31,9 +31,9 @@ COMPACT_FONT = "tom-thumb"
 """The use of two fonts here means we won't have to Marquee the origin/destination labels until they are very long"""
 
 RATIO_COLORS = {
-    0.99: "#090",
-    1.2: "#CC0",
-    1.5: "#F50",
+    1.1: "#090",
+    1.3: "#CC0",
+    1.6: "#F50",
     2.0: "#900",
 }
 """

--- a/apps/traffic/traffic.star
+++ b/apps/traffic/traffic.star
@@ -1,7 +1,7 @@
 """
 Applet: Traffic
 Summary: Time to your destination
-Description: This app shows the duration to get from an origin to a destination by using traffic information from MapQuest.
+Description: Shows your estimated travel duration using traffic information from Bing/MapQuest.
 Author: Rob Kimball
 Honorable Mention: LukiLeu, for the inspiration with Google Traffic
 """
@@ -15,6 +15,7 @@ load("schema.star", "schema")
 load("encoding/json.star", "json")
 load("encoding/base64.star", "base64")
 
+BING_URL = "http://dev.virtualearth.net/REST/v1"
 MQ_URL = "http://www.mapquestapi.com"
 ORS_URL = "https://api.openrouteservice.org"
 
@@ -22,6 +23,7 @@ BASE_CACHE = "traffic"
 CACHE_TTL = {
     "location": 60 * 60 * 365,  # locations are very unlikely to change coorindates, so we'll keep these for 1 year
     "directions": 60 * 5,  # to reduce API load, we'll only request directions every 5 minutes
+    "bing": 60 * 15,  # Bing Maps allows 125k transactions annually before we're billed, so we'll cache slightly longer
 }
 
 DEFAULT_FONT = "tb-8"
@@ -30,8 +32,8 @@ COMPACT_FONT = "tom-thumb"
 
 RATIO_COLORS = {
     0.99: "#090",
-    1.2: "#FFF",
-    1.7: "#990",
+    1.2: "#CC0",
+    1.5: "#F50",
     2.0: "#900",
 }
 """
@@ -43,15 +45,21 @@ the time in red if we estimate the trip will be twice as long as it would be wit
 
 SAMPLE_DATA = {
     "coordinates": {
-        "origin": ("41.310141951963885", "-72.92617064650368"),  # Kennedy Airport
+        "origin": ("40.644461105185385", "-73.78255247613296"),  # Kennedy Airport
         "destination": ("40.771771628998565", "-73.97485055572092"),  # Central Park
+        # "origin": ("47.378954", "8.535667"),  # Zurich, CHE
+        # "destination": ("47.165775", "8.516988"),  # Zug, CHE
     },
     "labels": {
         "origin": "JFK Airport",
         "destination": "Central Park",
+        # "origin": "Zurich",
+        # "destination": "Zug",
     },
     # These times were calculated using ORS in a traffic-less vacuum, for entertainment purposes only.
     "time_to_destination": {
+        "Driving": time.parse_duration("994.7s"),
+        "Transit": time.parse_duration("3120.1s"),
         "fastest": time.parse_duration("994.7s"),
         "shortest": time.parse_duration("994.7s"),
         "driving-car": time.parse_duration("994.7s"),
@@ -66,6 +74,14 @@ SAMPLE_DATA = {
         "foot-hiking": time.parse_duration("6352.5s"),
         "foot-walking": time.parse_duration("5601.3s"),
     },
+}
+
+# Values match "travelMode" parameter
+BING_MODES = {
+    "Driving": "Driving",
+    "Transit": "Transit",
+    # MapQuest is preferred here:
+    # "Walking": "Walking",
 }
 
 ORS_MODES = {
@@ -93,6 +109,55 @@ def round(num, precision):
     """Round a float to the specified number of significant digits"""
     return math.round(num * math.pow(10, precision)) / math.pow(10, precision)
 
+def bing_reverse_geo(coordinates, key):
+    """
+    Reverse-search a pair of GPS coordinates using Bing to return the name, region and state/province of a location.
+
+    We also round coordinates to 4 decimal places (precision to 11.1 meters) and cache the results for a year.
+
+    :param coordinates: tuple of lat/lon as floats
+    :param key: string, Bing API Key
+    :return: tuple of address parts as strings
+    """
+    coordinates = [round(float(coordinates[0]), 4), round(float(coordinates[1]), 4)]
+
+    location = ",".join((str(coordinates[0]), str(coordinates[1])))
+    cache_id = "%s/geo/%s" % (BASE_CACHE, str(coordinates))
+
+    data = cache.get(cache_id)
+
+    if data:
+        print("Returning cached address from %s" % cache_id)
+        address_parts = json.decode(data)
+    else:
+        req_url = "%s/Locations/%s?key=%s" % (BING_URL, location, key)
+        print("Requesting address from API: %s" % req_url)
+
+        request = http.get(req_url)
+        response = request.json()
+
+        if request.status_code != 200 or response.get("statusCode", False) != 200:
+            print("API Failure: %s" % response.get("statusDescription", "No error message provided"))
+            return None
+        else:
+            resources = []
+            resource_sets = response.get("resourceSets", [])
+            if len(resource_sets):
+                resources = resource_sets[0].get("resources", [])
+            if not len(resources):
+                print("Uncaught parsing exception, no results: %s" % response)
+                return None
+
+            # I'm feeling lucky:
+            first = resources[0]
+
+            # We'll return address parts in a tuple and match the parts between origin/destination; we can then only
+            # display the more broad information if parts don't match (i.e. traveling between cities or countries)
+            address_parts = [first["address"].get(item, None) for item in ["addressLine", "locality", "adminDistrict", "countryRegion"]]
+            cache.set(cache_id, json.encode(address_parts), ttl_seconds = CACHE_TTL["location"])
+
+    return address_parts
+
 def mq_reverse_geo(coordinates, key):
     """
     Reverse-search a pair of GPS coordinates using MapQuest to return the name, region and state/province of a location.
@@ -106,7 +171,7 @@ def mq_reverse_geo(coordinates, key):
     coordinates = [round(float(coordinates[0]), 4), round(float(coordinates[1]), 4)]
 
     location = ",".join((str(coordinates[0]), str(coordinates[1])))
-    cache_id = "%s/travel_time/%s" % (BASE_CACHE, str(coordinates))
+    cache_id = "%s/geo/%s" % (BASE_CACHE, str(coordinates))
 
     data = cache.get(cache_id)
 
@@ -135,7 +200,7 @@ def mq_reverse_geo(coordinates, key):
             # We'll return address parts in a tuple and match the parts between origin/destination; we can then only
             # display the more broad information if parts don't match (i.e. traveling between cities or countries)
             address_parts = [first["fields"].get(item, None) for item in ["address", "city", "state", "country"]]
-            cache.set(cache_id, json.encode(address_parts), ttl_seconds = CACHE_TTL["directions"])
+            cache.set(cache_id, json.encode(address_parts), ttl_seconds = CACHE_TTL["location"])
 
     return address_parts
 
@@ -151,7 +216,7 @@ def ors_reverse_geo(coordinates, key):
     """
     coordinates = [round(float(coordinates[0]), 4), round(float(coordinates[1]), 4)]
     lat, lon = str(coordinates[0]), str(coordinates[1])
-    cache_id = "%s/travel_time/%s" % (BASE_CACHE, str(coordinates))
+    cache_id = "%s/geo/%s" % (BASE_CACHE, str(coordinates))
 
     data = cache.get(cache_id)
 
@@ -180,7 +245,7 @@ def ors_reverse_geo(coordinates, key):
             # We'll return address parts in a tuple and match the parts between origin/destination; we can then only
             # display the more broad information if parts don't match (i.e. traveling between cities or countries)
             address_parts = [first["properties"].get(item, None) for item in ["name", "locality", "region", "country_a"]]
-            cache.set(cache_id, json.encode(address_parts), ttl_seconds = CACHE_TTL["directions"])
+            cache.set(cache_id, json.encode(address_parts), ttl_seconds = CACHE_TTL["location"])
 
     return address_parts
 
@@ -191,7 +256,7 @@ def ors_directions(origin, destination, mode, key, **kwargs):
     very useful since they assume empty streets, the travel time for walking/mountain biking/wheelchairs should be
     unaffected by the absence of this data. However, a key benefit is the data is 100% community-supported!
 
-    Since we use the ORS and MapQuest direction functions interchangeably, the function signatures must match!
+    Since we use the Bing/ORS/MapQuest direction functions interchangeably, the function signatures must match!
 
     :param origin: tuple of coordinates for the journey origin, (lng, lat)
     :param destination: tuple of coordinates for the destination, (lng, lat)
@@ -260,7 +325,7 @@ def mq_directions(origin, destination, mode, key, **kwargs):
     prediction of the travel time, as well as the "zero traffic" travel time which we can use to display how bad the
     traffic is on a relative basis.
 
-    Since we use the ORS and MapQuest direction functions interchangeably, the function signatures must match!
+    Since we use the Bing/ORS/MapQuest direction functions interchangeably, the function signatures must match!
 
     :param origin: tuple of coordinates for the journey origin, (lng, lat)
     :param destination: tuple of coordinates for the destination, (lng, lat)
@@ -311,7 +376,74 @@ def mq_directions(origin, destination, mode, key, **kwargs):
     travel_time_with_traffic = int(data.get("route", {}).get("realTime", None))
 
     # This indicates some kind of data issue that we'll override with traffic-naive duration.
-    if travel_time_with_traffic == 10000000:
+    if travel_time_with_traffic in (-1, 10000000):
+        travel_time_with_traffic = travel_time
+
+    print("Returning directions from %s to %s, estimated time %d vs. %d" % (start, end, travel_time_with_traffic, travel_time))
+    return travel_time_with_traffic, travel_time
+
+def bing_directions(origin, destination, mode, key, **kwargs):
+    """
+    Build URL and request data from the Bing Maps API for travel time with different modes of transportation.
+    The key advantage here over MapQuest is international traffic coverage, while MapQuest allows more API calls but
+    only has coverage in select regions (primarily US).
+
+    Since we use the Bing/ORS/MapQuest direction functions interchangeably, the function signatures must match!
+
+    :param origin: tuple of coordinates for the journey origin, (lng, lat)
+    :param destination: tuple of coordinates for the destination, (lng, lat)
+    :param mode: str, Bing-recognized codes for routeTypes ("Driving", "Walking", "Transit")
+    :param key: Bing API key as a string
+    :param kwargs: optional arguments that are relevant to the Bing Routes API endpoint
+        See the docs for details: https://docs.microsoft.com/en-us/bingmaps/rest-services/routes/calculate-a-route
+    :return: tuple, the travel time with traffic and travel time without
+    """
+    start = ",".join((str(origin[0]), str(origin[1])))
+    end = ",".join((str(destination[0]), str(destination[1])))
+    cache_id = "%s/travel_time/%s/%s/%s/%s" % (BASE_CACHE, mode, start, end, json.encode(kwargs))
+
+    data = cache.get(cache_id)
+
+    if data:
+        print("Returning cached data from %s" % cache_id)
+        data = json.decode(data)
+    else:
+        req_url = "%s/Routes?travelMode=%s&key=%s&wayPoint.1=%s&wayPoint.2=%s&optimize=timeWithTraffic" % (
+            BING_URL,
+            mode,
+            key,
+            start,
+            end,
+        )
+        if len(kwargs.get("avoids", [])):
+            req_url += "&avoid=" + ",".join([a.replace(" ", "%20") for a in kwargs["avoids"]])
+
+        print("Requesting directions from API: %s" % req_url)
+
+        request = http.get(req_url)
+        response = request.json()
+
+        if request.status_code != 200 or response.get("statusCode", False) != 200:
+            print("API Failure: %s" % response.get("statusDescription", "No error message provided"))
+            msg = ";".join(response.get("errorDetails", []))
+            return msg, None
+        else:
+            data = response
+            cache.set(cache_id, json.encode(response), ttl_seconds = CACHE_TTL["bing"])
+
+    resources = []
+    resource_sets = data.get("resourceSets", [])
+    if len(resource_sets):
+        resources = resource_sets[0].get("resources", [])
+    if len(resources):
+        route = resources[0]
+        travel_time = int(route.get("travelDuration", None))
+        travel_time_with_traffic = int(route.get("travelDurationTraffic", None))
+    else:
+        travel_time, travel_time_with_traffic = None, None
+
+    # This indicates some kind of data issue that we'll override with traffic-naive duration.
+    if travel_time_with_traffic == -1:
         travel_time_with_traffic = travel_time
 
     print("Returning directions from %s to %s, estimated time %d vs. %d" % (start, end, travel_time_with_traffic, travel_time))
@@ -344,6 +476,7 @@ def duration_to_string(sec):
     return time_string
 
 def main(config):
+    bing_key = config.get("bing_auth", None)
     ors_key = config.get("ors_auth", None)
     mq_key = config.get("mq_auth", None)
     mode = config.get("mode", MQ_MODES["Bike"])
@@ -353,18 +486,25 @@ def main(config):
         directions = ors_directions
         key = ors_key
         service = "ORS"
-    else:
+    elif mode in MQ_MODES.values():
         directions = mq_directions
         key = mq_key
         service = "MapQuest"
+    else:
+        directions = bing_directions
+        key = bing_key
+        service = "Bing"
 
     search_key = None
     reverse_search = lambda *_: None
 
-    # The reverse geo results from ORS are actually a little better than MapQuest, we'll take those unless we can't
+    # The reverse geo results from Bing/ORS are actually a little better than MapQuest, we'll take those unless we can't
     if ors_key:
         reverse_search = ors_reverse_geo
         search_key = ors_key
+    elif bing_key:
+        reverse_search = bing_reverse_geo
+        search_key = bing_key
     elif mq_key:
         reverse_search = mq_reverse_geo
         search_key = mq_key
@@ -418,13 +558,22 @@ def main(config):
         elif type(destination_name) == "list":
             destination_name = ", ".join(destination_name)
 
-        avoid_configs = {
-            "avoid_bandt": ["Bridge", "Tunnel"],
-            "avoid_ferry": ["Ferry"],
-            "avoid_tolls": ["Toll Road"],
-            "avoid_unpaved": ["Unpaved"],
-            "avoid_highways": ["Limited Access"],
-        }
+        avoid_configs = dict()
+        if service == "MapQuest":
+            avoid_configs = {
+                "avoid_bandt": ["Bridge", "Tunnel"],
+                "avoid_ferry": ["Ferry"],
+                "avoid_tolls": ["Toll Road"],
+                "avoid_unpaved": ["Unpaved"],
+                "avoid_highways": ["Limited Access"],
+            }
+        elif service == "Bing":
+            avoid_configs = {
+                "avoid_ferry": ["ferry"],
+                "avoid_tolls": ["tolls"],
+                # Minimize instead of remove since we still want the routing to succeed if we can't do without it
+                "avoid_highways": ["minimizeHighways"],
+            }
         avoids = []
         for cfg_key, features in avoid_configs.items():
             if config.bool(cfg_key):
@@ -529,6 +678,9 @@ def get_schema():
                 desc = "",
                 icon = "car",
                 options = [
+                    schema.Option(value = v, display = k + " (Bing)")
+                    for k, v in BING_MODES.items()
+                ] + [
                     schema.Option(value = v, display = k + " (MapQuest)")
                     for k, v in MQ_MODES.items()
                 ] + [
@@ -613,6 +765,13 @@ def get_schema():
                 default = True,
             ),
             schema.Text(
+                id = "bing_auth",
+                name = "Bing Maps API Key",
+                desc = "Enter your API Key from bingmapsportal.com/Application. Bringing your own key means all Tidbyt owners can use this app!",
+                icon = "userGear",
+                default = "",
+            ),
+            schema.Text(
                 id = "mq_auth",
                 name = "MapQuest API Consumer Key",
                 desc = "Enter your free or paid API Key from mapquestapi.com. Bringing your own key means all Tidbyt owners can use this app!",
@@ -629,7 +788,7 @@ def get_schema():
         ],
     )
 
-FLAG_ICON = base64.decode("""iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAAXNSR0IArs4c6QAAAHRJREFUKFNj/H/20n9GYz1GBgKA8Wlx8f+HW7cy8LKzg5V+/vkTRQtMHKzw0sqVDPw8PGAFH798gbORdcAVggRBikEKYQDGlxEWZsBQCDMV2TSiFIJMBbkTw0SQ4JO3b8EGwtwNYjPOmzfvf1JSEuHgobpCAP0AQ/XpfSMWAAAAAElFTkSuQmCC""")
+FLAG_ICON = base64.decode("""iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAAXNSR0IArs4c6QAAAHhJREFUKFNj/H/20n9GYz1GBgKA8Wlx8f+HW7cy8LKzg5V+/vkTRQtIXPfiRUawwksrVzLw8/CAFXz88gXOhumwunEDoRAkCFIMUggDML7nkyeYCmGmIttPlEKQqVitBjn+ydu3YANh7gYrnDdv3v+kpCTCwUN1hQDajk8L9CuJKgAAAABJRU5ErkJggg==""")
 
 PIN_ICON = base64.decode("""iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAAXNSR0IArs4c6QAAAH9JREFUKFNjZEACVxkY/sO42gwMjMhycA5I0SMZGbic3JMnDMiKwQphijw2bmNgkJNhYHj0hGGHvxcDsmKwwu0yMmArPc5fYmAQEWRgePOeYYehHth0zydPwGpQFaKZiKEQ3X0wh2JYjexObIrgVsMkYSaj+5h8hTAnoAc2SBwAWAA5CwcOk+IAAAAASUVORK5CYII=""")
 
@@ -641,6 +800,8 @@ MTNBIKE_ICON = base64.decode("""iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAA
 
 CAR_ICON = base64.decode("""iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAAXNSR0IArs4c6QAAAKxJREFUKFNjZCASMCKrO6ah8R9dn9WNG2A1cIUgRW/3XmHI2/idYekkUwbbxjMMh+tNwPpAisEKQYp2r7nE0HT1F1gCpACkEMaGK9wuI/Pfc8EOuK3bEzwYYHww+8kTRkaQIkL+4efhYWD8f5D9v3qhIVztgm8fwOwELgG42M3+8wyM8+bN+98xZRZDRU4aA4wGqUAXA3tGzcgCbv2tcyewijFOWLKOoBtBhgEAPI5MoAfdihMAAAAASUVORK5CYII=""")
 
+TRAIN_ICON = base64.decode("""iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAAXNSR0IArs4c6QAAAHZJREFUKFNjZICCefPm/YexkemkpCRGEB9M4FIE0wBSzLhh31GsJqGbDlZYmZ3C8OPHD4b+uUsYwpJbwWpWza1mQBYHKyxMjgFLoitEFmfkdV+IYvXPWyvBmtjVwlFsJ14h0Z4hOnhgDvn/2vo/o+hRcLhiEwMAfc5Cuz9XduwAAAAASUVORK5CYII=""")
+
 BIKE_ICON2 = base64.decode("""iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAAP0lEQVQY042NsQ2AQBDDYjqWYMTbvzMNBR9AwtUpUXzJX1TU3Ysul/B+b0kC0MXD0CbVmTlQBej1kr2pP981J/H6Q0DDzqOfAAAAAElFTkSuQmCC""")
 
 WALK_ICON = base64.decode("""iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAAQ0lEQVQY03WNQRLAMAgC2U7//2IjvTQd41huwCpS01rLtr391YGIOPwBZKZtC2BnSFJ9+RUvRA07CHBrUJ0Yr6fJXz3cmSHnOt8PoAAAAABJRU5ErkJggg==""")
@@ -648,9 +809,11 @@ WALK_ICON = base64.decode("""iVBORw0KGgoAAAANSUhEUgAAAAgAAAAICAYAAADED76LAAAAQ0l
 WHEELCHAIR_ICON = base64.decode("""iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAAXNSR0IArs4c6QAAAIVJREFUKFNjZEAC/////w/jMjIyMiLLoXCIVggyAaQY3TSQOIqJIAGf9QFg6zcHrGdA1gBXCDJph6wsw9TJJgxbAjdgGAAWgCnyfPKEkXnlF7CJf8N5MD2DrBCkCKYYWQOGibAg2S4j89+n9wbDnzBusFsx3AhT6PH4MVjB/4PsYKcQHY4AQ3FH0Sv7jXEAAAAASUVORK5CYII=""")
 
 MODE_ICONS = {
+    "Driving": CAR_ICON,
     "fastest": CAR_ICON,
     "shortest": CAR_ICON,
     "driving-car": CAR_ICON,
+    "Transit": TRAIN_ICON,
     "pedestrian": WALK_ICON,
     "foot-hiking": WALK_ICON,
     "bicycle": BIKE_ICON,

--- a/apps/traffic/traffic.star
+++ b/apps/traffic/traffic.star
@@ -31,9 +31,9 @@ COMPACT_FONT = "tom-thumb"
 """The use of two fonts here means we won't have to Marquee the origin/destination labels until they are very long"""
 
 RATIO_COLORS = {
-    1.1: "#090",
-    1.3: "#CC0",
-    1.6: "#F50",
+    0.0: "#090",
+    1.1: "#CC0",
+    1.4: "#F50",
     2.0: "#900",
 }
 """

--- a/apps/traffic/traffic.star
+++ b/apps/traffic/traffic.star
@@ -408,13 +408,15 @@ def bing_directions(origin, destination, mode, key, **kwargs):
         print("Returning cached data from %s" % cache_id)
         data = json.decode(data)
     else:
-        req_url = "%s/Routes?travelMode=%s&key=%s&wayPoint.1=%s&wayPoint.2=%s&optimize=timeWithTraffic" % (
+        req_url = "%s/Routes/%s?key=%s&wayPoint.1=%s&wayPoint.2=%s" % (
             BING_URL,
             mode,
             key,
             start,
             end,
         )
+        if mode == "Driving":
+            req_url += "&optimize=timeWithTraffic"
         if len(kwargs.get("avoids", [])):
             req_url += "&avoid=" + ",".join([a.replace(" ", "%20") for a in kwargs["avoids"]])
 
@@ -443,7 +445,7 @@ def bing_directions(origin, destination, mode, key, **kwargs):
         travel_time, travel_time_with_traffic = None, None
 
     # This indicates some kind of data issue that we'll override with traffic-naive duration.
-    if travel_time_with_traffic == -1:
+    if travel_time_with_traffic in (-1, 0):
         travel_time_with_traffic = travel_time
 
     print("Returning directions from %s to %s, estimated time %d vs. %d" % (start, end, travel_time_with_traffic, travel_time))


### PR DESCRIPTION
@LukiLeu noticed yesterday that MapQuest's traffic coverage is very limited to select metro regions in the US, and suggested we try the Bing API instead. Fortunately, their API 1. also allows free requests up to a limit, 2. has dramatically better international traffic coverage, and 3. supports public transit routes!

![image](https://user-images.githubusercontent.com/7003930/166984840-5a7f08e3-1dbd-4f73-a81c-328b9c156368.png)

This PR implements Bing as a third data source for both route times and reverse geocoding, as well as the addition of public transit as shown above.

For reference, a full table of the API's geographic coverage of routing and traffic information can be found here: https://docs.microsoft.com/en-us/bingmaps/coverage/geographic-coverage

## API Key Acquisition

Similar to MapQuest and ORS, Tidbyt users will need to visit https://www.bingmapsportal.com/ in order to register a new app and generate an API key, which they can then paste into the app's settings.

![image](https://user-images.githubusercontent.com/7003930/166985293-8764e043-1e6a-4131-94e5-16d1bd87cbb4.png)

## API Billing

Users are permitted up to 125,000 billable transactions per year (routes and reverse search both qualify) before API fees are incurred. Generally, I would recommend users at least register for an ORS key in addition to either MapQuest or Bing to reduce overall load, and ORS has better reverse geocoding results anyway. 

To reduce load in instances where people only give us a Bing key, I cache the route results for 15 minutes which would amount to ~35k requests per year for a single screen. Note that for all 3 services, reverse geocoding is cached for a full year so this should only represent a marginal increase in transactions.

Full Details: https://www.microsoft.com/en-us/maps/licensing/licensing-options