### PR TITLE
USGS Earthquakes: Update defaults for better previews.

### DIFF
--- a/apps/usgsearthquakes/usgs_earthquakes.star
+++ b/apps/usgsearthquakes/usgs_earthquakes.star
@@ -6,6 +6,7 @@ Author: Chris Silverberg (csilv)
 """
 
 # USGS Earthquakes
+# Version: 1.0.1 (2022/05/07)
 #
 # This app uses the USGS GeoJSON Summary Feed:
 # https://earthquake.usgs.gov/earthquakes/feed/v1.0/geojson.php
@@ -57,8 +58,8 @@ DEFAULT_LOCATION = """
     "timezone": "America/Los_Angeles"
 }
 """
-DEFAULT_MAGNITUDE = "1"
-DEFAULT_RADIUS = "100"
+DEFAULT_MAGNITUDE = "3"
+DEFAULT_RADIUS = "0"
 
 ICON = base64.decode("""
 iVBORw0KGgoAAAANSUhEUgAAAAoAAAAICAYAAADA+m62AAAAAXNSR0IArs4c6QAAAD1JREFUKFNjZM


### PR DESCRIPTION
While the default options worked well for California, they probably aren't very good for other parts of the world. Changed the default radius to unlimited which should always result in a good preview. I likely could have set the minimum magnitude to 4, but we'll use 3 to be extra sure we'll get at least one result.