### PR TITLE
goodservice: Display first street for station names that use a combination of 2

### DIFF
--- a/apps/goodservice/goodservice.star
+++ b/apps/goodservice/goodservice.star
@@ -280,5 +280,9 @@ def condense_name(name):
         name = name.replace(key, ABBREVIATIONS[key])
     split_name = name.split("-")
     if len(split_name) > 1 and ("St" in split_name[1] or "Av" in split_name[1] or "Sq" in split_name[1] or "Bl" in split_name[1]) and (split_name[0] != "Far Rckwy"):
+        if "Sts" in split_name[1]:
+            return split_name[0] + "St"
+        if "Avs" in split_name[1]:
+            return split_name[0] + "Av"
         return split_name[1]
     return split_name[0]


### PR DESCRIPTION
Right now, "Myrtle–Wyckoff Avs" show up as "Wyckoff Avs", which is weird.

This change will have "Myrtle–Wyckoff Av" show up as "Myrtle Av" and "Bedford–Nostrand Avs" as "Bedford Av."