### PR TITLE
SF Next Muni app: more accurate predictions

### DIFF
--- a/apps/baywheels/bay_wheels.star
+++ b/apps/baywheels/bay_wheels.star
@@ -140,7 +140,9 @@ def get_stations(location):
     ]
 
 def square_distance(lat1, lon1, lat2, lon2):
-    return int((float(lat2) - float(lat1)) * 1000) ^ 2 + int((float(lon2) - float(lon1)) * 1000) ^ 2
+    latitude_difference = int((float(lat2) - float(lat1)) * 10000)
+    longitude_difference = int((float(lon2) - float(lon1)) * 10000)
+    return latitude_difference * latitude_difference + longitude_difference * longitude_difference
 
 def fetch_cached(url, ttl):
     cached = cache.get(url)

--- a/apps/sfnextmuni/sf_next_muni.star
+++ b/apps/sfnextmuni/sf_next_muni.star
@@ -118,7 +118,9 @@ def get_stops(location):
     ]
 
 def square_distance(lat1, lon1, lat2, lon2):
-    return int((float(lat2) - float(lat1)) * 1000) ^ 2 + int((float(lon2) - float(lon1)) * 1000) ^ 2
+    latitude_difference = int((float(lat2) - float(lat1)) * 10000)
+    longitude_difference = int((float(lon2) - float(lon1)) * 10000)
+    return latitude_difference * latitude_difference + longitude_difference * longitude_difference
 
 def fetch_cached(url, ttl):
     cached = cache.get(url)

--- a/apps/sfnextmuni/sf_next_muni.star
+++ b/apps/sfnextmuni/sf_next_muni.star
@@ -194,11 +194,11 @@ def main(config):
 
             title = routeTag if "short" == config.get("prediction_format") else (routeTag, destTitle)
             seconds = [int(prediction["seconds"]) - data_age_seconds for prediction in predictions if "seconds" in prediction]
-            minutes = [int(time / 60) for time in seconds if int(time / 60) > minimum_time]
+            minutes = [int(time / 60) for time in seconds if int(time / 60) >= minimum_time]
             
             prediction_map[title] = [str(time) for time in sorted(minutes)]
 
-    output = sorted(prediction_map.items(), key = lambda kv: int(min(kv[1], key = int)))
+    output = sorted(prediction_map.items(), key = lambda kv: int(min(kv[1], key = int))) if prediction_map.items() else []
     lowest_message_pri = config.get("service_messages")
     messages = [
         message["text"]

--- a/apps/sfnextmuni/sf_next_muni.star
+++ b/apps/sfnextmuni/sf_next_muni.star
@@ -10,6 +10,7 @@ load("encoding/json.star", "json")
 load("http.star", "http")
 load("render.star", "render")
 load("schema.star", "schema")
+load("time.star", "time")
 
 DEFAULT_STOP = '{"value":"15728","display":"Castro Station Inbound"}'
 PREDICTIONS_URL = "https://retro.umoiq.com/service/publicJSONFeed?command=predictions&a=sf-muni&stopId=%s&useShortTitles=true"
@@ -107,13 +108,13 @@ def get_schema():
 def get_stops(location):
     loc = json.decode(location)
 
-    raw_routes = fetch_cached(ROUTES_URL, 86400)
+    (timestamp, raw_routes) = fetch_cached(ROUTES_URL, 86400)
     routes = [route["tag"] for route in raw_routes["route"]]
 
     stops = []
 
     for route in routes:
-        raw_stops = fetch_cached((STOPS_URL % route), 86400)
+        (timestamp, raw_stops) = fetch_cached((STOPS_URL % route), 86400)
         stops.extend(raw_stops["route"]["stop"])
 
     return [
@@ -131,15 +132,18 @@ def square_distance(lat1, lon1, lat2, lon2):
 
 def fetch_cached(url, ttl):
     cached = cache.get(url)
-    if cached != None:
-        return json.decode(cached)
+    timestamp = cache.get("timestamp::%s" % url)
+    if cached and timestamp:
+        return (int(timestamp), json.decode(cached))
     else:
         res = http.get(url)
         if res.status_code != 200:
             fail("NextBus request to %s failed with status %d", (url, res.status_code))
         data = res.json()
+        timestamp = time.now().unix
         cache.set(url, str(data), ttl_seconds = ttl)
-        return data
+        cache.set(("timestamp::%s" % url), str(timestamp), ttl_seconds = ttl)
+        return (timestamp, data)
 
 def higher_priority_than(pri, threshold):
     return threshold == "Low" or pri == "High" or threshold == pri
@@ -148,7 +152,9 @@ def main(config):
     stop = json.decode(config.get("stop_code", DEFAULT_STOP))
     stopId = stop["value"]
 
-    routes = fetch_cached(PREDICTIONS_URL % stopId, 240)["predictions"]
+    (data_timestamp, data) = fetch_cached(PREDICTIONS_URL % stopId, 240)
+    routes = data["predictions"]
+    data_age_seconds = time.now().unix - data_timestamp
 
     if type(routes) != "list":
         routes = [routes]
@@ -187,11 +193,10 @@ def main(config):
                 routeTag = "T" if "Inbound" in dest["title"] else "K"
 
             title = routeTag if "short" == config.get("prediction_format") else (routeTag, destTitle)
-            minutes = [prediction["minutes"] for prediction in predictions if "minutes" in prediction]
+            seconds = [int(prediction["seconds"]) - data_age_seconds for prediction in predictions if "seconds" in prediction]
+            minutes = [int(time / 60) for time in seconds if int(time / 60) > minimum_time]
             
-            minutes = [time for time in minutes if time.isdigit() and int(time) > minimum_time]
-            
-            prediction_map[title] = sorted(minutes, key = int)
+            prediction_map[title] = [str(time) for time in sorted(minutes)]
 
     output = sorted(prediction_map.items(), key = lambda kv: int(min(kv[1], key = int)))
     lowest_message_pri = config.get("service_messages")

--- a/apps/sfnextmuni/sf_next_muni.star
+++ b/apps/sfnextmuni/sf_next_muni.star
@@ -101,7 +101,7 @@ def get_schema():
                 desc = "Don't show predictions nearer than this minimum.",
                 icon = "clock",
                 default = "0",
-            )
+            ),
         ],
     )
 
@@ -195,7 +195,7 @@ def main(config):
             title = routeTag if "short" == config.get("prediction_format") else (routeTag, destTitle)
             seconds = [int(prediction["seconds"]) - data_age_seconds for prediction in predictions if "seconds" in prediction]
             minutes = [int(time / 60) for time in seconds if int(time / 60) >= minimum_time]
-            
+
             prediction_map[title] = [str(time) for time in sorted(minutes)]
 
     output = sorted(prediction_map.items(), key = lambda kv: int(min(kv[1], key = int))) if prediction_map.items() else []

--- a/apps/sfnextmuni/sf_next_muni.star
+++ b/apps/sfnextmuni/sf_next_muni.star
@@ -94,6 +94,13 @@ def get_schema():
                 default = priorities[0].value,
                 options = priorities,
             ),
+            schema.Text(
+                id = "minimum_time",
+                name = "Minimum time to show",
+                desc = "Don't show predictions nearer than this minimum.",
+                icon = "clock",
+                default = "0",
+            )
         ],
     )
 
@@ -146,6 +153,8 @@ def main(config):
     if type(routes) != "list":
         routes = [routes]
 
+    minimum_time_string = config.str("minimum_time", "0")
+    minimum_time = int(minimum_time_string) if minimum_time_string.isdigit() else 0
     prediction_map = {}
     messages = []
 
@@ -179,6 +188,9 @@ def main(config):
 
             title = routeTag if "short" == config.get("prediction_format") else (routeTag, destTitle)
             minutes = [prediction["minutes"] for prediction in predictions if "minutes" in prediction]
+            
+            minutes = [time for time in minutes if time.isdigit() and int(time) > minimum_time]
+            
             prediction_map[title] = sorted(minutes, key = int)
 
     output = sorted(prediction_map.items(), key = lambda kv: int(min(kv[1], key = int)))


### PR DESCRIPTION
With this PR, we cache the timestamp at which the data was fetched along with the data itself, and use that and the "seconds" in the GTFS prediction to calculate the actual current minutes, rather than just echoing the minutes as returned by GTFS.

This PR also adds a setting to hide predictions nearer than a minimum number of minutes.