### PR TITLE
fix(deps): update module tidbyt.dev/pixlet to v0.17.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 
 require (
 	github.com/manifoldco/promptui v0.9.0
-	tidbyt.dev/pixlet v0.17.8
+	tidbyt.dev/pixlet v0.17.9
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -354,5 +354,5 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
-tidbyt.dev/pixlet v0.17.8 h1:kKmMzyQpd8e7ZAsP7HUjumN8AWFJH0vxzgdHQWeSUbI=
-tidbyt.dev/pixlet v0.17.8/go.mod h1:po46vRofA4eD8EaUg05+C8ajiMqZvidyed2fHRGctTE=
+tidbyt.dev/pixlet v0.17.9 h1:c3ySkFhPL8Lmqymky9SfqLb73CQPeCN5EtHDlzf59r4=
+tidbyt.dev/pixlet v0.17.9/go.mod h1:po46vRofA4eD8EaUg05+C8ajiMqZvidyed2fHRGctTE=


### PR DESCRIPTION
This commit manually bumps the pixlet version.