### PR TITLE
indegostations: Temporarily disable app.

### DIFF
--- a/apps/apps.go
+++ b/apps/apps.go
@@ -50,7 +50,7 @@ import (
 	"tidbyt.dev/community/apps/hurricanetracker"
 	"tidbyt.dev/community/apps/hvvdepartures"
 	"tidbyt.dev/community/apps/ifparank"
-	"tidbyt.dev/community/apps/indegostations"
+	// "tidbyt.dev/community/apps/indegostations"
 	"tidbyt.dev/community/apps/isitchristmas"
 	"tidbyt.dev/community/apps/islamicprayer"
 	"tidbyt.dev/community/apps/isstracker"
@@ -178,7 +178,7 @@ func GetManifests() []manifest.Manifest {
 		hurricanetracker.New(),
 		hvvdepartures.New(),
 		ifparank.New(),
-		indegostations.New(),
+		// indegostations.New(),
 		isitchristmas.New(),
 		islamicprayer.New(),
 		isstracker.New(),


### PR DESCRIPTION
This app is failing HTTP reqeusts when getting stations. The issue is, because the request is in get_schema, our server fails to load the app all together. The Tidbyt team needs to figure out why this request is failing on our end since it does work with pixlet and we need to figure out a better way to ensure our server can startup when an app fails to create schema. I'm disabling the app for now so that we can get the rest of the apps out 😿 