### PR TITLE
Strava: Monthly progress plot bug

### DIFF
--- a/apps/strava/strava.star
+++ b/apps/strava/strava.star
@@ -339,7 +339,7 @@ def progress_chart(config, refresh_token, sport, units):
                                 main_align = "end",
                                 children = [
                                     render.Plot(
-                                        data = curr_plot[0:i - len(prev_plot)],
+                                        data = curr_plot[0:i - len(prev_plot) + 1],
                                         width = graph_width,
                                         height = 22,
                                         color = "#fc4c02",

--- a/apps/strava/strava.star
+++ b/apps/strava/strava.star
@@ -296,7 +296,7 @@ def progress_chart(config, refresh_token, sport, units):
 
     frames = []
     num_frames = len(prev_plot) + len(curr_plot)
-    for i in range(num_frames):
+    for i in range(num_frames + 1):
         frames.append(
             render.Stack(
                 children = [
@@ -339,7 +339,7 @@ def progress_chart(config, refresh_token, sport, units):
                                 main_align = "end",
                                 children = [
                                     render.Plot(
-                                        data = curr_plot[0:i - len(prev_plot) + 1],
+                                        data = curr_plot[0:i - len(prev_plot)],
                                         width = graph_width,
                                         height = 22,
                                         color = "#fc4c02",


### PR DESCRIPTION
The monthly progress plot has had a small bug for a while - the current month line doesn't update for the current date due to an off-by-one error in the function that generates the frames.

This plot error isn't obvious if you're adding activities regularly but becomes increasingly noticeable if you take a break. As an extreme example, if your last activity was June 1st but today is the 15th, the plot should show a flat orange line out to the middle of the screen, but currently only shows a dot at the beginning.