### PR TITLE
Fix a typo in cryptotracker readme

### DIFF
--- a/apps/cryptotracker/README.md
+++ b/apps/cryptotracker/README.md
@@ -1,6 +1,6 @@
 # Crypto Tracker for Tidbyt
 
-Displays one of 5 24-hour cryptocurrency price charts in USD on your Tidbyt. Includes Bitcoin, Ethereum, Binance Coin, Cardano and Solana. Counter-clockwise from symbol is 24-hour price change, 24-hour percentage, and current price. Below this is a 24-hour price graph. Data is provided by [AlphaVantage](https://www.alphavantage.co/documentation/#crypto-intraday) and updated every 15 minutes. No API key required currently.
+Displays one of 5 24-hour cryptocurrency price charts in USD on your Tidbyt. Includes Bitcoin, Ethereum, Binance Coin, Cardano and Solana. Clockwise from symbol is 24-hour price change, 24-hour percentage, and current price. Below this is a 24-hour price graph. Data is provided by [AlphaVantage](https://www.alphavantage.co/documentation/#crypto-intraday) and updated every 15 minutes. No API key required currently.
 
 ![Crypto Tracker for Tidbyt](screenshot.png)
 


### PR DESCRIPTION
Pretty sure it's clockwise in the image, not counter-clockwise.