### PR TITLE
Support up to four timezones in world clock

### DIFF
--- a/apps/worldclock/world_clock.star
+++ b/apps/worldclock/world_clock.star
@@ -1,7 +1,7 @@
 """
 Applet: World Clock
 Summary: Multi timezone clock
-Description: Displays the time in up to three different locations.
+Description: Displays the time in up to four different locations.
 Author: Elliot Bentley
 """
 
@@ -20,13 +20,38 @@ def main(config):
             json.decode(config.get("location_1")),
             json.decode(config.get("location_2")),
             json.decode(config.get("location_3")),
+            json.decode(config.get("location_4")),
         ]
     else:
         locations = [
-            {"timezone": "America/New_York", "locality": "New York", "lat": 0, "lng": 0},
+            {
+                "timezone": "America/New_York",
+                "locality": "New York",
+                "lat": 0,
+                "lng": 0,
+            },
             {"timezone": "Europe/London", "locality": "London", "lat": 0, "lng": 0},
-            {"timezone": "Asia/Tokyo", "locality": "Tokyo", "lat": 35.703286, "lng": 139.748475},
+            {
+                "timezone": "Asia/Tokyo",
+                "locality": "Tokyo",
+                "lat": 35.703286,
+                "lng": 139.748475,
+            },
+            {
+                "timezone": "America/Sao_Paulo",
+                "locality": "São Paulo",
+                "lat": -23.55,
+                "lng": -46.633333,
+            },
         ]
+
+    location_count = int(config.get("location_count") or 3)
+
+    if location_count < 4:
+        locations.remove(locations[3])
+
+    if location_count < 3:
+        locations.remove(locations[2])
 
     horizonal_rule = render.Box(
         height = 1,
@@ -140,6 +165,27 @@ def get_schema():
     return schema.Schema(
         version = "1",
         fields = [
+            schema.Dropdown(
+                id = "location_count",
+                name = "Number of clocks",
+                desc = "How many locations to display onscreen.",
+                icon = "list",
+                default = "3",
+                options = [
+                    schema.Option(
+                        display = "2",
+                        value = "2",
+                    ),
+                    schema.Option(
+                        display = "3",
+                        value = "3",
+                    ),
+                    schema.Option(
+                        display = "4",
+                        value = "4",
+                    ),
+                ],
+            ),
             schema.Location(
                 id = "location_1",
                 name = "Location 1",
@@ -175,6 +221,19 @@ def get_schema():
             schema.Text(
                 id = "location_3_label",
                 name = "Location 3 label",
+                desc = "Custom label (optional)",
+                icon = "tag",
+                default = "",
+            ),
+            schema.Location(
+                id = "location_4",
+                name = "Location 4",
+                desc = "Location for which to display time.",
+                icon = "place",
+            ),
+            schema.Text(
+                id = "location_4_label",
+                name = "Location 4 label",
                 desc = "Custom label (optional)",
                 icon = "tag",
                 default = "",

--- a/apps/worldclock/world_clock.star
+++ b/apps/worldclock/world_clock.star
@@ -89,14 +89,14 @@ def main(config):
             height = 7,
             width = (43, 35)[useMeridianTime],
             child = render.Padding(
-                pad = (4, 0, 0, 0),
+                pad = (4, 1, 0, 0),
                 child = render.Marquee(
                     width = (43, 35)[useMeridianTime],
                     child = render.Text(
                         content = locality,
                         font = font,
                         color = time_color,
-                        offset = -1,
+                        offset = 0,
                     ),
                 ),
             ),


### PR DESCRIPTION
This adds new functionality to the world clock app that allows support for up to four timezones onscreen at once.

I couldn't see any way to dynamically adjust the schema based on user inputs, so the third and fourth clocks will show up in the mobile app interface even when the user has chosen to display only two or three clocks.

See below for examples.


Four timezones:
![world_clock](https://user-images.githubusercontent.com/1442752/177157454-58009bd5-cd8c-4186-a0ec-8632b0ff0dde.gif)

Three (the default):
![world_clock-1](https://user-images.githubusercontent.com/1442752/177157453-667049c9-56f0-4705-8219-4bec8b05223a.gif)

Two:
![world_clock-2](https://user-images.githubusercontent.com/1442752/177157455-8ec4f4fe-2fc0-4007-9c8f-1b5fd4e352b4.gif)
