### PR TITLE
Introduce configuration option for 24h time format

### DIFF
--- a/apps/datetimeclock/date_time_clock.star
+++ b/apps/datetimeclock/date_time_clock.star
@@ -20,6 +20,7 @@ DEFAULT_LOCATION = """
 	"timezone": "America/New_York"
 }
 """
+DEFAULT_IS_24_HOUR_FORMAT = False
 
 def main(config):
     location = config.get("location", DEFAULT_LOCATION)
@@ -29,6 +30,13 @@ def main(config):
     now = time.now().in_location(timezone)
     now_date = now.format("2 Jan 2006").upper()
     day = now.format("Monday").upper()
+
+    is_24_hour_format = config.bool("is_24_hour_format", DEFAULT_IS_24_HOUR_FORMAT)
+    time_format_separator = "3:04 PM"
+    time_format_no_separator = "3 04 PM"
+    if is_24_hour_format:
+        time_format_separator = "15:04"
+        time_format_no_separator = "15 04"
 
     return render.Root(
         delay = 500,
@@ -40,11 +48,11 @@ def main(config):
                 render.Animation(
                     children = [
                         render.Text(
-                            content = now.format("3:04 PM"),
+                            content = now.format(time_format_separator),
                             font = "6x13",
                         ),
                         render.Text(
-                            content = now.format("3 04 PM"),
+                            content = now.format(time_format_no_separator),
                             font = "6x13",
                         ),
                     ],
@@ -71,6 +79,12 @@ def get_schema():
                 name = "Location",
                 desc = "Location for which to display time.",
                 icon = "place",
+            ),
+            schema.Toggle(
+                id = "is_24_hour_format",
+                name = "24 hour format",
+                desc = "Display the time in 24 hour format.",
+                icon = "clock",
             ),
         ],
     )


### PR DESCRIPTION
The changes introduce a new configuration option, which lets the user select the time format to be used:

- AM/PM
- 24h

By default, the AM/PM format is used as before.