### PR TITLE
Fixed bug with some Shopify Line Items that do not contain a SKU

### DIFF
--- a/apps/shopifychart/shopify_chart.star
+++ b/apps/shopifychart/shopify_chart.star
@@ -415,9 +415,9 @@ def should_order_be_excluded(order, excluded_skus):
 def should_line_item_be_excluded(line_item, excluded_skus):
     if line_item["gift_card"]:
         return True
-
-    if excluded_skus:
-        sku = line_item["sku"]
+    excluded_skus = [es.lower().strip() for es in excluded_skus]
+    sku = line_item["sku"].lower() if line_item.get("sku") else None
+    if excluded_skus and sku:
         for ex_sku in excluded_skus:
             if ex_sku in sku:
                 # print("{} is excluded".format(sku))


### PR DESCRIPTION
Found an issue where I had a Shopify line item that did not have a SKU.

Also took the chance to make sure the compare was case insensitive and removed any trailing whitespace.

@matslina 