### PR TITLE
sunrisesunset: stop first digit from being cut off

### DIFF
--- a/apps/sunrisesunset/sunrise_sunset.star
+++ b/apps/sunrisesunset/sunrise_sunset.star
@@ -129,10 +129,12 @@ def main(config):
             title = "Sunrise"
             text = sunriseText
             image = sunriseImage
+            pad = sunrisePad
         else:
             title = "Sunset"
             text = sunsetText
             image = sunsetImage
+            pad = sunsetPad
 
         top = render.Padding(
             pad = (0, 2, 0, 4),
@@ -153,7 +155,10 @@ def main(config):
             cross_align = "center",
             children = [
                 render.Image(src = base64.decode(image)),
-                render.Text(text),
+                render.Padding(
+                    pad = (pad, 0, 0, 0),
+                    child = render.Text(text),
+                ),
             ],
         )
 

--- a/apps/sunrisesunset/sunrise_sunset.star
+++ b/apps/sunrisesunset/sunrise_sunset.star
@@ -60,26 +60,32 @@ def main(config):
 
     # Get sunset and sunrise times
     now = time.now()
-    sunriseTime = sunrise.sunrise(lat, lng, now)
-    sunsetTime = sunrise.sunset(lat, lng, now)
+    sunriseTime = sunrise.sunrise(lat, lng, now).in_location(location["timezone"])
+    sunsetTime = sunrise.sunset(lat, lng, now).in_location(location["timezone"])
 
     # Get whether to display in 24h format
     display24Hour = config.bool("24_hour", DEFAULT_24_HOUR)
     itemsToDisplay = config.get("items_to_display", DEFAULT_ITEMS_TO_DISPLAY)
 
+    sunrisePad, sunsetPad = 0, 0
+
     if sunriseTime == None:
         sunriseText = "  None"
     elif display24Hour:
-        sunriseText = "  %s" % sunriseTime.in_location(location["timezone"]).format("15:04")
+        sunriseText = "  %s" % sunriseTime.format("15:04")
     else:
-        sunriseText = "%s" % sunriseTime.in_location(location["timezone"]).format("3:04 PM")
+        sunriseText = "%s" % sunriseTime.format("3:04 PM")
+        if sunriseTime.hour >= 10:
+            sunrisePad = -1
 
     if sunsetTime == None:
         sunsetText = "  None"
     elif display24Hour:
-        sunsetText = "  %s" % sunsetTime.in_location(location["timezone"]).format("15:04")
+        sunsetText = "  %s" % sunsetTime.format("15:04")
     else:
-        sunsetText = "%s" % sunsetTime.in_location(location["timezone"]).format("3:04 PM")
+        sunsetText = "%s" % sunsetTime.format("3:04 PM")
+        if sunsetTime.hour >= 10:
+            sunsetPad = -1
 
     # Got what we need, render it.
 
@@ -93,7 +99,7 @@ def main(config):
                 children = [
                     render.Image(src = base64.decode(sunriseImage)),
                     render.Padding(
-                        pad = (-1, -1, 0, 0),
+                        pad = (sunrisePad, -1, 0, 0),
                         child = render.Text(sunriseText),
                     ),
                 ],
@@ -112,7 +118,7 @@ def main(config):
             children = [
                 render.Image(src = base64.decode(sunsetImage)),
                 render.Padding(
-                    pad = (-1, -1, 0, 0),
+                    pad = (sunsetPad, -1, 0, 0),
                     child = render.Text(sunsetText),
                 ),
             ],


### PR DESCRIPTION
Negative padding for time component is currently shaving of 1 pixel for single digit hours in AM/PM format:
![iTerm2 q4GZOC derp](https://user-images.githubusercontent.com/208392/179357194-0948e7da-f627-4c91-a83e-048a553c84a2.gif)

After this change:
![iTerm2 ohI23f derp](https://user-images.githubusercontent.com/208392/179357204-aadab2c1-4fb4-4638-84bb-5aef521f2dce.gif)
