### PR TITLE
Shuffle Images: Reduce maximum number of images

### DIFF
--- a/apps/shuffleimages/shuffle_images.star
+++ b/apps/shuffleimages/shuffle_images.star
@@ -1,20 +1,20 @@
 """
 Applet: Shuffle Images
 Summary: "Randomly display an image",
-Description: "Randomly displays an image from a user-specified list (20 image max).",
+Description: "Randomly displays an image from a user-specified list.",
 Author: rs7q5
 """
 
 #shuffle_images.star
 #Created 20220704 RIS
-#Last Modified 20220717 RIS
+#Last Modified 20220719 RIS
 
 load("render.star", "render")
 load("schema.star", "schema")
 load("encoding/base64.star", "base64")
 load("random.star", "random")
 
-maxImages = 20  #max images that can be selected
+maxImages = 6  #max images that can be selected
 
 def main(config):
     if config.bool("hide_app", False):

--- a/apps/shuffleimages/shuffleimages.go
+++ b/apps/shuffleimages/shuffleimages.go
@@ -17,7 +17,7 @@ func New() manifest.Manifest {
 		Name:        "Shuffle Images",
 		Author:      "rs7q5",
 		Summary:     "Randomly display an image",
-		Desc:        "Randomly displays an image from a user-specified list (20 image max).",
+		Desc:        "Randomly displays an image from a user-specified list.",
 		FileName:    "shuffle_images.star",
 		PackageName: "shuffleimages",
 		Source:  source,


### PR DESCRIPTION
max images to rotate through is 6 instead of 20