### PR TITLE
Todoist config to allow hiding when no tasks

### DIFF
--- a/apps/todoist/todoist.star
+++ b/apps/todoist/todoist.star
@@ -47,6 +47,9 @@ l/d/WBrBhOVz/g1OHB6agdqc6AAAAABJRU5ErkJggg==
 
 DEFAULT_NAME = "Todoist"
 DEFAULT_FILTER = "today | overdue"
+DEFAULT_SHOW_IF_EMPTY = True
+
+NO_TASKS_CONTENT = "No Tasks :)"
 
 TODOIST_URL = "https://api.todoist.com/rest/v1/tasks"
 
@@ -76,11 +79,15 @@ def main(config):
             if num_tasks == -1:
                 content = "Error"
             elif num_tasks == 0:
-                content = "No Tasks :)"
+                content = NO_TASKS_CONTENT
             else:
                 content = humanize.plural(int(num_tasks), "Task")
 
             cache.set(cache_key, content, ttl_seconds = 60)
+
+        if (content == NO_TASKS_CONTENT and not config.bool("show")):
+            # Don't display the app in the user's rotation
+            return []
 
     else:
         # This is used to display the app preview image
@@ -161,6 +168,13 @@ def get_schema():
                 desc = "Filter to apply to tasks.",
                 icon = "filter-list",
                 default = DEFAULT_FILTER,
+            ),
+            schema.Toggle(
+                id = "show",
+                name = "Show When No Tasks",
+                desc = "Show this app when there are no tasks.",
+                icon = "eye",
+                default = DEFAULT_SHOW_IF_EMPTY,
             ),
         ],
     )


### PR DESCRIPTION
I like this app, but I would prefer an option to not have the app show when I have no tasks that I need to worry about.

I'd like to add a config toggle which would allow the app to not render when the number of tasks fetched is zero.

It defaults to the current behavior so that only users who change this config would opt-in to not rendering the app in this scenario.

![screenshot](https://apearce.dev/img/S105PPUH.png)