### PR TITLE
Add better time, colors, config to ffxconnector

### DIFF
--- a/apps/fairfaxconnector/fairfax_connector.star
+++ b/apps/fairfaxconnector/fairfax_connector.star
@@ -12,12 +12,80 @@ load("http.star", "http")
 load("schema.star", "schema")
 load("secret.star", "secret")
 
+apiKey = secret.decrypt("AV6+xWcEHWq0zUeozY3oe2t6xhMzEHRhb/Tn+2RBF5rGUi5jc8XcDKxG2RC7lqqhGYS8z0+glkxCg1ZsTf6sCsNAMB7RD+HQpPyyhmB8cek35AnYxHQQsy2A7o9uLswG3g3k3edobR3Qy4KHckKqGdtkVYxXNG3HK0yEqCG4hQ==")
 ONE_MINUTE = 60
+ONE_DAY = ONE_MINUTE * 60 * 24
+ONE_WEEK = ONE_DAY * 7
 BASE_URL = "https://www.fairfaxcounty.gov/bustime/api/v3"
 DEFAULT_STOP = "6484"
 
+def getAllRoutes():
+    routes = cache.get("ROUTES")
+    if routes == None:
+        routesUrl = BASE_URL + "/getroutes?key=" + apiKey + "&format=json"
+        routes = http.get(routesUrl).body()
+        cache.set("ROUTES", routes, ONE_DAY)
+
+    routes = json.decode(routes).get("bustime-response").get("routes")
+    return routes
+
+def getRouteDirections(route):
+    cacheKey = "DIRECTIONS-" + route.get("rt")
+    directions = cache.get(cacheKey)
+    if directions == None:
+        dirUrl = BASE_URL + "/getdirections?key=" + apiKey + "&rt=" + route.get("rt") + "&format=json"
+        directions = http.get(dirUrl).body()
+        cache.set(cacheKey, directions, ONE_DAY)
+
+    directions = json.decode(directions).get("bustime-response").get("directions")
+    return directions
+
+def getStops(route, direction):
+    cacheKey = "STOPS-" + route.get("rt") + "-" + direction.get("id")
+    stops = cache.get(cacheKey)
+    if stops == None:
+        stopsUrl = BASE_URL + "/getstops?key=" + apiKey + "&rt=" + route.get("rt") + "&dir=" + direction.get("id") + "&format=json"
+
+        # Some of the directions have spaces in their IDs. Why this is allowed, I have no clue. I can't seem to find a starlark lib
+        # for URL encoding, so I'm doing this one-off here where it's needed.
+        stopsUrl = stopsUrl.replace(" ", "%20")
+        stops = http.get(stopsUrl).body()
+        cache.set(cacheKey, stops, ONE_DAY)
+
+    stops = json.decode(stops).get("bustime-response").get("stops")
+    return stops
+
+# Warning: Expensive operation! Sends a lot of network requests the first time it's called
+# before the cache is filled up (and again every 24h when the cache expires).
+def getAllStops():
+    allStops = []
+    routes = getAllRoutes()
+    for route in routes:
+        directions = getRouteDirections(route)
+        for direction in directions:
+            stops = getStops(route, direction)
+            if stops == None:
+                continue
+            for stop in stops:
+                allStops.append([route, stop])
+
+    return allStops
+
+def getRouteColor(routeId):
+    routeColor = cache.get("COLOR-" + routeId)
+    if routeColor == None:
+        routes = getAllRoutes()
+
+        # Find the matching route and extract its color
+        for route in routes:
+            if route["rt"] == routeId:
+                routeColor = route["rtclr"]
+                cache.set("COLOR-" + routeId, routeColor, ONE_WEEK)
+                break
+    return routeColor or "#ffffff"
+
 # Gets the list of predicted bus times for an individual bus stop
-def getPredictions(apiKey, stopId):
+def getPredictions(stopId):
     stopPredictions = cache.get(stopId)
     if stopPredictions == None:
         predictionUrl = BASE_URL + "/getpredictions?key=" + apiKey + "&stpid=" + stopId + "&format=json"
@@ -28,25 +96,27 @@ def getPredictions(apiKey, stopId):
     return stopPredictions
 
 def renderBusRow(prediction):
+    routeColor = getRouteColor(prediction.get("rt"))
     if prediction == None:
         return render.Text("")
+    minutesRemaining = prediction.get("prdctdn")
+    if minutesRemaining != "DUE":
+        minutesRemaining = minutesRemaining + " min"
     return render.Row(
         expanded = True,
         main_align = "space_between",
         children = [
             render.Text(
                 content = prediction.get("rt"),
-                color = "#00f",
+                color = routeColor,
             ),
             render.Text(
-                content = prediction.get("prdtm").split(" ")[1],
+                content = minutesRemaining,
             ),
         ],
     )
 
 def main(config):
-    apiKey = secret.decrypt("AV6+xWcEHWq0zUeozY3oe2t6xhMzEHRhb/Tn+2RBF5rGUi5jc8XcDKxG2RC7lqqhGYS8z0+glkxCg1ZsTf6sCsNAMB7RD+HQpPyyhmB8cek35AnYxHQQsy2A7o9uLswG3g3k3edobR3Qy4KHckKqGdtkVYxXNG3HK0yEqCG4hQ==")
-
     stop = config.get("stop") or DEFAULT_STOP
     banner = render.Row(
         children = [
@@ -60,7 +130,7 @@ def main(config):
             ),
         ],
     )
-    predictions = getPredictions(apiKey, stop)
+    predictions = getPredictions(stop)
     if predictions == None:
         return render.Root(
             child = render.Column(


### PR DESCRIPTION
- Display routes in the color specified in the API per-route
- Display arrival as minutes remaining instead of just a timestamp
- ~Change config from a plain text input to a dropdown populated with every bus stop~
  - ~@matslina Let me know what you think about this, since we were discussing it. I'm not sure this is the best solution tbh, and it comes with quite a performance hit - on my machine this takes about 5 seconds to "spin up" and make all the requests before they're in the cache. If you don't think it's a good idea, I'll just remove this change and leave the other two in.~
  - I'm getting rid of this as it's causing errors in the test suite

![ezgif com-gif-maker](https://user-images.githubusercontent.com/12942439/180109300-0e819621-59c4-43cd-8f5c-5a7cdfff807f.gif)
<hr/>

![fairfax_connector](https://user-images.githubusercontent.com/12942439/180109383-c4468bd7-e1e0-4b7c-be04-b296cfbe9d35.png)

