### PR TITLE
Fix timezone issue

### DIFF
--- a/apps/fullybinarytime/fullybinarytime.star
+++ b/apps/fullybinarytime/fullybinarytime.star
@@ -126,7 +126,7 @@ def make_frame(elapsed):
 def make_animation(timezone):
     # Key input is how long has passed since the start of the day.
     now = time.now().in_location(timezone)
-    midnight = time.time(year = now.year, month = now.month, day = now.day).in_location(timezone)
+    midnight = time.time(year = now.year, month = now.month, day = now.day, location = timezone)
     elapsed = now - midnight
 
     frames = []


### PR DESCRIPTION
Noticed that the time was off by some exact number of hours, which made me think there was a timezone issue.

Using America/New_York, it's currently 14:26. It now says "on early sub 1101" which is correct. With the old code, it said "on late sub 0010" which is after 6pm. That's four hours later, which makes sense since NY is currently on GMT-4.

In Europe/London, it's currently 19:32. It now says "on late sub 1000", which is just after 19:30. It used to say "on late sub 0010", which is around 18:30. That also makes sense since with daylight savings London is currently on GMT+1