### PR TITLE
Speed up life by 10x

### DIFF
--- a/apps/life/life.star
+++ b/apps/life/life.star
@@ -9,8 +9,8 @@ load("random.star", "random")
 load("render.star", "render")
 load("schema.star", "schema")
 
-ALIVE = 1
-DEAD = 0
+ALIVE = True
+DEAD = False
 WIDTH = 64
 HEIGHT = 32
 APP_DURATION_MILLISECONDS = 15000
@@ -35,94 +35,142 @@ COLOURS = [
     schema.Option(display = "Purple", value = "#800080"),
 ]
 
+# The offsets of a cell's eight neighbours.
+# We wrap around at the edges, so we are treating the board
+# as a toroidal array. Seems appropriate when small.
+NEIGHBOUR_DIFFS = {
+    (-1, -1): True,  # NE
+    (0, -1): True,  # N
+    (1, -1): True,  # NW
+    (-1, 0): True,  # E
+    (1, 0): True,  # W
+    (-1, 1): True,  # SE
+    (0, 1): True,  # S
+    (1, 1): True,  # SW
+}
+
+NEIGHBOUR_AND_CELL_DIFFS = {
+    (-1, -1): True,  # NE
+    (0, -1): True,  # N
+    (1, -1): True,  # NW
+    (-1, 0): True,  # E
+    (0, 0): True,  # The cell itself
+    (1, 0): True,  # W
+    (-1, 1): True,  # SE
+    (0, 1): True,  # S
+    (1, 1): True,  # SW
+}
+
 # Random starting point where every cell has equal chance
 # of starting dead or alive.
-def generate_board():
-    return [
-        [random.number(DEAD, ALIVE) for c in range(WIDTH)]
-        for r in range(HEIGHT)
-    ]
+def generate_initial_state():
+    neighbours = {}
+    changed = []
+    living = {}
 
-# Wrap around at the edges, so we are treating the board
-# as a toroidal array. Seems appropriate when small.
-def prev_row(row):
-    if row == 0:
-        return HEIGHT - 1
-    return row - 1
+    for x in range(WIDTH):
+        for y in range(HEIGHT):
+            is_alive = random.number(0, 1) > 0.5
+            if is_alive:
+                changed.append((x, y))
+                living[(x, y)] = True
+                for dx, dy in NEIGHBOUR_DIFFS.keys():
+                    #dx, dy = neighbour
+                    nx = (x + dx) % WIDTH
+                    ny = (y + dy) % HEIGHT
+                    neighbours.setdefault((nx, ny), 0)
+                    neighbours[(nx, ny)] += 1
 
-def next_row(row):
-    if row == HEIGHT - 1:
-        return 0
-    return row + 1
-
-def prev_col(col):
-    if col == 0:
-        return WIDTH - 1
-    return col - 1
-
-def next_col(col):
-    if col == WIDTH - 1:
-        return 0
-    return col + 1
-
-# Key input to determining next state
-def count_living_neighbours(board, row, col):
-    living = 0
-    for r in [prev_row(row), row, next_row(row)]:
-        for c in [prev_col(col), col, next_col(col)]:
-            if r == row and c == col:
-                continue  # cells are not their own neighbours.
-            living += board[r][c]
-    return living
+    return living, neighbours, changed
 
 # Determine what happens to a given cell in the next generation,
 # based on its current state and that of its neighbours.
-def next_state(board, row, col):
-    living_neighbours = count_living_neighbours(board, row, col)
-    current_state = board[row][col]
+def next_state(current_state, living_neighbours):
     if current_state == ALIVE and living_neighbours in [2, 3]:
         return ALIVE
     if current_state == DEAD and living_neighbours == 3:
         return ALIVE
     return DEAD
 
+# Returns details of which cells have changed in the next generation and which
+# are alive.
+def update_changed_cells(living, neighbours, changed):
+    # There is some redundancy in keeping track of both of these, but we are
+    # optimising for speed. There can be many living cells which don't change
+    # between generations, so don't need to be updated, so we can skip them. And
+    # neighbours of cells that died don't need their neighbour counts updated.
+    next_living = {}
+    next_changed = []
+
+    checked = {}
+    for x, y in changed:
+        for dx, dy in NEIGHBOUR_AND_CELL_DIFFS.keys():
+            nx = (x + dx) % WIDTH
+            ny = (y + dy) % HEIGHT
+            if checked.get((nx, ny)):
+                continue
+            checked[(nx, ny)] = True
+            was_alive = living.get((nx, ny), DEAD)
+            is_alive = next_state(was_alive, neighbours.get((nx, ny), 0))
+            if is_alive:
+                next_living[(nx, ny)] = True
+            if is_alive != was_alive:
+                next_changed.append((nx, ny))
+
+    return next_living, next_changed
+
+# Returns details of how many living neighbours each cell in the next generation has.
+def update_neighbours(living):
+    neighbours = {}
+    for x, y in living.keys():
+        for dx, dy in NEIGHBOUR_DIFFS.keys():
+            nx = (x + dx) % WIDTH
+            ny = (y + dy) % HEIGHT
+            neighbours.setdefault((nx, ny), 0)
+            neighbours[(nx, ny)] += 1
+    return neighbours
+
 # Compute a new board representing the next generation of the
 # given board.
-def next_board(board):
-    return [
-        [next_state(board, r, c) for c in range(WIDTH)]
-        for r in range(HEIGHT)
-    ]
+def next_generation(living, neighbours, changed, cache):
+    key = (tuple(living.keys()), tuple(neighbours.items()), tuple(changed))
+    cached = cache.get(key)
+    if cached != None:
+        return cached
 
-# Display the board as widgets on screen.
-def render_board(board, alive_colour, dead_colour):
-    rows = []
-    for r in range(HEIGHT):
-        cells = []
-        for c in range(WIDTH):
-            if board[r][c] == ALIVE:
-                colour = alive_colour
-            else:
-                colour = dead_colour
-            cells.append(
-                render.Box(
-                    width = 1,
-                    height = 1,
-                    color = colour,
-                ),
-            )
-        rows.append(render.Row(children = cells))
-    return render.Column(children = rows)
+    next_living, next_changed = update_changed_cells(living, neighbours, changed)
+    next_neighbours = update_neighbours(next_living)
+    cache[key] = (next_living, next_neighbours, next_changed)
+    return next_living, next_neighbours, next_changed
+
+# Display the curent state as widgets on screen.
+def render_frame(living, alive_cell, dead_cell, cache):
+    cached = cache.get(living)
+    if cached != None:
+        return cached
+
+    rows = [[dead_cell for c in range(WIDTH)] for r in range(HEIGHT)]
+    for x, y in living:
+        rows[y][x] = alive_cell
+
+    frame = render.Column(children = [render.Row(children = row) for row in rows])
+    cache[living] = frame
+    return frame
 
 # Create an animation of the game of life with a random starting point.
-def animate(alive_colour, dead_colour):
+def animate(alive_cell, dead_cell):
     frames = []
-    board = generate_board()
+    living, neighbours, changed = generate_initial_state()
+
+    # We often reach the point where the end has lots of oscillators but no
+    # other action. We don't have to recompute each of those frames.
+    generation_cache = {}
+    frame_cache = {}
 
     # Generate enough frames to last for the maximum time the app can be on screen.
     for delay in range(0, APP_DURATION_MILLISECONDS, REFRESH_MILLISECONDS):
-        frames.append(render_board(board, alive_colour, dead_colour))
-        board = next_board(board)  # eveolve to next step
+        frames.append(render_frame(tuple(living.keys()), alive_cell, dead_cell, frame_cache))
+        living, neighbours, changed = next_generation(living, neighbours, changed, generation_cache)  # evolve to next step
     return render.Animation(children = frames)
 
 def main(config):
@@ -133,9 +181,23 @@ def main(config):
     if not dead_colour:
         dead_colour = COLOURS[3].value  # Black
 
+    # Turns out to be significantly faster to re-use
+    # a single element rather than create one for each
+    # cell on each iteration.
+    alive_cell = render.Box(
+        width = 1,
+        height = 1,
+        color = alive_colour,
+    )
+    dead_cell = render.Box(
+        width = 1,
+        height = 1,
+        color = dead_colour,
+    )
+
     return render.Root(
         delay = REFRESH_MILLISECONDS,
-        child = animate(alive_colour, dead_colour),
+        child = animate(alive_cell, dead_cell),
     )
 
 def get_schema():


### PR DESCRIPTION
Following up on comment in [pull request](https://github.com/tidbyt/community/pull/560) about performance, and using [profiler](https://github.com/tidbyt/pixlet/pull/353).

Speed up achieved by:
1. Reusing two Box objects rather than creating one per pixel per frame
1. iterating over changed cells in each generation rather than all cells in the board
1. keeping track of how many neighbours a cell has, so we don't have to keep recomputing it
1. caching results, particularly for later frames where there are just oscillators for many frames

Benchmark results using my laptop below, comparing the existing and updated versions of the app.

Starlark profiler shows 92% less time spent executing the Starlark code:

```shell

$ for i in {0..9}; do ./pixlet profile --pprof="top 1" ~/Desktop/old_life.star | grep total | awk '{ print $8 }'; done

6.27s
6.24s
6.27s
6.24s
6.24s
6.27s
6.27s
6.27s
6.24s
6.24s

--

$ for i in {0..9}; do ./pixlet profile --pprof="top 1" ../tidbyt-community/apps/life/life.star | grep total | awk '{ print $8 }'; done

510ms
540ms
660ms
870ms
510ms
570ms
390ms
780ms
870ms
540ms
```

Overall render time down 50%. This isn't quite so drastic, but suspect it's to do with the number of gif frames. If so, it could be reduced by slowing/shortening the animation (which would be a little sad as it's quite smooth at the moment)

```shell
$ for i in {0..9}; do time pixlet render ~/Desktop/old_life.star; done

pixlet render apps/life/life.star  5.47s user 0.51s system 202% cpu 2.948 total
pixlet render apps/life/life.star  5.41s user 0.53s system 209% cpu 2.842 total
pixlet render apps/life/life.star  5.43s user 0.59s system 211% cpu 2.848 total
pixlet render apps/life/life.star  5.53s user 0.54s system 212% cpu 2.854 total
pixlet render apps/life/life.star  5.36s user 0.53s system 207% cpu 2.838 total
pixlet render apps/life/life.star  5.38s user 0.53s system 208% cpu 2.833 total
pixlet render apps/life/life.star  5.38s user 0.55s system 207% cpu 2.849 total
pixlet render apps/life/life.star  5.43s user 0.54s system 209% cpu 2.852 total
pixlet render apps/life/life.star  5.47s user 0.56s system 210% cpu 2.866 total
pixlet render apps/life/life.star  5.41s user 0.53s system 208% cpu 2.846 total

--

$ for i in {0..9}; do time pixlet render ../tidbyt-community/apps/life/life.star; done

pixlet render apps/life/life.star  2.49s user 0.54s system 351% cpu 0.861 total
pixlet render apps/life/life.star  2.82s user 0.52s system 392% cpu 0.853 total
pixlet render apps/life/life.star  2.51s user 0.57s system 375% cpu 0.820 total
pixlet render apps/life/life.star  2.43s user 0.60s system 389% cpu 0.777 total
pixlet render apps/life/life.star  2.22s user 0.58s system 381% cpu 0.732 total
pixlet render apps/life/life.star  2.38s user 0.55s system 381% cpu 0.767 total
pixlet render apps/life/life.star  2.88s user 0.49s system 400% cpu 0.842 total
pixlet render apps/life/life.star  2.33s user 0.56s system 377% cpu 0.766 total
pixlet render apps/life/life.star  2.75s user 0.54s system 404% cpu 0.812 total
pixlet render apps/life/life.star  2.29s user 0.54s system 387% cpu 0.732 total
```