### PR TITLE
Statuspage.io

### DIFF
--- a/apps/apps.go
+++ b/apps/apps.go
@@ -120,6 +120,7 @@ import (
 	"tidbyt.dev/community/apps/sportsstandings"
 	"tidbyt.dev/community/apps/spotthestation"
 	"tidbyt.dev/community/apps/stateflags"
+	"tidbyt.dev/community/apps/statuspage"
 	"tidbyt.dev/community/apps/steam"
 	"tidbyt.dev/community/apps/stepcounter"
 	"tidbyt.dev/community/apps/stockticker"
@@ -275,6 +276,7 @@ func GetManifests() []manifest.Manifest {
 		sportsstandings.New(),
 		spotthestation.New(),
 		stateflags.New(),
+		statuspage.New(),
 		steam.New(),
 		stepcounter.New(),
 		stockticker.New(),

--- a/apps/statuspage/statuspage.go
+++ b/apps/statuspage/statuspage.go
@@ -1,0 +1,25 @@
+// Package statuspage provides details for the StatusPage applet.
+package statuspage
+
+import (
+	_ "embed"
+
+	"tidbyt.dev/community/apps/manifest"
+)
+
+//go:embed statuspage.star
+var source []byte
+
+// New creates a new instance of the StatusPage applet.
+func New() manifest.Manifest {
+	return manifest.Manifest{
+		ID:          "statuspage",
+		Name:        "StatusPage",
+		Author:      "Ricky Smith (DigitallyBorn)",
+		Summary:     "A statuspage status",
+		Desc:        "Shows the status of a page from StatusPage.io.",
+		FileName:    "statuspage.star",
+		PackageName: "statuspage",
+		Source:  source,
+	}
+}

--- a/apps/statuspage/statuspage.star
+++ b/apps/statuspage/statuspage.star
@@ -1,0 +1,102 @@
+"""
+Applet: StatusPage
+Summary: A statuspage status
+Description: Shows the status of a page from StatusPage.io.
+Author: Ricky Smith (DigitallyBorn)
+"""
+
+load("cache.star", "cache")
+load("encoding/json.star", "json")
+load("http.star", "http")
+load("render.star", "render")
+load("schema.star", "schema")
+
+def main(config):
+    page_url = config.get("page_url", "https://status.atlassian.com/")
+    page_data = get_statuspage_data(page_url)
+
+    title = page_data["page"]["name"]
+
+    if page_data["status"]["indicator"] == "none":
+        bgcolor = "#0f0"
+        fgcolor = "#fff"
+        display = "Operational"
+    elif page_data["status"]["indicator"] == "major":
+        bgcolor = "#f00"
+        fgcolor = "#fff"
+        display = "Major"
+    else:
+        bgcolor = "#ff0"
+        fgcolor = "#000"
+        display = "Minor"
+
+    return render.Root(
+        delay = 20,
+        child = render.Stack(
+            children = [
+                render.Box(
+                    width = 64,
+                    height = 32,
+                    color = bgcolor,
+                    child = render.Box(
+                        width = 60,
+                        height = 28,
+                        color = "#000",
+                    ),
+                ),
+                render.Column(
+                    expanded = True,
+                    main_align = "center",
+                    children = [
+                        render.Row(
+                            expanded = True,
+                            main_align = "center",
+                            children = [
+                                render.Text(
+                                    content = title,
+                                    color = fgcolor,
+                                ),
+                            ],
+                        ),
+                        render.Row(
+                            expanded = True,
+                            main_align = "center",
+                            children = [
+                                render.Text(
+                                    content = display,
+                                    color = fgcolor,
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        ),
+    )
+
+def get_statuspage_data(url):
+    raw_data = cache.get(url)
+    if raw_data == None:
+        response = http.get(
+            url,
+            headers = {
+                "Accept": "application/json",
+            },
+        )
+        raw_data = response.body()
+        cache.set(url, raw_data, 120)
+    return json.decode(raw_data)
+
+def get_schema():
+    return schema.Schema(
+        version = "1",
+        fields = [
+            schema.Text(
+                id = "page_url",
+                name = "Status Page Url",
+                desc = "The URL of a status page hosted by statuspage.io.",
+                icon = "desktop",
+                default = "https://status.atlassian.com/",
+            ),
+        ],
+    )

--- a/apps/statuspage/statuspage.star
+++ b/apps/statuspage/statuspage.star
@@ -13,22 +13,26 @@ load("schema.star", "schema")
 
 def main(config):
     page_url = config.get("page_url", "https://status.atlassian.com/")
+
     page_data = get_statuspage_data(page_url)
 
     title = page_data["page"]["name"]
 
-    if page_data["status"]["indicator"] == "none":
+    indicator = page_data["status"]["indicator"]
+
+    if indicator == "none":
         bgcolor = "#0f0"
-        fgcolor = "#fff"
         display = "Operational"
-    elif page_data["status"]["indicator"] == "major":
+    elif indicator == "major":
         bgcolor = "#f00"
         fgcolor = "#fff"
-        display = "Major"
+        display = "Major Outage"
+    elif indicator == "maintenance":
+        bgcolor = "#00f"
+        display = "Maintenance"
     else:
         bgcolor = "#ff0"
-        fgcolor = "#000"
-        display = "Minor"
+        display = "Minor Outage"
 
     return render.Root(
         delay = 20,
@@ -54,7 +58,6 @@ def main(config):
                             children = [
                                 render.Text(
                                     content = title,
-                                    color = fgcolor,
                                 ),
                             ],
                         ),
@@ -64,7 +67,6 @@ def main(config):
                             children = [
                                 render.Text(
                                     content = display,
-                                    color = fgcolor,
                                 ),
                             ],
                         ),


### PR DESCRIPTION
Display simple status from an Atlassian Status Page (aka statuspage.io).

These are screenshots when the user configured site is https://status.atlassian.com/. The title "Atlassian" is the name of that statuspage -- it won't always say "Atlassian".

![statuspage](https://user-images.githubusercontent.com/16527/185034463-5feeb24a-e847-4483-a5ff-ac40788dfeb7.gif)
![statuspage](https://user-images.githubusercontent.com/16527/185034609-1e52f6ee-db7c-4766-83ce-63d32be954d7.gif)
![statuspage](https://user-images.githubusercontent.com/16527/185034654-6c34009f-eb49-4d56-8112-914f9fec1e27.gif)

