### PR TITLE
Update: Verge Taglines to use new marquee centering and add scroll offset

### DIFF
--- a/apps/vergetaglines/verge_taglines.star
+++ b/apps/vergetaglines/verge_taglines.star
@@ -105,28 +105,20 @@ def get_top_img(html_body):
         return PLACEHOLDER_IMG
 
 def content(value, img):
-    if len(value) > 13:
-        return [
-            image_stack(img),
-            render.Marquee(
-                height = 8,
-                width = 64,
-                scroll_direction = "horizontal",
-                child = render.Text(
-                    content = value,
-                ),
+    return [
+        image_stack(img),
+        render.Marquee(
+            height = 8,
+            width = 64,
+            scroll_direction = "horizontal",
+            align = "center",
+            offset_start = 64,
+            offset_end = 64,
+            child = render.Text(
+                content = value,
             ),
-        ]
-    else:
-        return [
-            image_stack(img),
-            render.Box(
-                child = render.Text(
-                    height = 8,
-                    content = value,
-                ),
-            ),
-        ]
+        ),
+    ]
 
 def image_stack(img):
     return render.Stack(


### PR DESCRIPTION
# What is this?

This updates the Verge Taglines with the following:
- Use the new `align` feature of Marquee and remove the custom text centering
- Add an offset configuration so scrolling brings the text into view on render to address a readability issue

# Checklist

- [x] I ran `make lint` to ensure code is formatted.
- [x] I tested this locally to ensure nothing is broken.

# Screenshots

Here is an example of how a tagline from today, which is not scrollable, fits before and after the change.

Before
<img width="1457" alt="verge-taglines-before" src="https://user-images.githubusercontent.com/1731429/185820854-bcb6bab6-b298-4f45-ac20-aaab87179812.png">

After
<img width="1456" alt="verge-taglines-after" src="https://user-images.githubusercontent.com/1731429/185820857-89973321-0f0e-40d2-8a11-e7ab0a93cdd9.png">
