### PR TITLE
Add: Blackout

### DIFF
--- a/apps/apps.go
+++ b/apps/apps.go
@@ -19,6 +19,7 @@ import (
 	"tidbyt.dev/community/apps/bigclock"
 	"tidbyt.dev/community/apps/bikeshare"
 	"tidbyt.dev/community/apps/binaryclock"
+	"tidbyt.dev/community/apps/blackout"
 	"tidbyt.dev/community/apps/burgeroftheday"
 	"tidbyt.dev/community/apps/charlestownferry"
 	"tidbyt.dev/community/apps/chessviewer"
@@ -183,6 +184,7 @@ func GetManifests() []manifest.Manifest {
 		bigclock.New(),
 		bikeshare.New(),
 		binaryclock.New(),
+		blackout.New(),
 		burgeroftheday.New(),
 		charlestownferry.New(),
 		chessviewer.New(),

--- a/apps/blackout/blackout.go
+++ b/apps/blackout/blackout.go
@@ -1,0 +1,25 @@
+// Package blackout provides details for the Blackout applet.
+package blackout
+
+import (
+	_ "embed"
+
+	"tidbyt.dev/community/apps/manifest"
+)
+
+//go:embed blackout.star
+var source []byte
+
+// New creates a new instance of the Blackout applet.
+func New() manifest.Manifest {
+	return manifest.Manifest{
+		ID:          "blackout",
+		Name:        "Blackout",
+		Author:      "mabroadfo1027",
+		Summary:     "Blackout tidbyt",
+		Desc:        "Black out TidByt during evenings (or whenever).",
+		FileName:    "blackout.star",
+		PackageName: "blackout",
+		Source:  source,
+	}
+}

--- a/apps/blackout/blackout.star
+++ b/apps/blackout/blackout.star
@@ -1,0 +1,28 @@
+"""
+Applet: Blackout
+Summary: Blackout tidbyt
+Description: Black out TidByt during evenings (or whenever).
+Author: mabroadfo1027
+"""
+
+load("render.star", "render")
+load("schema.star", "schema")
+load("encoding/json.star", "json")
+
+def main():
+
+    pulseList=[]
+    for i in range(0, 1000):
+        pulseList.append(render.Text(".", color = "#8B0000" if i % 10 == 0 else "#000000"))
+
+    return render.Root(
+        delay = 1000,
+        child = render.Box(
+                  render.Column(
+                        main_align="end",
+                        cross_align="end",
+                        expanded=True,
+                        children = [render.Animation(children = pulseList)],
+                     ),
+                  ),
+        )


### PR DESCRIPTION
Black out TidByt during evenings (or whenever). Adds a slow pulsating pixel so users are aware the Tidbyt is on and not stuck/frozen.