### PR TITLE
SF NextMuni Updates

### DIFF
--- a/apps/sfnextmuni/sf_next_muni.star
+++ b/apps/sfnextmuni/sf_next_muni.star
@@ -21,11 +21,14 @@ DEFAULT_LOCATION = """
 	"timezone": "America/Los_Angeles"
 }
 """
-PREDICTIONS_URL = "https://retro.umoiq.com/service/publicJSONFeed?command=predictions&a=sf-muni&stopId=%s&useShortTitles=true"
+PREDICTIONS_URL = "https://retro.umoiq.com/service/publicJSONFeed?command=predictions&a=sf-muni&stopId=%s&useShortTitles=true%s"
 ROUTES_URL = "https://retro.umoiq.com/service/publicJSONFeed?command=routeList&a=sf-muni&useShortTitles=true"
 STOPS_URL = "https://retro.umoiq.com/service/publicJSONFeed?command=routeConfig&a=sf-muni&r=%s&useShortTitles=true"
 
+# Colours for Muni Metro/Street Car lines
 MUNI_COLORS = {
+    "E": "#666666",
+    "F": "#f0e68c",
     "J": "#faa634",
     "K": "#569bbe",
     "L": "#92278f",
@@ -33,6 +36,58 @@ MUNI_COLORS = {
     "N": "#00539b",
     "T": "#d31245",
     "S": "#ffcc00",
+}
+
+# Display the route letter in black text (#000000) inside the circle for these routes
+MUNI_BLACK_TEXT = [
+    "F", 
+    "S",
+]
+
+# Inbound stops on KT line that should display as K. If not listed stop will display as T
+K_INBOUND_STOPS = [
+    "17778",
+    "15784",
+    "15794",
+    "15797",
+    "15787",
+    "15788",
+    "15809",
+    "15779",
+    "15806",
+    "17113",
+    "17109",
+    "16898"
+]
+# Outbound stops on KT line that should display as T. If not listed stop will display as K
+T_OUTBOUND_STOPS = [
+    "17398",
+    "17399",
+    "17400",
+    "17347",
+    "17343",
+    "17345",
+    "17401",
+    "17402",
+    "17403",
+    "17404",
+    "17352",
+    "17353",
+    "17354",
+    "17355",
+    "17356",
+    "17357",
+    "17358",
+    "17166",
+    "15237",
+    "17145",
+    "14510"
+]
+
+# Dictionary to define default config values when pixlet commands are run as get_schema() currently not referenced then
+DEFAULT_CONFIG = {
+    "route_filter": "all-routes",
+    "prediction_format": "long",
 }
 
 def get_schema():
@@ -72,6 +127,14 @@ def get_schema():
             display = "Compact",
             value = "short",
         ),
+        schema.Option(
+            display = "Two line w/destination",
+            value = "two_line_dest",
+        ),
+        schema.Option(
+            display = "Two line w/4 times",
+            value = "two_line_four_times",
+        ),
     ]
 
     return schema.Schema(
@@ -83,6 +146,14 @@ def get_schema():
                 desc = "A list of bus stops based on a location.",
                 icon = "bus",
                 handler = get_stops,
+            ),
+            schema.Dropdown(
+                id = "route_filter",
+                name = "Route Filter",
+                desc = "Filter to only display one route",
+                icon = "route",
+                default = "all-routes",
+                options = get_route_list(),
             ),
             schema.Toggle(
                 id = "show_title",
@@ -137,6 +208,25 @@ def get_stops(location):
         for stop in sorted(stops.values(), key = lambda stop: square_distance(loc["lat"], loc["lng"], stop["lat"], stop["lon"]))
     ]
 
+# Function to get the available route list for route filter selection. Additionally adds 'all-routes' option to the beginning of the list
+def get_route_list():
+    (timestamp, raw_routes) = fetch_cached(ROUTES_URL, 86400)
+    route_list = [
+        schema.Option(
+            display = route["title"],
+            value = route["tag"],
+        )
+        for route in raw_routes["route"]
+    ]
+    route_list.insert(
+        0,
+        schema.Option(
+            display = "All Routes",
+            value = "all-routes",
+        )
+    )
+    return route_list
+
 def square_distance(lat1, lon1, lat2, lon2):
     latitude_difference = int((float(lat2) - float(lat1)) * 10000)
     longitude_difference = int((float(lon2) - float(lon1)) * 10000)
@@ -164,9 +254,14 @@ def main(config):
     default_stop = json.encode(get_stops(DEFAULT_LOCATION)[0])
     stop = json.decode(config.get("stop_code", default_stop))
     stopId = stop["value"]
+    route_filter = config.get("route_filter", DEFAULT_CONFIG["route_filter"])
 
-    (data_timestamp, data) = fetch_cached(PREDICTIONS_URL % stopId, 240)
-    routes = data["predictions"]
+    if route_filter != "all-routes":
+        (data_timestamp, data) = fetch_cached(PREDICTIONS_URL % (stopId, "&r=" + route_filter), 240)
+    else:
+        (data_timestamp, data) = fetch_cached(PREDICTIONS_URL % (stopId, ""), 240)
+
+    routes = data.get("predictions", [])
     data_age_seconds = time.now().unix - data_timestamp
 
     if type(routes) != "list":
@@ -205,9 +300,14 @@ def main(config):
             if type(predictions) != "list":
                 predictions = [predictions]
 
-            # Hack for KT interlining, until the Central Subway opens
+            # Hack for KT interlining, until the Central Subway opens. If stop is in override list, then route designation overriden. Else, use Inbound/Outbound direction to determine route letter
             if routeTag == "KT":
-                routeTag = "T" if "Inbound" in dest["title"] else "K"
+                kt_override_stops = {}
+                for stop in K_INBOUND_STOPS:
+                    kt_override_stops[stop] = "K"
+                for stop in T_OUTBOUND_STOPS:
+                    kt_override_stops[stop] = "T"
+                routeTag = kt_override_stops.get(stopId, "T" if "Inbound" in dest["title"] else "K")
 
             titleKey = routeTag if "short" == config.get("prediction_format") else (routeTag, destTitle)
             seconds = [int(prediction["seconds"]) - data_age_seconds for prediction in predictions if "seconds" in prediction]
@@ -340,7 +440,7 @@ def shortPredictions(output, messages, lines, config):
                             render.Row(
                                 children = [
                                     render.Circle(
-                                        child = render.Text(routeTag, font = "tom-thumb"),
+                                        child = render.Text(routeTag, font = "tom-thumb", color = "#000000" if routeTag in MUNI_BLACK_TEXT else "#ffffff"),
                                         diameter = 7,
                                         color = MUNI_COLORS[routeTag] if routeTag in MUNI_COLORS else "#000000",
                                     ),
@@ -364,6 +464,7 @@ def shortPredictions(output, messages, lines, config):
     ]
 
 def longRows(output, config):
+    output = output[:2] if config.get("prediction_format", DEFAULT_CONFIG["prediction_format"])[:8] == "two_line" else output
     return [
         render.Row(
             children = getLongRow(routeTag, destination, predictions, config),
@@ -379,16 +480,19 @@ def getLongRow(routeTag, destination, predictions, config):
     if routeTag in MUNI_COLORS:
         row.append(
             render.Circle(
-                child = render.Text(routeTag, font = "tom-thumb"),
-                diameter = 7,
+                child = render.Text(routeTag, font = "tom-thumb" if config.get("prediction_format", DEFAULT_CONFIG["prediction_format"])[:8] != "two_line" else "", color = "#000000" if routeTag in MUNI_BLACK_TEXT else "#ffffff"),
+                diameter = 7 if config.get("prediction_format", DEFAULT_CONFIG["prediction_format"])[:8] != "two_line" else 12,
                 color = MUNI_COLORS[routeTag],
             ),
         )
     else:
         row.append(
-            render.Text(routeTag + " ", font = "tom-thumb"),
+            render.Text(
+                routeTag + " ", 
+                font = "tom-thumb" if config.get("prediction_format", DEFAULT_CONFIG["prediction_format"])[:8] != "two_line" else ""
+            ),
         )
-    if "xlong" == config.get("prediction_format"):
+    if "xlong" == config.get("prediction_format", DEFAULT_CONFIG["prediction_format"]):
         row.append(
             render.Marquee(
                 child = render.Text(destination, font = "tom-thumb"),
@@ -401,7 +505,7 @@ def getLongRow(routeTag, destination, predictions, config):
                 width = 10,
             ),
         )
-    elif "long" == config.get("prediction_format"):
+    elif "long" == config.get("prediction_format", DEFAULT_CONFIG["prediction_format"]):
         row.append(
             render.Marquee(
                 child = render.Text(destination, font = "tom-thumb"),
@@ -414,6 +518,26 @@ def getLongRow(routeTag, destination, predictions, config):
             render.Marquee(
                 child = render.Text(nextTwoPredictions, font = "tom-thumb"),
                 width = 20,
+            ),
+        )
+    elif "two_line" == config.get("prediction_format", DEFAULT_CONFIG["prediction_format"])[:8]:
+        max_width = 50
+        max_predictions = 4
+        
+        if "two_line_dest" == config.get("prediction_format", DEFAULT_CONFIG["prediction_format"]):
+            row.append(
+                render.Marquee(
+                    child = render.Text(destination),
+                    width = 25,
+                ),
+            )
+            max_width = max_width - 25
+            max_predictions = 2
+
+        row.append(
+            render.Marquee(
+                child = render.Text(",".join([prediction for prediction in predictions[:max_predictions]])),
+                width = max_width,
             ),
         )
     else:

--- a/apps/sfnextmuni/sf_next_muni.star
+++ b/apps/sfnextmuni/sf_next_muni.star
@@ -40,7 +40,7 @@ MUNI_COLORS = {
 
 # Display the route letter in black text (#000000) inside the circle for these routes
 MUNI_BLACK_TEXT = [
-    "F", 
+    "F",
     "S",
 ]
 
@@ -57,8 +57,9 @@ K_INBOUND_STOPS = [
     "15806",
     "17113",
     "17109",
-    "16898"
+    "16898",
 ]
+
 # Outbound stops on KT line that should display as T. If not listed stop will display as K
 T_OUTBOUND_STOPS = [
     "17398",
@@ -81,7 +82,7 @@ T_OUTBOUND_STOPS = [
     "17166",
     "15237",
     "17145",
-    "14510"
+    "14510",
 ]
 
 # Dictionary to define default config values when pixlet commands are run as get_schema() currently not referenced then
@@ -223,7 +224,7 @@ def get_route_list():
         schema.Option(
             display = "All Routes",
             value = "all-routes",
-        )
+        ),
     )
     return route_list
 
@@ -488,8 +489,8 @@ def getLongRow(routeTag, destination, predictions, config):
     else:
         row.append(
             render.Text(
-                routeTag + " ", 
-                font = "tom-thumb" if config.get("prediction_format", DEFAULT_CONFIG["prediction_format"])[:8] != "two_line" else ""
+                routeTag + " ",
+                font = "tom-thumb" if config.get("prediction_format", DEFAULT_CONFIG["prediction_format"])[:8] != "two_line" else "",
             ),
         )
     if "xlong" == config.get("prediction_format", DEFAULT_CONFIG["prediction_format"]):
@@ -523,7 +524,6 @@ def getLongRow(routeTag, destination, predictions, config):
     elif "two_line" == config.get("prediction_format", DEFAULT_CONFIG["prediction_format"])[:8]:
         max_width = 50
         max_predictions = 4
-        
         if "two_line_dest" == config.get("prediction_format", DEFAULT_CONFIG["prediction_format"]):
             row.append(
                 render.Marquee(


### PR DESCRIPTION
New Features:
* Route Filter: Filter predictions to only one route for a given stop
* Prediction Formats: Two Line w/Destination only shows predictions for the next two lines, two times, w/ destination. Larger Font
* Prediction Formats: Two Line w/4 Times only shows predictions for the next two lines, 4 times, no destination. Larger Font

Enhancements:
* Added line colours for E and F lines
* Display route letter for F and S lines as black to provide better contrast
* Improved KT route tag override to properly show K or T depending on which stop and to match Muni signage
* Better handling of default config values when pixlet commands are used as get_schema is not currently called then