### PR TITLE
cla: Add alternate renovate.

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -18,7 +18,7 @@ jobs:
           PERSONAL_ACCESS_TOKEN: ${{ secrets.TIDBYT_GITHUB_TOKEN }}
         with:
           path-to-document: https://github.com/tidbyt/community/blob/main/docs/CLA.md
-          allowlist: tidbyt-bot,renovate-bot
+          allowlist: tidbyt-bot,renovate-bot,renovate[bot]
 
           remote-organization-name: tidbyt
           remote-repository-name: cla-signatures


### PR DESCRIPTION
This commit adds an additional renovate bot. At some point, renovate
changed from an account to an app on GitHub which broke this
integration.