### PR TITLE
Goodservice: Skip rendering when there's no data

### DIFF
--- a/apps/goodservice/goodservice.star
+++ b/apps/goodservice/goodservice.star
@@ -193,6 +193,9 @@ def main(config):
                     ),
                 ))
 
+    if len(blocks) == 0:
+        return []
+
     return render.Root(
         child = render.Marquee(
             height = 32,


### PR DESCRIPTION
Small fix to skip rendering when there's no data from the selected station.