### PR TITLE
Fixes for London apps

### DIFF
--- a/apps/londonbusstop/london_bus_stop.star
+++ b/apps/londonbusstop/london_bus_stop.star
@@ -18,7 +18,7 @@ STOP_URL = "https://api.tfl.gov.uk/StopPoint"
 ARRIVALS_URL = "https://api.tfl.gov.uk/StopPoint/%s/Arrivals"
 
 # Allows 500 queries per minute
-ENCRYPTED_API_KEY = "AV6+xWcELQeKmsYDiEPA6VUWk2IZKw+uc9dkaM5cXT/xirUKWgWKfsRAQz2pOxq0eKTNhb/aShsRjavxA84Ay12p6NaZDnDOgVeVxoMCCOnWxJsxmURHogJHpVQpuqBTNttfvafOj0PC1zUXkEpcN7EYhveycs6qxmouIwpDzY5I93wpTy4="
+ENCRYPTED_API_KEY = "AV6+xWcEwOzw3Prks28FxD8mnJMXHr1dGqzhOXvIsAXbGKKGd7VbVZ7JV8q0RUqKZ9ymhPUV4ZbDECOI42Eyg0h1SIsA3are83w007OIoPV4fIQ1S8g6ruswsuHZ1NzwE6KGYdPSX1fXYoz/qiaDg7RHoTvfVtDhFDE5kEMBswB9VZrOz/M="
 
 RED = "#DA291C"  # Pantone 485 C - same as the buses
 ORANGE = "#FFA500"  # Like the countdown timers at bus stops

--- a/apps/londonbusstop/london_bus_stop.star
+++ b/apps/londonbusstop/london_bus_stop.star
@@ -18,7 +18,7 @@ STOP_URL = "https://api.tfl.gov.uk/StopPoint"
 ARRIVALS_URL = "https://api.tfl.gov.uk/StopPoint/%s/Arrivals"
 
 # Allows 500 queries per minute
-ENCRYPTED_API_KEY = "AV6+xWcEwOzw3Prks28FxD8mnJMXHr1dGqzhOXvIsAXbGKKGd7VbVZ7JV8q0RUqKZ9ymhPUV4ZbDECOI42Eyg0h1SIsA3are83w007OIoPV4fIQ1S8g6ruswsuHZ1NzwE6KGYdPSX1fXYoz/qiaDg7RHoTvfVtDhFDE5kEMBswB9VZrOz/M="
+ENCRYPTED_API_KEY = "AV6+xWcELQeKmsYDiEPA6VUWk2IZKw+uc9dkaM5cXT/xirUKWgWKfsRAQz2pOxq0eKTNhb/aShsRjavxA84Ay12p6NaZDnDOgVeVxoMCCOnWxJsxmURHogJHpVQpuqBTNttfvafOj0PC1zUXkEpcN7EYhveycs6qxmouIwpDzY5I93wpTy4="
 
 RED = "#DA291C"  # Pantone 485 C - same as the buses
 ORANGE = "#FFA500"  # Like the countdown timers at bus stops

--- a/apps/tubestatus/tube_status.star
+++ b/apps/tubestatus/tube_status.star
@@ -13,7 +13,7 @@ load("schema.star", "schema")
 load("secret.star", "secret")
 
 # Allows 500 queries per minute
-ENCRYPTED_APP_KEY = "AV6+xWcE2sENYC+/SYTqo/7oaIT8Q+BjV27Q/Bm9b1C19OEsiEuWKQQ3KKx6ymZQk2DOkiaPMjvoYmBlYZl/yr6AqusGweRYyA/gZ26zZBYX6krBCckHACEZQIS0mtAkwZmiLoGxhH2XpUkBBQdmBBwjODAqrcthPYPCm7u597BdzWyhljQ="
+ENCRYPTED_APP_KEY = "AV6+xWcEhlNSpbLLbDENcp6ciPWXIbN1PeIKjZ67POTBLIpBlN3rGqCHyQ2mz4Wt3NoRzZTrd9HfWr5cfcTTh5pNqV4OAie/8vEEGiAi0tHsYH/ZOUCBZnryz8aL+cDTsqOCSsr3l5dzCkBM0ZjPwTsigZp5mFCFW4or0C0ZIz2BGXPSXA4="
 STATUS_URL = "https://api.tfl.gov.uk/Line/Mode/%s/Status"
 
 WHITE = "#FFF"

--- a/apps/tubestatus/tube_status.star
+++ b/apps/tubestatus/tube_status.star
@@ -13,7 +13,7 @@ load("schema.star", "schema")
 load("secret.star", "secret")
 
 # Allows 500 queries per minute
-ENCRYPTED_APP_KEY = "AV6+xWcEhlNSpbLLbDENcp6ciPWXIbN1PeIKjZ67POTBLIpBlN3rGqCHyQ2mz4Wt3NoRzZTrd9HfWr5cfcTTh5pNqV4OAie/8vEEGiAi0tHsYH/ZOUCBZnryz8aL+cDTsqOCSsr3l5dzCkBM0ZjPwTsigZp5mFCFW4or0C0ZIz2BGXPSXA4="
+ENCRYPTED_APP_KEY = "AV6+xWcE2sENYC+/SYTqo/7oaIT8Q+BjV27Q/Bm9b1C19OEsiEuWKQQ3KKx6ymZQk2DOkiaPMjvoYmBlYZl/yr6AqusGweRYyA/gZ26zZBYX6krBCckHACEZQIS0mtAkwZmiLoGxhH2XpUkBBQdmBBwjODAqrcthPYPCm7u597BdzWyhljQ="
 STATUS_URL = "https://api.tfl.gov.uk/Line/Mode/%s/Status"
 
 WHITE = "#FFF"


### PR DESCRIPTION
1. Make sure app keys are encrypted using names of the .star files (e.g. "london_bus_stop") rather than the folder ("londonbusstop")
2. Truncate latitude and longitudes to three decimal places for better caching when calling the API.