### PR TITLE
[fix] Mbtanewtrains over counting

### DIFF
--- a/apps/mbtanewtrains/mbta_new_trains.star
+++ b/apps/mbtanewtrains/mbta_new_trains.star
@@ -55,21 +55,25 @@ CACHE_TTL_SECONDS = 3600 * 24  # 1 day in seconds.
 #         "direction": 0,
 #         "stationId": "place-rugg",
 #         "route": "Orange"
+#         "isNewTrain": "true"
 #     },
 #     {
 #         "direction": 0,
 #         "stationId": "place-unsqu",
 #         "route": "Green-E"
+#         "isNewTrain": "true"
 #     },
 #     {
 #         "direction": 1,
 #         "stationId": "place-bbsta",
-#         "route": "Orange"
+#         "route": "Orange",
+#         "isNewTrain": "true"
 #     },
 #         {
 #         "direction": 1,
 #         "stationId": "place-davis",
-#         "route": "Red-A"
+#         "route": "Red-A",
+#         "isNewTrain": "true"
 #     },
 # ]
 
@@ -109,6 +113,9 @@ def mapRouteToColor(route, config):
     return None
 
 def createTrain(loc, config):
+    if loc["isNewTrain"] != True:
+        return None
+
     routeResult = mapRouteToColor(loc["route"], config)
     if routeResult == None:
         return
@@ -205,6 +212,8 @@ def displayDigest(apiResult, config):
     g = 0
     o = 0
     for loc in apiResult:
+        if loc["isNewTrain"] != True:
+            continue
         route = loc["route"]
         if "Red" in route:
             r += 1


### PR DESCRIPTION
The API response changed, adding in an `isNewTrain` attribute.  This PR updates the applet to respect that flag.