### PR TITLE
SevereWxAlertsUSA: fix overlapping alerts

### DIFF
--- a/apps/severewxalertsusa/severewxalertsusa.star
+++ b/apps/severewxalertsusa/severewxalertsusa.star
@@ -53,7 +53,7 @@ def main(config):
         columnFrames.append(render_summary_card_zero_alerts(jsonLocation))
 
     return render.Root(
-        render.Sequence(columnFrames),
+        render.Animation(columnFrames),
         delay = 5000,
     )
 


### PR DESCRIPTION
@aschechter88 this PR should resolve #646 to at least make alerts readable until you can find some time to play around with the display more if desired. As per that discussion, I simply swapped `render.Sequence` for `render.Animation`. the `delay` parameter may need to be modified to show alerts quick enough, but I did not test that. Again if you want to change the icon for hide app when no alerts, you may also consider that. 