### PR TITLE
Feature: NHL Live - Add Game Day Only option

### DIFF
--- a/apps/nhllive/nhl_live.star
+++ b/apps/nhllive/nhl_live.star
@@ -2,7 +2,7 @@
 Applet: NHL Live
 Summary: Live updates of NHL games
 Description: Displays live game stats or next scheduled NHL game information
-Author: Reed Arnesonx
+Author: Reed Arneson
 """
 
 load("render.star", "render")
@@ -13,6 +13,8 @@ load("encoding/json.star", "json")
 load("schema.star", "schema")
 load("random.star", "random")
 load("cache.star", "cache")
+
+APP_VERSION = "1.3.0"
 
 # Constants
 DEFAULT_LOCATION = """
@@ -103,8 +105,9 @@ def main(config):
     today = now.format("2006-1-2").upper()
 
     # Grab teamid from our schema
-    config_teamid = config.get("teamid") or 0
-    config_teamid = int(config_teamid)
+    orig_config_teamid = config.get("teamid") or 0
+    orig_config_teamid = int(orig_config_teamid)
+    config_teamid = orig_config_teamid
 
     if config_teamid == 0:
         config_teamid = get_random_team()
@@ -122,7 +125,7 @@ def main(config):
 
     # Check our game info cache first
     print("Grabbing Game for team: %s" % team)
-    teamid_away, teamid_home, gamePk, game_state, gameDate, score_away, score_home = get_game(today, config_teamid)
+    teamid_away, teamid_home, gamePk, game_state, gameDate, score_away, score_home, isGameToday = get_game(today, config_teamid)
 
     # No Game URL found
     if gamePk != None:
@@ -174,6 +177,11 @@ def main(config):
     # PowerPlay/EmptyNet Color Change
     score_color_away = get_score_color(game_info["is_pp_away"], game_info["is_empty_away"])
     score_color_home = get_score_color(game_info["is_pp_home"], game_info["is_empty_home"])
+
+    # Game Day Only
+    if config.bool("gameday", False) and (isGameToday == False or isGameToday == "False"):
+        print("  - No %s games today, returning nothing." % str(team))
+        return [] 
 
     return render.Root(
         child = render.Column(
@@ -291,6 +299,8 @@ def get_game(date, teamId):
         game_state = cache.get("game_" + gamePk + "_gamestate") or None
         score_away = cache.get("game_" + gamePk + "_scoreaway") or None
         score_home = cache.get("game_" + gamePk + "_scorehome") or None
+        isGameToday = cache.get("game_" + gamePk + "_isGameToday") or None
+
     else:
         print("  - CACHE: No GamePk Found")
         teamid_away = None
@@ -299,8 +309,9 @@ def get_game(date, teamId):
         game_state = None
         score_away = None
         score_home = None
+        isGameToday = None
 
-    if teamid_away == None or teamid_home == None or gamePk == None or gameDate == None or game_state == None:
+    if teamid_away == None or teamid_home == None or gamePk == None or gameDate == None or game_state == None or isGameToday == None:
         print("  - CACHE: No Game Info Found")
         url = BASE_URL + "/api/v1/schedule?startDate=" + date + "&teamId=" + str(teamId)
         print("  - HTTP.GET: %s" % url)
@@ -312,6 +323,9 @@ def get_game(date, teamId):
             # Check next scheduled
             if response["totalGames"] == 0:
                 response = get_next_game(teamId)
+                isGameToday = False
+            else:
+                isGameToday = True
 
             if response["totalGames"] > 0:
                 gamePk = str(int(response["dates"][0]["games"][0]["gamePk"]))
@@ -332,13 +346,14 @@ def get_game(date, teamId):
                 cache.set("game_" + gamePk + "_gamestate", str(game_state), ttl_seconds = CACHE_GAME_SECONDS)
                 cache.set("game_" + gamePk + "_scoreaway", str(score_away), ttl_seconds = CACHE_GAME_SECONDS)
                 cache.set("game_" + gamePk + "_scorehome", str(score_home), ttl_seconds = CACHE_GAME_SECONDS)
+                cache.set("game_" + gamePk + "_isGameToday", str(isGameToday), ttl_seconds = CACHE_GAME_SECONDS)
 
                 # Associate team with game in cache
                 cache.set("teamid_" + str(teamId) + "_gamepk", str(gamePk), ttl_seconds = CACHE_GAME_SECONDS)
     else:
         print("  - CACHE: Game Info Found for GamePk %s" % gamePk)
 
-    return teamid_away, teamid_home, gamePk, game_state, gameDate, score_away, score_home
+    return teamid_away, teamid_home, gamePk, game_state, gameDate, score_away, score_home, isGameToday
 
 # looks up the next game for a team
 def get_next_game(teamId):
@@ -722,6 +737,13 @@ def get_schema():
     ]
     team_schema_list.insert(0, schema.Option(display = "Shuffle All Teams", value = "0"))
 
+    version = [
+        schema.Option(
+            display = APP_VERSION,
+            value = APP_VERSION,
+        ),
+    ]
+
     return schema.Schema(
         version = "1",
         fields = [
@@ -738,6 +760,13 @@ def get_schema():
                 name = "Location",
                 desc = "Location for which to display time.",
                 icon = "locationDot",
+            ),
+            schema.Toggle(
+                id = "gameday",
+                name = "Game Day Only",
+                desc = "",
+                icon = "calendar",
+                default = False,
             ),
             schema.Toggle(
                 id = "liveupdates",
@@ -822,6 +851,14 @@ def get_schema():
                 desc = "Toggle Giveaway Stats",
                 icon = "hockeyPuck",
                 default = True,
+            ),
+            schema.Dropdown(
+                id = "version",
+                name = "Version",
+                desc = "NHL Live App Version",
+                icon = "codeCompare",
+                options = version,
+                default = version[0].value,
             ),
         ],
     )


### PR DESCRIPTION
- Added Game Day Only option per a request. If the current game day api endpoint returns no games, it will return []. Note - the NHL API rolls game day data mid morning (depending on your location) / caching. So yesterday's game score will stick around until then. 
- Added an app version for tracking
- Fixed author line