### PR TITLE
feat: Add help text to color field names

### DIFF
--- a/apps/desknametag/desk_name_tag.star
+++ b/apps/desknametag/desk_name_tag.star
@@ -99,14 +99,14 @@ def get_schema():
             ),
             schema.Text(
                 id = "text_color",
-                name = "Text Color",
-                desc = "Enter a valid hex string: #FFFFFF",
+                name = "Text Color (ex: #FFFFFF)",
+                desc = "Enter a valid color hex code: #FFFFFF",
                 icon = "paintbrush",
             ),
             schema.Text(
                 id = "background_color",
-                name = "Background Color",
-                desc = "Enter a valid hex string: #00008B",
+                name = "Background Color (ex: #00008B)",
+                desc = "Enter a valid color hex code: #00008B",
                 icon = "fillDrip",
             ),
         ],


### PR DESCRIPTION
The app does not display field descriptions. The initial version of this applet assumed these values would be shown to help users. I've updated the applet to add help text to the color field names so users know they need to enter a full hex code.