### PR TITLE
Test that all apps are registered

### DIFF
--- a/apps/apps.go
+++ b/apps/apps.go
@@ -199,6 +199,7 @@ import (
 	"tidbyt.dev/community/apps/usyieldcurve"
 	"tidbyt.dev/community/apps/vergetaglines"
 	"tidbyt.dev/community/apps/verticalmessage"
+	"tidbyt.dev/community/apps/visibleplanets"
 	"tidbyt.dev/community/apps/wantedposter"
 	"tidbyt.dev/community/apps/warframecycles"
 	"tidbyt.dev/community/apps/weathermap"
@@ -410,6 +411,7 @@ func GetManifests() []manifest.Manifest {
 		usyieldcurve.New(),
 		vergetaglines.New(),
 		verticalmessage.New(),
+		visibleplanets.New(),
 		wantedposter.New(),
 		warframecycles.New(),
 		weathermap.New(),

--- a/apps/apps_test.go
+++ b/apps/apps_test.go
@@ -1,6 +1,7 @@
 package apps_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,4 +39,37 @@ func TestFindManifest(t *testing.T) {
 	// App that should not exist.
 	_, err = apps.FindManifest("foo-bar-123")
 	assert.Error(t, err)
+}
+
+func TestAllAppsRegistered(t *testing.T) {
+	// List of directories that are not expected to be registered in apps.go.
+	exclusions := []string{
+		"manifest",
+	}
+
+	dirs, err := os.ReadDir(".")
+	if err != nil {
+		assert.NoError(t, err)
+	}
+	manifests := apps.GetManifests()
+	registered := make(map[string]bool, len(manifests))
+	for _, app := range manifests {
+		registered[app.PackageName] = true
+	}
+
+	for _, dir := range dirs {
+		if !dir.IsDir() {
+			continue
+		}
+		excluded := false
+		for _, exclusion := range exclusions {
+			if dir.Name() == exclusion {
+				excluded = true
+			}
+		}
+		if excluded {
+			continue
+		}
+		assert.Containsf(t, registered, dir.Name(), "Package %s is not registered", dir.Name())
+	}
 }

--- a/apps/apps_test.go
+++ b/apps/apps_test.go
@@ -47,16 +47,16 @@ func TestAllAppsRegistered(t *testing.T) {
 		"manifest",
 	}
 
-	dirs, err := os.ReadDir(".")
-	if err != nil {
-		assert.NoError(t, err)
-	}
 	manifests := apps.GetManifests()
 	registered := make(map[string]bool, len(manifests))
 	for _, app := range manifests {
 		registered[app.PackageName] = true
 	}
 
+	dirs, err := os.ReadDir(".")
+	if err != nil {
+		assert.NoError(t, err)
+	}
 	for _, dir := range dirs {
 		if !dir.IsDir() {
 			continue


### PR DESCRIPTION
Seems like there's been a bunch of issues recently where changes aren't being reflected in apps.go, then people get confused. Or they accidentally removed existing apps when making their change due to sync issues.

Existing tests check that everything in apps.go is backed up by code in the repo.

This goes the other way and checks that what's in the repo is registered.

You can still quickly unregister existing apps if they start misbehaving. Just have to add the directory name to "exclusions" list and the test will ignore it.