### PR TITLE
Only support teams on accounts with the teams ability

### DIFF
--- a/apps/pagerduty/pagerduty.star
+++ b/apps/pagerduty/pagerduty.star
@@ -86,12 +86,15 @@ def pagerduty_api_call(config, url, use_cache = True):
             },
         )
 
-        if res.status_code != 200:
+        if res.status_code < 200 or res.status_code >= 300:
             # buildifier: disable=print
             print("pagerduty_api_call failed: %s - %s " % (res.status_code, res.body()))
             return None
-
-        cached_res = res.body()
+        else:
+            if len(res.body()) > 0:
+                cached_res = res.body()
+            else:
+                cached_res = '{"status": %i}' % res.status_code
 
         if use_cache:
             cache.set(cache_key, cached_res, DEFAULT_CACHE_TTL)
@@ -99,7 +102,7 @@ def pagerduty_api_call(config, url, use_cache = True):
     return json.decode(cached_res)
 
 # buildifier: disable=function-docstring
-def get_pagerduty_counts(config, profile = None):
+def get_pagerduty_counts(config, profile = None, teams_supported = True):
     received_data = False
     counts = dict(
         total = 0,
@@ -109,7 +112,7 @@ def get_pagerduty_counts(config, profile = None):
     team_param = ""
     team_id = config.get("team_id", DEFAULT_TEAM_ID)
 
-    if profile != None:
+    if teams_supported and profile != None:
         if team_id != "all":
             team_param = "&team_ids[]=%s" % team_id
         elif len(profile["teams"]) > 0:
@@ -229,6 +232,14 @@ def is_user_oncall(config, shifts, user_id):
 
     return is_user_oncall
 
+def are_teams_supported(config):
+    result = pagerduty_api_call(config, "%s/abilities/teams" % PAGERDUTY_BASE_URL)
+
+    if result != None and result["status"] != None:
+        return result["status"] == 204
+    else:
+        return False
+
 # buildifier: disable=function-docstring
 def get_oncall_scroll_text(shifts, timezone = DEFAULT_TIMEZONE):
     scroll = ""
@@ -287,7 +298,8 @@ def get_state(config):
         if profile == None:
             return Error("Failed to get user profile")
 
-        counts = get_pagerduty_counts(config, profile)
+        account_has_teams = are_teams_supported(config)
+        counts = get_pagerduty_counts(config, profile, account_has_teams)
 
         if show_oncall_bar:
             shifts = get_oncall_shifts(config, profile["id"] if only_when_oncall else None)
@@ -308,6 +320,7 @@ def get_state(config):
         level_one_only = level_one_only,
         only_when_oncall = only_when_oncall,
         team_id = team_id,
+        teams_supported = account_has_teams,
     )
 
 # buildifier: disable=function-docstring
@@ -425,6 +438,11 @@ def main(config):
 def build_teams(refresh_token):
     config = dict(auth = refresh_token)
     user = get_current_user(config)
+    teams_supported = are_teams_supported(config)
+
+    if not teams_supported:
+        return None
+    
     options = [
         schema.Option(
             display = "All",

--- a/apps/pagerduty/pagerduty.star
+++ b/apps/pagerduty/pagerduty.star
@@ -90,11 +90,10 @@ def pagerduty_api_call(config, url, use_cache = True):
             # buildifier: disable=print
             print("pagerduty_api_call failed: %s - %s " % (res.status_code, res.body()))
             return None
+        elif len(res.body()) > 0:
+            cached_res = res.body()
         else:
-            if len(res.body()) > 0:
-                cached_res = res.body()
-            else:
-                cached_res = '{"status": %i}' % res.status_code
+            cached_res = '{"status": %i}' % res.status_code
 
         if use_cache:
             cache.set(cache_key, cached_res, DEFAULT_CACHE_TTL)
@@ -442,7 +441,7 @@ def build_teams(refresh_token):
 
     if not teams_supported:
         return None
-    
+
     options = [
         schema.Option(
             display = "All",


### PR DESCRIPTION
Due to some recent changes to my company's PagerDuty account, I noticed that the app was crashing with insufficient permissions:

```json
{
    "error": {
        "message": "Required abilities are unavailable",
        "code": 2014,
        "errors": [
            "The teams account ability is required to filter by teams."
        ],
        "missing_abilities": "teams"
    }
}
```

PagerDuty offers an abilities endpoint to test whether features are available or not. I've implemented that to restore the app to working order for users on the Professional plan which does not include Teams support in the API.