### PR TITLE
Stupid Chat for Tidbyt

### DIFF
--- a/apps/apps.go
+++ b/apps/apps.go
@@ -177,6 +177,7 @@ import (
 	"tidbyt.dev/community/apps/stepcounter"
 	"tidbyt.dev/community/apps/stockticker"
 	"tidbyt.dev/community/apps/strava"
+	"tidbyt.dev/community/apps/stupidchat"
 	"tidbyt.dev/community/apps/subreddit"
 	"tidbyt.dev/community/apps/sunrisesunset"
 	"tidbyt.dev/community/apps/supermariokart"
@@ -398,6 +399,7 @@ func GetManifests() []manifest.Manifest {
 		stepcounter.New(),
 		stockticker.New(),
 		strava.New(),
+		stupidchat.New(),
 		subreddit.New(),
 		sunrisesunset.New(),
 		supermariokart.New(),

--- a/apps/stupidchat/README.md
+++ b/apps/stupidchat/README.md
@@ -1,0 +1,41 @@
+# stupid.chat for Tidbyt
+
+Send messages and pictures to your Tidbyt from anywhere.
+
+Visit https://stupid.chat and click `Get Started`. You will be assigned a
+random, unique token for your Tidbyt. Configure your stupid.chat token in
+the app to link the website to your device. Having done so, you may
+send messages or images from the stupid.chat website to your Tidbyt.
+Tokens are free, you can always visit stupid.chat and generate a new one.
+
+## Messages
+
+Text has these qualities:
+
+* scrolled vertically or horizontally
+* aligned center, left or right
+* 5 fonts to choose from: `10x20` (largest) to `tom-thumb` (smallest)
+* choice of background and foreground colors
+
+## Images
+
+Images are served at 64x32. The server will do its best to resize larger
+images.
+
+## Share
+
+Your secret stupid.chat URL can be shared with friends and family to allow
+them to send updates.
+
+## API
+
+You can use your favorite programming language or command-line tools to
+send messages to your your Tidbyt. API documentation is available
+[here](https://api.stupid.chat/).
+
+## About this App
+
+* Created 17-Jun-2022 by [harrisonpage](https://harrison.page)
+* For updates: https://toad.house/@harrison
+* I can also be found here: [Tidbyt Discord](https://discord.com/invite/r45MXG4kZc)
+* [About Page](https://stupid.chat/about)

--- a/apps/stupidchat/stupid_chat.star
+++ b/apps/stupidchat/stupid_chat.star
@@ -1,0 +1,81 @@
+"""
+Applet: Stupid Chat
+Summary: Tidbyt Messaging
+Description: Send messages to your Tidbyt via https://stupid.chat or an API.
+Author: harrisonpage
+"""
+
+load("http.star", "http")
+load("render.star", "render")
+load("schema.star", "schema")
+load("encoding/base64.star", "base64")
+load("encoding/json.star", "json")
+
+VERSION = "1.0.0"
+
+def get_config(config, key, default):
+    value = config.get(key)
+    if not value:
+        value = default
+    return value
+
+def main(config):
+    token = get_config(config, "token", "WELCOME")
+    client_id = get_config(config, "client_id", "XXX")
+    response = http.get(
+        "https://api.stupid.chat/v1/" + token + "?client_id=" + client_id + "&format=base64&version=" + VERSION,
+        headers = {"User-Agent": "stupid.chat/" + VERSION},
+    )
+    if response.status_code != 200:
+        fail("failed with status %d", response.status_code)
+    cooked = response.json()
+
+    if cooked["upload"]:
+        return render.Root(
+            render.Image(
+                src = base64.decode(cooked["image"]),
+                width = 64,
+                height = 32,
+            ),
+        )
+
+    return render.Root(
+        child = render.Column(
+            children = [
+                render.Box(
+                    color = "#" + cooked["bgcolor"],
+                    child = render.Marquee(
+                        offset_start = 32,
+                        offset_end = 32,
+                        width = 64,
+                        height = 32,
+                        scroll_direction = cooked["direction"],
+                        child = render.Column(
+                            children = [
+                                render.WrappedText(
+                                    content = cooked["message"],
+                                    color = "#" + cooked["color"],
+                                    font = cooked["font"],
+                                    align = cooked["align"],
+                                ),
+                            ],
+                        ),
+                    ),
+                ),
+            ],
+        ),
+    )
+
+def get_schema():
+    return schema.Schema(
+        version = "1",
+        fields = [
+            schema.Text(
+                id = "token",
+                name = "Secret token",
+                desc = "Visit https://stupid.chat to get started",
+                icon = "eye",
+                default = "",
+            ),
+        ],
+    )

--- a/apps/stupidchat/stupidchat.go
+++ b/apps/stupidchat/stupidchat.go
@@ -1,0 +1,25 @@
+// Package stupidchat provides details for the Stupid Chat applet.
+package stupidchat
+
+import (
+	_ "embed"
+
+	"tidbyt.dev/community/apps/manifest"
+)
+
+//go:embed stupid_chat.star
+var source []byte
+
+// New creates a new instance of the Stupid Chat applet.
+func New() manifest.Manifest {
+	return manifest.Manifest{
+		ID:          "stupid-chat",
+		Name:        "Stupid Chat",
+		Author:      "harrisonpage",
+		Summary:     "Tidbyt Messaging",
+		Desc:        "Send messages to your Tidbyt via https://stupid.chat or an API.",
+		FileName:    "stupid_chat.star",
+		PackageName: "stupidchat",
+		Source:  source,
+	}
+}


### PR DESCRIPTION
Send messages and pictures to your Tidbyt from anywhere.

Visit https://stupid.chat and click `Get Started`.  You will be assigned a random, unique token for your Tidbyt. Configure your stupid.chat token in the app to link the website to your device. Having done so, you may send messages or images from the stupid.chat website to your Tidbyt.  Tokens are free, you can always visit stupid.chat and generate a new one.