### PR TITLE
Change NS Error Cache to 30 mins

### DIFF
--- a/apps/nightscout/nightscout.star
+++ b/apps/nightscout/nightscout.star
@@ -38,7 +38,7 @@ GRAPH_WIDTH = 43
 GRAPH_BOTTOM = 50
 GRAPH_TOP = 275
 
-CACHE_TTL_SECONDS = 300  #5 mins
+CACHE_TTL_SECONDS = 1800  #30 mins
 
 PROVIDER_CACHE_TTL = 7200  #2 hours
 NS_PROVIDERS = "https://gist.githubusercontent.com/IsThisPaul/e976c41112d79383c51ed7315bb114ab/raw/170f967eba27587ffd289631c1a2ae9e31f1bee3/nightscout_providers.csv"


### PR DESCRIPTION
This cache is used only when Nightscout returns an error. The cache ensures a blood sugar value is shown (and displayed as stale) for up to 30 minutes if NS is temporarily unavailable. It does not affect live glucose values if they are available as this app never displays cached data unless there is a NS error.