### PR TITLE
Added new applet for tracking portfolio value of a stock

### DIFF
--- a/apps/apps.go
+++ b/apps/apps.go
@@ -190,6 +190,7 @@ import (
 	"tidbyt.dev/community/apps/steam"
 	"tidbyt.dev/community/apps/stepcounter"
 	"tidbyt.dev/community/apps/stockticker"
+	"tidbyt.dev/community/apps/stockvalue"
 	"tidbyt.dev/community/apps/strava"
 	"tidbyt.dev/community/apps/subreddit"
 	"tidbyt.dev/community/apps/sunrisesunset"
@@ -427,6 +428,7 @@ func GetManifests() []manifest.Manifest {
 		steam.New(),
 		stepcounter.New(),
 		stockticker.New(),
+		stockvalue.New(),
 		strava.New(),
 		subreddit.New(),
 		sunrisesunset.New(),

--- a/apps/stockvalue/README.md
+++ b/apps/stockvalue/README.md
@@ -1,0 +1,5 @@
+# Stock Value Price Applet for Tidbyt
+
+Allows you to track the value of a stock that you currently own. I use this to always remind me of my RSU value while working to motivate me. You will need to enter in the company stock symbol, number of shares you have, and your alphavantage API key. If you need to get a API KEY, it's free at https://www.alphavantage.co/
+
+![Stock Value Applet for Tidbyt](stock_value.gif)

--- a/apps/stockvalue/stock_value.star
+++ b/apps/stockvalue/stock_value.star
@@ -1,0 +1,92 @@
+"""
+Applet: Stock Value
+Summary: Portfolio value
+Description: This app will allow you track the value of your portfolio for a single stock.
+Author: gshipley
+"""
+
+load("render.star", "render")
+load("http.star", "http")
+load("math.star", "math")
+load("humanize.star", "humanize")
+load("encoding/base64.star", "base64")
+load("schema.star", "schema")
+load("cache.star", "cache")
+load("secret.star", "secret")
+
+STOCK_PRICE_URL = "https://www.alphavantage.co/query?function=GLOBAL_QUOTE&symbol="
+DEFAULT_SHARES = 1
+DEFAULT_SYMBOL = "IBM"
+
+DOLLAR_ICON = base64.decode("""
+iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAA
+Cxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAGtSURBVDhPpZPNK4RRFMaf9y1KrCQLG2ZK
+1iLZsrKTslXSZCRF+QOEtWLhY14S5Q9goaymLOxIliwmLCRLH0kKv3PvfTNDkjzT6T33POecue
+fjRvqKFbUrVl6RevWuFmeLdIle1JsKGtepswV8JlhQjWq1hJZDSsguic4Jivi1kaAfWxbZ0JMm
+Na1n9JDAgut0gFM7lindaEuzhJZjhnRNGsZnEZ9TPaovTSKtKUHukU5vCEg04KQc5uN9EztGoe
+YTtByVbzonQ6Ju7jCPVoVsw+/AvzquoBFusgHfEbuGWc127RSJMpCHaA0EPvCd45txnMH7liw2
+huhF9ipqfnO9qEZbxnmAFmY0qgtPAvO1GGJjrtKCnAfKI9Ixtlu+6zTuDnaVUhsD62ExxMbhWI
+m8rvXiRjfB6YxEOa674slKWAmXSFs4fyJmsGOUkFcPpyN8mj0RYDHEWglFpN/NOUWiQXp/xaiK
+dHwfvgvrjieB+VoMsTHtKGDKuiVJ0eq2cJh/sEWrR4a4iW2ph/fNhljw0yKtMgGTcnxbJMM/Vv
+nnx2RzTsf762Mqx5+es/QBsMaX7pbQA0YAAAAASUVORK5CYII=
+""")
+
+def main(config):
+    DEFAULT_API_KEY = secret.decrypt("AV6+xWcEoxaMY+yAVrWhOa/VWxu11stEvJIV+akY8ilogee67GPOhvO9HP360IQlHd5Aj9MTVP/NXllxHIV1AyD/KvgQU4vMpZ7YWpDhwhVjtISncPqnTsrzBBkrI1axvvI4yq77ZKTIbcdrsktXIoF1/w8Ckw==")
+
+    price_cached = cache.get("price")
+
+    if DEFAULT_API_KEY == None:
+        DEFAULT_API_KEY = config.str("alphavantage", "demo")
+
+    if price_cached != None:
+        price = float(price_cached)
+    else:
+        rep = http.get(STOCK_PRICE_URL + config.str("symbol", DEFAULT_SYMBOL) + "&apikey=" + config.str("API_KEY", DEFAULT_API_KEY))
+
+        if rep.status_code != 200:
+            fail("Request failed with status %d", rep.status_code)
+        price = rep.json()["Global Quote"]["05. price"]
+        cache.set("price", str(float(price)), ttl_seconds = 43200)
+
+    value = (float(price) * int(config.str("shares", DEFAULT_SHARES)))
+    total = humanize.float("#,###.", value)
+
+    return render.Root(
+        child = render.Box(
+            render.Row(
+                expanded = True,
+                main_align = "space_evenly",
+                cross_align = "center",
+                children = [
+                    render.Image(src = DOLLAR_ICON),
+                    render.Text(total),
+                ],
+            ),
+        ),
+    )
+
+def get_schema():
+    return schema.Schema(
+        version = "1",
+        fields = [
+            schema.Text(
+                id = "symbol",
+                name = "Symbol?",
+                desc = "What stock symbol to track?",
+                icon = "chart-line",
+            ),
+            schema.Text(
+                id = "shares",
+                name = "Number of shares",
+                desc = "How many shares do you have?",
+                icon = "hashtag",
+            ),
+            schema.Text(
+                id = "alphavantage",
+                name = "API KEY",
+                desc = "API key for Alpha Vantage (https://www.alphavantage.co)",
+                icon = "key",
+            ),
+        ],
+    )

--- a/apps/stockvalue/stockvalue.go
+++ b/apps/stockvalue/stockvalue.go
@@ -1,0 +1,25 @@
+// Package stockvalue provides details for the Stock Value applet.
+package stockvalue
+
+import (
+	_ "embed"
+
+	"tidbyt.dev/community/apps/manifest"
+)
+
+//go:embed stock_value.star
+var source []byte
+
+// New creates a new instance of the Stock Value applet.
+func New() manifest.Manifest {
+	return manifest.Manifest{
+		ID:          "stock-value",
+		Name:        "Stock Value",
+		Author:      "gshipley",
+		Summary:     "Portfolio value",
+		Desc:        "This app will allow you track the value of your portfolio for a single stock.",
+		FileName:    "stock_value.star",
+		PackageName: "stockvalue",
+		Source:  source,
+	}
+}


### PR DESCRIPTION
I created a simple applet that will track the value of a particular stock that is owned. I mainly coded this to track my RSU value on my office tidbyt to constantly motivate me to work hard.

The user must provide a ticker symbol, number of shares owned, and a stock API key.

I set the cache value to 12 hours as the app is intended for a daily overview, not a real time account value. 

I am a bit concerned about the unfriendliness of the user having to provide an API key but it will default to mine if not provided. I have searched high and low for a unauthenticated simple stock quote service.