### PR TITLE
[break fix] Upgrade Todoist from Rest API v1 to v2.

### DIFF
--- a/apps/todoist/todoist.star
+++ b/apps/todoist/todoist.star
@@ -51,7 +51,7 @@ DEFAULT_SHOW_IF_EMPTY = True
 
 NO_TASKS_CONTENT = "No Tasks :)"
 
-TODOIST_URL = "https://api.todoist.com/rest/v1/tasks"
+TODOIST_URL = "https://api.todoist.com/rest/v2/tasks"
 
 OAUTH2_CLIENT_ID = secret.decrypt("AV6+xWcE3uxifd70n+JncXgagNue2eYtPYP05tbS77/hAd//mp4OQfMp+easxFROFLbCWsen/FCCDIzz8y5huFcAfV0hdyGL3mTGWaoUO2tVBvUUtGqPbOfb3HdJxMjuMb7C1fDFNqhdXhfJmo+UgRzRYzVZ/Q/C/sSl7U25DOrtKqhRs8I=")
 OAUTH2_CLIENT_SECRET = secret.decrypt("AV6+xWcEYGPbL6d105xHQ68RZWY/KSrCK/ivqz2Y2AkrVuPO9iUFkYXBqoJs4phKRdeh2QxHjjGTuwQ7RakOEPrER+2VACdGHiiytCIpMZ5Qst1PeuMT5NECKqmHhW73MwReMBtvyPl0SbjdF8XijqzhK/YvcDTwVOdZZALaj+3dvGnqANk=")


### PR DESCRIPTION
Per Todoist, v1 of the API is deprecated and has been removed on November 30th. As a result, this app is currently broken until this pull request is merged. Sorry I missed the deprecation announcement!

We didn't use any features which changed between v1 and v2, so this change simply adjusts our URL to point to their new v2 endpoint. Tested locally and works with this change. Thanks!

See https://developer.todoist.com/rest/v1/#overview:
DEPRECATED: This version of the REST API (v1) is deprecated and will be removed on Nov 30. Please refer to the v2 documentation. 