### PR TITLE
BlueBomber app fix: Protoman got left off the array! Poor guy...

### DIFF
--- a/apps/bluebomber/bluebomber.star
+++ b/apps/bluebomber/bluebomber.star
@@ -20,6 +20,7 @@ BGBLURIMAGE = base64.decode("""R0lGODlhQAAOAJECAAGW5AGN1gAAAAAAACH/C05FVFNDQVBFM
 
 BOSS_LIST = {
     "MEGA": "MEGA",
+    "PROTO": "PROTO",
     "CUT": "CUT",
     "GUTS": "GUTS",
     "ICE": "ICE",


### PR DESCRIPTION
Accidentally left Protoman off the main randomized array as a selection. Restoring him to his rightful place