### PR TITLE
Fix timezone off-by-one error in Is It Xmas applet

### DIFF
--- a/apps/daystoxmas/days_to_xmas.star
+++ b/apps/daystoxmas/days_to_xmas.star
@@ -20,18 +20,15 @@ def main(config):
     today = time.time(year = now.year, month = now.month, day = now.day, location = timezone)
     current_xmas = time.time(year = today.year, month = 12, day = 25, location = timezone)
 
-    if today <= current_xmas:
-        xmas_timestamp = time.time(year = today.year, month = 12, day = 25).in_location(timezone)
-        xmasdateString = time.time(year = today.year, month = 12, day = 26).in_location(timezone).format("Jan 02, 2006")
-    else:
-        xmas_timestamp = time.time(year = today.year + 1, month = 12, day = 25).in_location(timezone)
-        xmasdateString = time.time(year = today.year + 1, month = 12, day = 26).in_location(timezone).format("Jan 02, 2006")
+    if today > current_xmas:
+        current_xmas = time.time(year = today.year + 1, month = 12, day = 25, location = timezone)
 
-    dateDiff = xmas_timestamp - time.now().in_location(timezone)
-    days = math.ceil(dateDiff.hours / 24)
+    xmas_datestring = current_xmas.format("Jan 02, 2006")
 
-    dayString = str(days)
-    dayString2 = "{}".format("Day" if days == 1 else "Days ") + " left"
+    date_diff = current_xmas - now
+    days = math.ceil(date_diff.hours / 24)
+
+    description = "{} left".format("Day" if days == 1 else "Days")
 
     return render.Root(
         child = render.Stack(
@@ -52,7 +49,7 @@ def main(config):
                         width = 32,
                         height = 16,
                         child = render.Text(
-                            content = dayString,
+                            content = str(days),
                             color = "#FFFFFF",
                             font = "10x20",
                             height = 0,
@@ -66,7 +63,7 @@ def main(config):
                         width = 64,
                         height = 8,
                         child = render.Text(
-                            content = dayString2,
+                            content = description,
                             color = "#FFFFFF",
                             font = "CG-pixel-3x5-mono",
                         ),
@@ -78,7 +75,7 @@ def main(config):
                         width = 64,
                         height = 8,
                         child = render.Text(
-                            content = xmasdateString,
+                            content = xmas_datestring,
                             color = "#FFFFFF",
                             font = "CG-pixel-4x5-mono",
                         ),


### PR DESCRIPTION
First, I love this applet and I loved discovering it in the tidbyt app! I am hoping seasonal things like this continue to make appearances.

There is a small bug in this applet where it uses a UTC date comparison instead of the local timezone. That means that in the evening west coast time today 2022-12-11, it shows "13 days until Christmas" instead of "14 days until Christmas".

The issue is that 
```
xmas_timestamp = time.time(year = today.year + 1, month = 12, day = 25).in_location(timezone)
```

Should be
```
xmas_timestamp = time.time(year = today.year + 1, month = 12, day = 25, location = timezone)
```

The former initializes a UTC 2022-12-25 and then translates it into PST - which is 2022-12-24. The latter creates a reference to 2022-12-25 in PST.

I also cleaned up some readability issues (I think the 26 on line 25 and 28 was patching around this issue).

@rohansingh @mgodfrey10 FYI!