### PR TITLE
fix(verge-taglines): Update mapping of tagline from data block

### DIFF
--- a/apps/vergetaglines/verge_taglines.star
+++ b/apps/vergetaglines/verge_taglines.star
@@ -91,7 +91,7 @@ def main():
     )
 
 def map_to_tagline():
-    return ["props", "pageProps", "hydration", "responses", 1, "data", "cellData", "prestoComponentData", "masthead_tagline"]
+    return ["props", "pageProps", "hydration", "responses", 0, "data", "cellData", "prestoComponentData", "masthead_tagline"]
 
 def get_tagline(html_body):
     json_blob = html_body.find(SELECTOR_TAGLINE).text()
@@ -99,9 +99,9 @@ def get_tagline(html_body):
 
     current_ref = json_object
     for key in map_to_tagline():
-        if key == 1:
+        if key == 0:
             if len(current_ref) >= 1:
-                current_ref = current_ref[1]
+                current_ref = current_ref[0]
         elif key in current_ref:
             current_ref = current_ref[key]
         else:


### PR DESCRIPTION
This fixes the currently broken Verge Taglines app with the updated path to the tagline from the embedded data block on the page.