### PR TITLE
Add `Airthings` Applets

### DIFF
--- a/apps/airthings/airthings.go
+++ b/apps/airthings/airthings.go
@@ -1,0 +1,25 @@
+// Package airthings provides details for the AirThings applet.
+package airthings
+
+import (
+	_ "embed"
+
+	"tidbyt.dev/community/apps/manifest"
+)
+
+//go:embed airthings.star
+var source []byte
+
+// New creates a new instance of the AirThings applet.
+func New() manifest.Manifest {
+	return manifest.Manifest{
+		ID:          "airthings",
+		Name:        "AirThings",
+		Author:      "joshspicer",
+		Summary:     "Environment sensor readings",
+		Desc:        "Interact with the API by creating a client app at https://dashboard.airthings.com/integrations/api-integration",
+		FileName:    "airthings.star",
+		PackageName: "airthings",
+		Source:      source,
+	}
+}

--- a/apps/airthings/airthings.star
+++ b/apps/airthings/airthings.star
@@ -1,0 +1,243 @@
+"""
+Applet: AirThings
+Summary: Environment sensor readings
+Description: Environment sensor readings from an AirThings sensor.
+Author: joshspicer
+"""
+
+# AirThings Environment Sensor Applet
+#
+# Copyright (c) 2022 Josh Spicer <hello@joshspicer.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+load("render.star", "render")
+load("schema.star", "schema")
+load("encoding/json.star", "json")
+load("http.star", "http")
+load("cache.star", "cache")
+
+def main(config):
+    # Require secrets
+    clientId = config.get("clientId")
+    clientSecret = config.get("clientSecret")
+    serialNumber = config.get("serialNumber")
+
+    if not clientId or not clientSecret or not serialNumber:
+        return render.Root(
+            child = render.WrappedText(
+                content = "AirThings credentials missing.",
+            ),
+        )
+
+    # Key unique to the user to fetch cached access_token
+    access_token_cache_key = "%s-%s" % (clientId, serialNumber)
+
+    access_token = cache.get(access_token_cache_key)
+    if access_token == None or access_token == "":
+        print("[+] Refreshing Token...")
+        access_token = client_credentials_grant_flow(config, access_token_cache_key)
+    else:
+        print("[+] Using Cached Token...")
+
+    # https://developer.airthings.com/consumer-api-docs/#operation/Device%20samples%20latest-values
+    samples = get_samples(config, access_token)
+
+    co2 = samples["data"]["co2"]
+    pm25 = samples["data"]["pm25"]
+    temp = samples["data"]["temp"]
+    voc = samples["data"]["voc"]
+
+    # https://help.airthings.com/en/articles/5367327-view-understanding-the-sensor-thresholds
+    co2_color = "#0f0"
+    pm25_color = "#0f0"
+    temp_color = "#0f0"
+    voc_color = "#0f0"
+
+    if co2 > 1000:
+        co2_color = "#f00"
+    elif co2 > 800:
+        co2_color = "#ff0"
+
+    if pm25 > 25:
+        pm25_color = "#f00"
+    elif pm25 > 10:
+        pm25_color = "#ff0"
+
+    if temp > 25:
+        temp_color = "#f00"
+    elif temp > 22:
+        temp_color = "#ff0"
+
+    if voc > 2000:
+        voc_color = "#f00"
+    elif voc > 250:
+        voc_color = "#ff0"
+
+    all_green = True
+    for sample in [co2_color, pm25_color, temp_color, voc_color]:
+        if not sample == "#0f0":
+            all_green = False
+            break
+
+    if all_green:
+        # Skip rendering
+        return []
+
+    return render.Root(
+        child = render.Column(
+            children = [
+                render.Row(
+                    expanded = True,
+                    main_align = "space_between",
+                    children = [
+                        render.Text(
+                            content = "CO2",
+                            color = co2_color,
+                        ),
+                        render.Text(
+                            content = str(co2),
+                            color = co2_color,
+                        ),
+                    ],
+                ),
+                render.Row(
+                    expanded = True,
+                    main_align = "space_between",
+                    children = [
+                        render.Text(
+                            content = "Pm2.5",
+                            color = pm25_color,
+                        ),
+                        render.Text(
+                            content = str(pm25),
+                            color = pm25_color,
+                        ),
+                    ],
+                ),
+                render.Row(
+                    expanded = True,
+                    main_align = "space_between",
+                    children = [
+                        render.Text(
+                            content = "Temp",
+                            color = temp_color,
+                        ),
+                        render.Text(
+                            content = str(temp),
+                            color = temp_color,
+                        ),
+                    ],
+                ),
+                render.Row(
+                    expanded = True,
+                    main_align = "space_between",
+                    children = [
+                        render.Text(
+                            content = "VOC",
+                            color = voc_color,
+                        ),
+                        render.Text(
+                            content = str(voc),
+                            color = voc_color,
+                        ),
+                    ],
+                ),
+            ],
+        ),
+    )
+
+def get_samples(config, access_token):
+    serial_number = config["serialNumber"]
+    if serial_number == None:
+        fail("serial_number is required")
+
+    url = "https://ext-api.airthings.com/v1/devices/" + serial_number + "/latest-samples"
+    headers = {
+        "Authorization": "Bearer " + access_token,
+    }
+    res = http.get(url, headers = headers)
+
+    if res.status_code != 200:
+        print("Error fetching samples: %s" % (res.body()))
+        fail("fetching samples failed with status code: %d - %s" % (res.status_code, res.body()))
+
+    status = res.json()
+    return status
+
+def client_credentials_grant_flow(config, access_token_cache_key):
+    clientSecret = config.str("clientSecret")
+    clientId = config.str("clientId")
+
+    form_body = dict(
+        client_id = clientId,
+        client_secret = clientSecret,
+        grant_type = "client_credentials",
+        scope = "read:device:current_values",
+    )
+
+    res = http.post(
+        url = "https://accounts-api.airthings.com/v1/token",
+        headers = {
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Accept": "*/*",
+        },
+        form_body = form_body,
+    )
+
+    if res.status_code == 200:
+        print("Success")
+    else:
+        cache.set(access_token_cache_key, "")
+        print("Error Fetching access_token: %s" % (res.body()))
+        fail("token request failed with status code: %d - %s" % (res.status_code, res.body()))
+        return None
+
+    token_params = res.json()
+    access_token = token_params["access_token"]
+    token_type = token_params["token_type"]
+    expires_in = token_params["expires_in"]
+
+    cache.set(access_token_cache_key, access_token, ttl_seconds = int(expires_in) - 30)
+    return access_token
+
+def get_schema():
+    return schema.Schema(
+        version = "1",
+        fields = [
+            schema.Text(
+                id = "clientSecret",
+                name = "AirThings API Client Secret",
+                desc = "API secret from https://dashboard.airthings.com/integrations/api-integration",
+                icon = "gear",
+            ),
+            schema.Text(
+                id = "clientId",
+                name = "AirThings API Client Id",
+                desc = "Client Id from https://dashboard.airthings.com/integrations/api-integration",
+                icon = "gear",
+            ),
+            schema.Text(
+                id = "serialNumber",
+                name = "Serial Number for AirThings Device",
+                desc = "Taken from the target device on https://dashboard.airthings.com/",
+                icon = "gear",
+            ),
+        ],
+    )

--- a/apps/apps.go
+++ b/apps/apps.go
@@ -11,6 +11,7 @@ import (
 	"tidbyt.dev/community/apps/abstractclock"
 	"tidbyt.dev/community/apps/advice"
 	"tidbyt.dev/community/apps/afl"
+	"tidbyt.dev/community/apps/airthings"
 	"tidbyt.dev/community/apps/amazing"
 	"tidbyt.dev/community/apps/ambientweather"
 	"tidbyt.dev/community/apps/analogclock"
@@ -250,6 +251,7 @@ func GetManifests() []manifest.Manifest {
 		abstractclock.New(),
 		advice.New(),
 		afl.New(),
+		airthings.New(),
 		amazing.New(),
 		ambientweather.New(),
 		analogclock.New(),


### PR DESCRIPTION
Resurrected from: https://github.com/tidbyt/community/pull/739


Adds environmental sensor readings from an [AirThings](https://www.airthings.com/) device.

Utilizes the public API (https://developer.airthings.com/consumer-api-docs/), which only supports the client credential oauth flow. Thus, each user must supply their own clientSecret and clientId, which can be generated for free from https://dashboard.airthings.com/integrations/api-integration.