### PR TITLE
Nightscout: Fix vertical bars where hour crosses day

### DIFF
--- a/apps/nightscout/nightscout.star
+++ b/apps/nightscout/nightscout.star
@@ -436,7 +436,7 @@ def main(config):
             if show_graph_hour_bars:
                 min_hour = time.from_timestamp(min_time, 0).hour
                 max_hour = time.from_timestamp(max_time, 0).hour
-                if min_hour < max_hour:
+                if min_hour != max_hour:
                     # Add hour marker at this point
                     graph_hour_bars.append(render.Padding(
                         pad = (point, 0, 0, 0),


### PR DESCRIPTION
Fix vertical bars where hour crosses day.
Vertical hour bar was not passing test to render when hour was midnight GMT