### PR TITLE
Fix module-docstring warnings.

### DIFF
--- a/apps/effheadlines/effheadlines.star
+++ b/apps/effheadlines/effheadlines.star
@@ -1,3 +1,10 @@
+"""
+Applet: EFF Headlines
+Author: hainish
+Summary: EFF Headlines tidbyt
+Description: Get the latest headlines from the Electronic Frontier Foundation.
+"""
+
 load("cache.star", "cache")
 load("encoding/base64.star", "base64")
 load("encoding/json.star", "json")

--- a/apps/fuzzyclock/fuzzy_clock.star
+++ b/apps/fuzzyclock/fuzzy_clock.star
@@ -1,3 +1,10 @@
+"""
+Applet: Fuzzy Clock
+Author: Max Timkovich
+Summary: Human readable time
+Description: Display the time in a groovy, human-readable way.
+"""
+
 load("encoding/json.star", "json")
 load("render.star", "render")
 load("schema.star", "schema")

--- a/apps/ifparank/ifparank.star
+++ b/apps/ifparank/ifparank.star
@@ -1,3 +1,10 @@
+"""
+Applet: IFPARank
+Author: cubsaaron
+Summary: Display IFPA Ranking
+Description: Display an International Flipper Pinball Association (IFPA) World Ranking.
+"""
+
 load("cache.star", "cache")
 load("encoding/base64.star", "base64")
 load("encoding/json.star", "json")

--- a/apps/manifest/testdata/source.star
+++ b/apps/manifest/testdata/source.star
@@ -1,3 +1,10 @@
+"""
+Applet:
+Summary:
+Description:
+Author:
+"""
+
 load("render.star", "render")
 
 def main():

--- a/apps/metar/metar.star
+++ b/apps/metar/metar.star
@@ -1,3 +1,12 @@
+"""
+Applet: METAR
+Author: Alexander Valys
+Summary: METAR aviation weather
+Description: Show METAR (aviation weather) text for one airport or flight
+    category (VFR/IFR/etc.) for up to 15 airports. Separate airport identifiers
+    by commas to display multiple airports.
+"""
+
 load("cache.star", "cache")
 load("http.star", "http")
 load("render.star", "render")

--- a/apps/mvv/mvv.star
+++ b/apps/mvv/mvv.star
@@ -1,6 +1,9 @@
-#
-# MVV departure times for Tidbyt.
-#
+"""
+Applet: MVV
+Author: Robin Sommer
+Summary: MVV departures (Munich)
+Description: Departure times for the Münchner Verkehrsverbund (MVV).
+"""
 
 load("cache.star", "cache")
 load("encoding/base64.star", "base64")

--- a/apps/outlookcalendar/outlook_calendar.star
+++ b/apps/outlookcalendar/outlook_calendar.star
@@ -1,3 +1,10 @@
+"""
+Applet: Outlook Calendar
+Author: Matt-Pesce
+Summary: Display Next Meeting
+Description: Shows the date, next meeting and time from your Outlook Calendar.
+"""
+
 load("cache.star", "cache")
 load("encoding/base64.star", "base64")
 load("encoding/json.star", "json")

--- a/apps/sbbtimetable/sbb_timetable.star
+++ b/apps/sbbtimetable/sbb_timetable.star
@@ -1,3 +1,11 @@
+"""
+Applet: SBB Timetable
+Author: LukiLeu
+Summary: SBB Timetable
+Description: Shows a timetable for a station in the Swiss Public Transport
+    network.
+"""
+
 load("cache.star", "cache")
 load("encoding/base64.star", "base64")
 load("encoding/json.star", "json")

--- a/apps/stepcounter/stepcounter.star
+++ b/apps/stepcounter/stepcounter.star
@@ -1,3 +1,11 @@
+"""
+Applet: Step Counter
+Author: Matt-Pesce
+Summary: Tracks Daily Step Progress
+Description: Fetches your Step Data from Google Fit, Reports progress versus
+    daily goal.
+"""
+
 load("cache.star", "cache")
 load("encoding/json.star", "json")
 load("http.star", "http")

--- a/apps/tempest/tempest.star
+++ b/apps/tempest/tempest.star
@@ -1,3 +1,10 @@
+"""
+Applet: Tempest Weather
+Author: Rohan Singh
+Summary: Tempest weather station
+Description: Show readings from your Tempest weather station.
+"""
+
 load("encoding/base64.star", "base64")
 load("encoding/json.star", "json")
 load("http.star", "http")

--- a/apps/testpatterns/test_patterns.star
+++ b/apps/testpatterns/test_patterns.star
@@ -1,3 +1,10 @@
+"""
+Applet: Test Patterns
+Author: harrisonpage
+Summary: Pretty test patterns
+Description: Test patterns are as old as TV broadcasts.
+"""
+
 load("random.star", "random")
 load("render.star", "render")
 

--- a/apps/theguardiannews/theguardiannews.star
+++ b/apps/theguardiannews/theguardiannews.star
@@ -1,3 +1,11 @@
+"""
+Applet: The Guardian News
+Author: jvivona
+Summary: Guardian News Headlines
+Description: Gets latest new articles from The Guardian and displays up to 3 articles
+    for selected edition.
+"""
+
 load("cache.star", "cache")
 load("encoding/json.star", "json")
 load("http.star", "http")


### PR DESCRIPTION
This commit adds a module docstring to the apps that don't have one by copying the information for the go source.