### PR TITLE
Fix no-effect warning.

### DIFF
--- a/apps/ctaltracker/cta_l_tracker.star
+++ b/apps/ctaltracker/cta_l_tracker.star
@@ -81,11 +81,10 @@ def get_schema():
         ],
     )
 
-"""
-Renders a given lists of arrivals
-"""
-
 def render_arrival_list(arrivals):
+    """
+    Renders a given lists of arrivals
+    """
     rendered = []
 
     if arrivals:
@@ -126,12 +125,11 @@ def render_arrival_list(arrivals):
         ],
     )
 
-"""
-Creates a Row and adds needed children objects
-for a single arrival
-"""
-
 def render_arrival_row(arrival):
+    """
+    Creates a Row and adds needed children objects
+    for a single arrival
+    """
     background_color = render.Box(width = 22, height = 11, color = arrival["color_hex"])
     destination_text = render.Marquee(
         width = 36,
@@ -160,12 +158,11 @@ def render_arrival_row(arrival):
         ],
     )
 
-"""
-Creates a Row and adds needed children objects
-for a single arrival.
-"""
-
 def get_selected_station_map_id(selected_station):
+    """
+    Creates a Row and adds needed children objects
+    for a single arrival.
+    """
     stations = get_stations()
     if not stations:
         return None
@@ -175,12 +172,12 @@ def get_selected_station_map_id(selected_station):
             return station["map_id"]
     fail("The stop selected was not matched to a formatted stop")
 
-"""
-Gets a list of "L" stations from API and
-eliminates duplicate stations
-"""
-
 def get_stations():
+    """
+    Gets a list of "L" stations from API and
+    eliminates duplicate stations
+    """
+
     cache_stations = cache.get(L_STOPS_CACHE_KEY)
     if cache_stations != None:
         return json.decode(cache_stations)
@@ -209,12 +206,11 @@ def get_stations():
     cache.set(L_STOPS_CACHE_KEY, json.encode(deduped_stations), ttl_seconds = 3600)
     return deduped_stations
 
-"""
-Formats list of "L" stations into options
-for dropdown
-"""
-
 def get_station_options(station_mapping):
+    """
+    Formats list of "L" stations into options
+    for dropdown
+    """
     if not station_mapping:
         return None
 
@@ -224,23 +220,21 @@ def get_station_options(station_mapping):
     ]
     return station_options
 
-"""
-Creates a dictionary for the passed in "L" station
-containing station name and id
-"""
-
 def build_station(station):
+    """
+    Creates a dictionary for the passed in "L" station
+    containing station name and id
+    """
     return {
         "station_descriptive_name": station["station_descriptive_name"],
         "map_id": station["map_id"],
     }
 
-"""
-Gets top 2 arrivals scheduled for the selected station
-from CTA Arrivals API
-"""
-
 def get_journeys(station_code):
+    """
+    Gets top 2 arrivals scheduled for the selected station
+    from CTA Arrivals API
+    """
     cache_arrivals = cache.get(ARRIVALS_CACHE_KEY)
     if cache_arrivals != None:
         return json.decode(cache_arrivals)
@@ -271,12 +265,11 @@ def get_journeys(station_code):
     cache.set(ARRIVALS_CACHE_KEY, json.encode(next_arrivals), ttl_seconds = 60)
     return next_arrivals
 
-"""
-Parses CTA Arrivals API response for fields that we
-are interested in
-"""
-
 def build_journey(prediction):
+    """
+    Parses CTA Arrivals API response for fields that we
+    are interested in
+    """
     destination_name = prediction["destNm"]
     line = prediction["rt"]
     color_hex = COLOR_MAP[line]

--- a/apps/njtransit/nj_transit.star
+++ b/apps/njtransit/nj_transit.star
@@ -57,11 +57,10 @@ def main(config):
         child = rendered_rows,
     )
 
-"""
-Renders a given lists of departures
-"""
-
 def render_departure_list(departures):
+    """
+    Renders a given lists of departures
+    """
     rendered = []
 
     for d in departures:
@@ -81,12 +80,11 @@ def render_departure_list(departures):
         ],
     )
 
-"""
-Creates a Row and adds needed children objects
-for a single departure.
-"""
-
 def render_departure_row(departure):
+    """
+    Creates a Row and adds needed children objects
+    for a single departure.
+    """
     background_color = render.Box(width = 22, height = 11, color = COLOR_MAP.get(departure.service_line, DEFAULT_COLOR))
     destination_text = render.Marquee(
         width = 36,
@@ -160,20 +158,19 @@ def get_schema():
         ],
     )
 
-"""
-Function gets all depatures for a given station
-returns a list of structs with the following fields
-
-depature_item struct:
-    departing_at: string
-    destination: string
-    service_line: string
-    train_number: string
-    track_number: string
-    departing_in: string
-"""
-
 def get_departures_for_station(station):
+    """
+    Function gets all depatures for a given station
+    returns a list of structs with the following fields
+
+    depature_item struct:
+        departing_at: string
+        destination: string
+        service_line: string
+        train_number: string
+        track_number: string
+        departing_in: string
+    """
     print("Getting departures for '%s'" % station)
 
     station_suffix = station.replace(" ", "%20")
@@ -204,11 +201,10 @@ def get_departures_for_station(station):
 
     return result
 
-"""
-Function Extracts necessary data from HTML of a given depature
-"""
-
 def extract_fields_from_departure(departure):
+    """
+    Function Extracts necessary data from HTML of a given depature
+    """
     data = departure.find(".media-body").first()
 
     departure_time = get_departure_time(data)
@@ -238,51 +234,46 @@ def extract_fields_from_departure(departure):
         departing_in = departing_in,
     )
 
-"""
-Function gets depature time for a given depature
-"""
-
 def get_departure_time(data):
+    """
+    Function gets depature time for a given depature
+    """
     time_string = data.find(".d-block.ff-secondary--bold.flex-grow-1.h2.mb-0").first().text().strip()
     return time_string
 
-"""
-Function gets the service line the train is running on
-"""
-
 def get_service_line(data):
+    """
+    Function gets the service line the train is running on
+    """
     nodes = data.find(".media-body").first().find(".mb-0")
     string = nodes.eq(1).text().strip().split()
     service_line = string[0].strip()
 
     return service_line
 
-"""
-Function gets the train number from a given depature
-"""
-
 def get_train_number(data):
+    """
+    Function gets the train number from a given depature
+    """
     nodes = data.find(".media-body").first().find(".mb-0")
     srvc_train_number = nodes.eq(1).text().strip().split()
     train_number = srvc_train_number[2].strip()
     return train_number
 
-"""
-Function gets the destation froma  given depature
-"""
-
 def get_destination_name(data):
+    """
+    Function gets the destation froma  given depature
+    """
     nodes = data.find(".media-body").first().find(".mb-0")
-    destination_name = nodes.eq(0).text().strip().replace("\u2708", "EWR").upper()
+    destination_name = nodes.eq(0).text().strip().replace("\\u2708", "EWR").upper()
     return destination_name
 
-"""
-Will attempt to get given departing time from nj transit
-If not availble will return the in X min via the scheduled
-Departure time - time.now()
-"""
-
 def get_real_time_estimated_departure(data, scheduled_time):
+    """
+    Will attempt to get given departing time from nj transit
+    If not availble will return the in X min via the scheduled
+    Departure time - time.now()
+    """
     nodes = data.find(".media-body").first().find(".mb-0")
     node = nodes.eq(2)
 
@@ -297,12 +288,11 @@ def get_real_time_estimated_departure(data, scheduled_time):
 
     return departing_in
 
-"""
-Returns the track number the train will be departing from.
-May not be availble until about 10 minutes before scheduled departure time.
-"""
-
 def get_track_number(data):
+    """
+    Returns the track number the train will be departing from.
+    May not be availble until about 10 minutes before scheduled departure time.
+    """
     node = data.find(".align-self-end.mb-0").first()
 
     if node != None:
@@ -316,12 +306,11 @@ def get_track_number(data):
 
     return track
 
-"""
-Function fetches trains station list from NJ Transit website
-To be used for creating Schema option list
-"""
-
 def fetch_stations_from_website():
+    """
+    Function fetches trains station list from NJ Transit website
+    To be used for creating Schema option list
+    """
     result = []
 
     nj_dv_page_response_body = cache.get(DEPARTURES_CACHE_KEY)
@@ -349,11 +338,10 @@ def fetch_stations_from_website():
 
     return result
 
-"""
-Creates a list of schema options from station list
-"""
-
 def getStationListOptions():
+    """
+    Creates a list of schema options from station list
+    """
     options = []
     cache_string = cache.get(STATION_CACHE_KEY)
 
@@ -371,11 +359,10 @@ def getStationListOptions():
 
     return options
 
-"""
-Helper function to create a schema option of a given display name and value
-"""
-
 def create_option(display_name, value):
+    """
+    Helper function to create a schema option of a given display name and value
+    """
     return schema.Option(
         display = display_name,
         value = value,

--- a/apps/pathtrainschedule/path_train_schedule.star
+++ b/apps/pathtrainschedule/path_train_schedule.star
@@ -239,20 +239,18 @@ def getAllStations():
     return stations
 
 # OPTIONS FOR USER
-"""
-def get_schema():
-    options = getAllStations()
-    return schema.Schema(
-        version = "1",
-        fields = [
-            schema.Dropdown(
-                id = "station",
-                name = "Station",
-                desc = "Station for arrival times.",
-                icon = "trainSubway",
-                default = options[0].value,
-                options = options,
-            ),
-        ],
-    )
-"""
+# def get_schema():
+#     options = getAllStations()
+#     return schema.Schema(
+#         version = "1",
+#         fields = [
+#             schema.Dropdown(
+#                 id = "station",
+#                 name = "Station",
+#                 desc = "Station for arrival times.",
+#                 icon = "trainSubway",
+#                 default = options[0].value,
+#                 options = options,
+#             ),
+#         ],
+#     )

--- a/apps/traffic/traffic.star
+++ b/apps/traffic/traffic.star
@@ -28,7 +28,7 @@ CACHE_TTL = {
 
 DEFAULT_FONT = "tb-8"
 COMPACT_FONT = "tom-thumb"
-"""The use of two fonts here means we won't have to Marquee the origin/destination labels until they are very long"""
+# The use of two fonts here means we won't have to Marquee the origin/destination labels until they are very long
 
 RATIO_COLORS = {
     0.0: "#090",
@@ -36,12 +36,10 @@ RATIO_COLORS = {
     1.4: "#F50",
     2.0: "#900",
 }
-"""
-When we are able to get both typical travel times, and a time including traffic, we can calculate the ratio and change
-the color of the duration text based on how much higher it is. We can safely assume that it will never be lower than 1,
-We change from green to white when the time is 20% higher, white to yellow if it exceeds +70%, and finally we'll display
-the time in red if we estimate the trip will be twice as long as it would be without traffic.
-"""
+# When we are able to get both typical travel times, and a time including traffic, we can calculate the ratio and change
+# the color of the duration text based on how much higher it is. We can safely assume that it will never be lower than 1,
+# We change from green to white when the time is 20% higher, white to yellow if it exceeds +70%, and finally we'll display
+# the time in red if we estimate the trip will be twice as long as it would be without traffic.
 
 SAMPLE_DATA = {
     "coordinates": {

--- a/apps/transsee/transsee.star
+++ b/apps/transsee/transsee.star
@@ -11,7 +11,7 @@ load("schema.star", "schema")
 
 def main(config):
     if config.str("id") == None:
-        """ Show example image by default when no TransSee Premium Id entered """
+        # Show example image by default when no TransSee Premium Id entered
         return render.Root(render.Column(children = [
             render.Row(children = [
                 render.Box(width = 17, height = 8, color = "#6CBE45", child = render.Text(content = "B54", color = "#FFFFFF")),
@@ -39,7 +39,7 @@ def main(config):
 
             return render.Root(render.Column(children = col))
         else:
-            """ Return [] to remove from cycle when no stops activated """
+            # Return [] to remove from cycle when no stops activated
             return []
 
 def get_schema():


### PR DESCRIPTION
This warning, in the community repo, mostly complained about "doc strings" having no effect. I moved all doc strings or converted the comment type to satisfy this check. The warning is useful in the general case though, since it identifies unused variables.