### PR TITLE
Fix ethstaker lint warning.

### DIFF
--- a/apps/ethstaker/ethstaker.star
+++ b/apps/ethstaker/ethstaker.star
@@ -75,7 +75,7 @@ def main(config):
         )
 
 def header_status(statuses):
-    status_counts = count_list_by(statuses, lambda status: status)
+    status_counts = count_list_by(statuses, lambda statuses: statuses)
     sorted_status_keys = sorted(status_counts.keys(), reverse = True, key = status_score)
     status = sorted_status_keys[0]
 


### PR DESCRIPTION
This commit resolves our last lint waring for status being undefined. I am not sure the intent here, and looking through the rest of the source code was no help. I presume this method already was erroring given this was not defined. My fix satisfies the linter but it likely does not resolve the logic error in this mehthod. cc @ColinCampbell 