### PR TITLE
New App: Discord Members Count

### DIFF
--- a/apps/apps.go
+++ b/apps/apps.go
@@ -56,6 +56,7 @@ import (
 	"tidbyt.dev/community/apps/destiny2stats"
 	"tidbyt.dev/community/apps/digibyteprice"
 	"tidbyt.dev/community/apps/digitalrain"
+	"tidbyt.dev/community/apps/discordmembers"
 	"tidbyt.dev/community/apps/duolingo"
 	"tidbyt.dev/community/apps/dutchfuzzyclock"
 	"tidbyt.dev/community/apps/dvdlogo"
@@ -315,6 +316,7 @@ func GetManifests() []manifest.Manifest {
 		destiny2stats.New(),
 		digibyteprice.New(),
 		digitalrain.New(),
+		discordmembers.New(),
 		duolingo.New(),
 		dutchfuzzyclock.New(),
 		dvdlogo.New(),

--- a/apps/discordmembers/discordmembers.go
+++ b/apps/discordmembers/discordmembers.go
@@ -1,0 +1,25 @@
+// Package discordmembers provides details for the Discord Members applet.
+package discordmembers
+
+import (
+	_ "embed"
+
+	"tidbyt.dev/community/apps/manifest"
+)
+
+//go:embed discord_members.star
+var source []byte
+
+// New creates a new instance of the Discord Members applet.
+func New() manifest.Manifest {
+	return manifest.Manifest{
+		ID:          "discordmembers",
+		Name:        "Discord Members",
+		Author:      "Dennis Zoma (https://zoma.dev)",
+		Summary:     "Discord Members Count",
+		Desc:        "Display the approximate member count for a given Discord server (via Invite ID).",
+		FileName:    "discord_members.star",
+		PackageName: "discordmembers",
+		Source:  source,
+	}
+}

--- a/apps/discordmembers/discordmembers.go
+++ b/apps/discordmembers/discordmembers.go
@@ -7,7 +7,7 @@ import (
 	"tidbyt.dev/community/apps/manifest"
 )
 
-//go:embed discord_members.star
+//go:embed discordmembers.star
 var source []byte
 
 // New creates a new instance of the Discord Members applet.
@@ -18,7 +18,7 @@ func New() manifest.Manifest {
 		Author:      "Dennis Zoma (https://zoma.dev)",
 		Summary:     "Discord Members Count",
 		Desc:        "Display the approximate member count for a given Discord server (via Invite ID).",
-		FileName:    "discord_members.star",
+		FileName:    "discordmembers.star",
 		PackageName: "discordmembers",
 		Source:  source,
 	}

--- a/apps/discordmembers/discordmembers.star
+++ b/apps/discordmembers/discordmembers.star
@@ -1,0 +1,89 @@
+"""
+Applet: Discord Members
+Summary: Discord Members Count
+Description: Display the approximate member count for a given Discord server (via Invite ID).
+Author: Dennis Zoma (https://zoma.dev)
+"""
+
+load("render.star", "render")
+load("schema.star", "schema")
+load("http.star", "http")
+load("encoding/base64.star", "base64")
+load("cache.star", "cache")
+load("humanize.star", "humanize")
+
+DISCORD_API_URL = "https://discord.com/api/v9/invites/%s?with_counts=true"
+
+TWITTER_ICON = base64.decode("""
+iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAEqADAAQAAAABAAAAEgAAAACaqbJVAAAC1ElEQVQ4Ec1Tz4vNURQ/59z7/b433pvhMUjIjwhZIJGMxSSxwqSepiSKbKysKKW3VHZWkiSTjbdRFhZCSlYiCbuJMmg05pdmvt/vu/cen/vG+JE/gLP43vv93HM+95zPOZfofzOeTajRUHn9YXyFqNlLwgfV0YDJKvcnk5FSZ2tBnlVGFpY4vRjUD5pQuv3Njr28e3XJNBFr5GgT9TbULv44eoLUXmLihEhTVZpiVq+qwthoUGLhKkK8cFqo+nuifObWtTkfIpHEz+KhydVM6Xlh0wmScsQRG4PmMgsw7mKRLqzRPwlaVCQp9eXaOlCvq4kc0turNgQ9YjhZhlsi9sN+Vj0L/LGqy20i5nRHLVsaD2TJ1k/zRPgobmlHIgMypkQiKY5/kTEb4GXgqBwGrUhseX3m8h3UaIi4iepOYbsKWlAkgRiZ9/nT4Iu38EeKM2TI9qv32WPgg5E0moZCwNzf++5YKgjdp2hRO4AN6PSxz4vDPrhTcEVQJOIsqF7OWr4PDueVwngki1IIU08tJBWs3BPZY0AIhcf/o+bN7qHm9flP0NfXIMapfsu9u37nRm2sSKYfwnEwlhirgDqLrKnuEeyXR6IIWlMSDWFH/K+fyNZgQtbxTGMrZbGHIm5deZMyr56pIiIBWnEf95+cyCFDVLatEUScQlbPcRdaTxtI2eKaeDyM5Q3mD10yayPBrCGHzxb1opz2OCFjH6cuTdLqNvXOQnTBeVs+4aQb3eyBLsG5qQi2g9AgTA8NWWyugOgU1rInX6AVD4ps4iVU3IIbNzJpTT3ngVvvQ3DP4DuKjI5geJfDp/Cu9cJQcYHr9eGq1NKdpHIOAm73oTWmTP1Ena8sTSZWWCx0zZ13gX2VXHoW83TcuekvEuSqMdM38tHu4dkh4f0HPnV0Leza5UVX+vHqQLPJeJB/W/3k2FZDsjmxnXez3TTSPMy/P4e/A/4Z8h28+06zjQXyTQAAAABJRU5ErkJggg==
+""")
+
+def main(config):
+    invite_id = config.get("invite_id", "r45MXG4kZc")
+
+    cache_key_members_count = "discord_members_%s" % invite_id
+    formatted_members_count = cache.get(cache_key_members_count)
+
+    cache_key_server_name = "discord_server_%s" % invite_id
+    server_name = cache.get(cache_key_server_name)
+
+    if formatted_members_count == None or server_name == None:
+        url = DISCORD_API_URL % invite_id
+        response = http.get(url)
+
+        if response.status_code != 200:
+            fail("Discord request failed with status %d", response.status_code)
+
+        body = response.json()
+
+        if body == None or len(body) == 0 or body["guild"] == None or len(body["guild"]) == 0:
+            formatted_members_count = "Not Found"
+            server_name = "Check your invite ID"
+        else:
+            formatted_members_count = "%s members" % humanize.comma(int(body["approximate_member_count"]))
+            server_name = body["guild"]["name"]
+            cache.set(cache_key_members_count, formatted_members_count, ttl_seconds = 240)
+            cache.set(cache_key_server_name, server_name, ttl_seconds = 240)
+
+    return render.Root(
+        child = render.Box(
+            render.Column(
+                expanded = True,
+                main_align = "space_evenly",
+                cross_align = "center",
+                children = [
+                    render.Row(
+                        expanded = True,
+                        main_align = "space_evenly",
+                        cross_align = "center",
+                        children = [
+                            render.Image(TWITTER_ICON),
+                            render.WrappedText(formatted_members_count),
+                        ],
+                    ),
+                    render.Marquee(
+                        width = 64,
+                        align = "center",
+                        offset_start = 10,
+                        child = render.Text(
+                            color = "#3c3c3c",
+                            content = server_name,
+                        ),
+                    ),
+                ],
+            ),
+        ),
+    )
+
+def get_schema():
+    return schema.Schema(
+        version = "1",
+        fields = [
+            schema.Text(
+                id = "invite_id",
+                name = "Invite ID",
+                icon = "userPlus",
+                desc = "Valid Discord Server Invite ID (Important: Set expiration to infinite)",
+            ),
+        ],
+    )


### PR DESCRIPTION
Adds a new app that displays the members count of a Discord Server. This is done by fetching an invite URL that contains an approximate members count. Therefore, a valid invite ID must be supplied as an input variable.

The app's layout and structure are inspired by the `twitterfollows` example.

**Example Render:**
![discordmembers](https://user-images.githubusercontent.com/3930150/212485234-6b1e9f21-deba-447b-9c1c-0a663cf6fa6c.gif)
