### PR TITLE
New App: Stripe Sales

### DIFF
--- a/apps/apps.go
+++ b/apps/apps.go
@@ -211,6 +211,7 @@ import (
 	"tidbyt.dev/community/apps/stepcounter"
 	"tidbyt.dev/community/apps/stockticker"
 	"tidbyt.dev/community/apps/strava"
+	"tidbyt.dev/community/apps/stripesales"
 	"tidbyt.dev/community/apps/subreddit"
 	"tidbyt.dev/community/apps/sunrisesunset"
 	"tidbyt.dev/community/apps/supermariokart"
@@ -469,6 +470,7 @@ func GetManifests() []manifest.Manifest {
 		stepcounter.New(),
 		stockticker.New(),
 		strava.New(),
+		stripesales.New(),
 		subreddit.New(),
 		sunrisesunset.New(),
 		supermariokart.New(),

--- a/apps/stripesales/README.md
+++ b/apps/stripesales/README.md
@@ -1,0 +1,3 @@
+# Stripe Sales App for Tidbyt
+
+This app displays the total sum and count of the sales you've made on Stripe today.

--- a/apps/stripesales/stripe_sales.star
+++ b/apps/stripesales/stripe_sales.star
@@ -1,0 +1,123 @@
+load("render.star", "render")
+load("http.star", "http")
+load("humanize.star", "humanize")
+load("cache.star", "cache")
+load("time.star", "time")
+load("schema.star", "schema")
+load("encoding/json.star", "json")
+
+BACKGROUND_COLOR = "#638475"
+ERROR_BACKGROUND_COLOR = "#540B0E"
+API_KEY = "api_key"
+
+def render_error_message(message):
+    return render.Root(
+        render.Box(
+            color = ERROR_BACKGROUND_COLOR,
+            child = render.Column(children = [
+                render.Text(content = "Error", font = "6x13"),
+                render.Marquee(child = render.Text(content = message), align = "center", width = 50),
+            ]),
+        ),
+    )
+
+def render_sales(count, total):
+    return render.Root(
+        render.Box(
+            color = BACKGROUND_COLOR,
+            child = render.Column(children = [
+                render.Text(content = "Sales Today", color = "#FFFECB"),
+                render.Text(content = total, font = "6x13"),
+                render.Text(content = "{} orders".format(count)),
+            ]),
+        ),
+    )
+
+def get_beginning_of_today():
+    now = time.now()
+
+    year = now.year
+    month = now.month
+    day = now.day
+
+    return time.time(year = year, month = month, day = day, hour = 0)
+
+def get_total(charges):
+    total = 0
+
+    for charge in charges:
+        total = total + charge["amount"]
+
+    return total // 100
+
+def stripe_api(endpoint, params, api_key):
+    url = "https://api.stripe.com/v1/{}".format(endpoint)
+
+    headers = {"Content-Type": "application/json", "Authorization": "Bearer {}".format(api_key)}
+
+    response = http.get(url = url, headers = headers, params = params)
+
+    return response.json()
+
+def get_charges(api_key):
+    beginning_of_today = get_beginning_of_today().unix
+
+    query = "status:\"succeeded\" AND created >= {}".format(beginning_of_today)
+
+    res = stripe_api(endpoint = "charges/search", params = {"limit": "100", "query": query}, api_key = api_key)
+
+    return res
+
+def get_sales(api_key):
+    res = get_charges(api_key)
+
+    data = res.get("data")
+
+    if data != None:
+        total = get_total(data)
+        return {"total": "$" + humanize.comma(total), "count": len(data)}
+
+    return {"error": res["error"]["message"]}
+
+def get_content(api_key):
+    content = cache.get(api_key)
+
+    if content == None:
+        response = get_sales(api_key)
+        cache.set(api_key, json.encode(response), ttl_seconds = 300)
+        content = response
+    else:
+        content = json.decode(content)
+
+    return content
+
+def main(config):
+    api_key = config.get(API_KEY)
+
+    if api_key == None:
+        return render_error_message("API Key required.")
+
+    content = get_content(api_key)
+
+    error = content.get("error")
+
+    if error:
+        return render_error_message(error)
+
+    total = content.get("total")
+    count = content.get("count")
+
+    return render_sales(count = count, total = total)
+
+def get_schema():
+    return schema.Schema(
+        version = "1",
+        fields = [
+            schema.Text(
+                id = API_KEY,
+                name = "API Key",
+                desc = "Your Stripe secret key",
+                icon = "user",
+            ),
+        ],
+    )

--- a/apps/stripesales/stripesales.go
+++ b/apps/stripesales/stripesales.go
@@ -1,0 +1,25 @@
+// Package stripesales provides details for the Stripe Sales applet.
+package stripesales
+
+import (
+	_ "embed"
+
+	"tidbyt.dev/community/apps/manifest"
+)
+
+//go:embed stripe_sales.star
+var source []byte
+
+// New creates a new instance of the Stripe Sales applet.
+func New() manifest.Manifest {
+	return manifest.Manifest{
+		ID:          "stripe-sales",
+		Name:        "Stripe Sales",
+		Author:      "Jon Bilous",
+		Summary:     "Shows your Stripe sales",
+		Desc:        "Shows the order count and total sum of sales you've made today on Stripe.",
+		FileName:    "stripe_sales.star",
+		PackageName: "stripesales",
+		Source:      source,
+	}
+}


### PR DESCRIPTION
This app does one simple thing: displays a user's Stripe sales made so far today. 

![stripe_sales](https://user-images.githubusercontent.com/59451908/212954737-55ff3dae-cd07-4a41-b930-264c25cc74b8.gif)

It only requires a user to provide a Stripe API Key, and all of the requests to the Stripe API are made directly, not through any external proxy. 