### PR TITLE
fix: Set max_age for clocks.

### DIFF
--- a/apps/analogclock/analog_clock.star
+++ b/apps/analogclock/analog_clock.star
@@ -356,6 +356,7 @@ def main(config):
     month = now.format("Jan").upper()
 
     return render.Root(
+        max_age = 120,
         child = render.Row(
             main_align = "center",
             cross_align = "center",

--- a/apps/analogtime/analog_time.star
+++ b/apps/analogtime/analog_time.star
@@ -91,6 +91,7 @@ def main(config):
 
     return render.Root(
         #delay=100, #speed up scroll text
+        max_age = 120,
         child = render.Stack(children = plot_marks),
     )
 

--- a/apps/bigclock/big_clock.star
+++ b/apps/bigclock/big_clock.star
@@ -193,6 +193,7 @@ def main(config):
 
     return render.Root(
         delay = 500,  # in milliseconds
+        max_age = 120,
         child = render.Box(
             child = render.Animation(
                 children = frames,

--- a/apps/binaryclock/binary_clock.star
+++ b/apps/binaryclock/binary_clock.star
@@ -171,6 +171,7 @@ def main(config):
     # Return the clock
     return render.Root(
         delay = 1000,
+        max_age = 120,
         child = render.Box(
             child = render.Animation(
                 children = clock_frames,

--- a/apps/clockbyhenry/clock_by_henry.star
+++ b/apps/clockbyhenry/clock_by_henry.star
@@ -130,6 +130,7 @@ def main(config):
     # generate the widget for the app
     return render.Root(
         delay = 1000,
+        max_age = 120,
         child = render.Column(
             main_align = "center",
             expanded = True,

--- a/apps/colorfulclock/colorful_clock.star
+++ b/apps/colorfulclock/colorful_clock.star
@@ -140,6 +140,7 @@ def main(config):
     # Return the clock
     return render.Root(
         delay = 1000,
+        max_age = 120,
         child = render.Box(
             child = render.Animation(
                 children = clock_frames,

--- a/apps/countupclock/countupclock.star
+++ b/apps/countupclock/countupclock.star
@@ -55,6 +55,7 @@ coloropt = [
 def main(config):
     return render.Root(
         delay = 100,
+        max_age = 120,
         child = render.Column(
             expanded = True,
             main_align = "center",

--- a/apps/datetimeclock/date_time_clock.star
+++ b/apps/datetimeclock/date_time_clock.star
@@ -46,6 +46,7 @@ def main(config):
 
     return render.Root(
         delay = 500,
+        max_age = 120,
         child = render.Column(
             expanded = True,
             cross_align = "center",

--- a/apps/fullybinarytime/fullybinarytime.star
+++ b/apps/fullybinarytime/fullybinarytime.star
@@ -144,6 +144,7 @@ def main(config):
     # The smallest bit shown corresponds to a period of ~1.3 seconds, so we should update
     # the screen while the app is showing.
     return render.Root(
+        max_age = 120,
         delay = REFRESH_MILLISECONDS,
         child = make_animation(timezone),
     )

--- a/apps/hexcolorclock/hex_color_clock.star
+++ b/apps/hexcolorclock/hex_color_clock.star
@@ -84,6 +84,7 @@ def main(config):
 
     return render.Root(
         delay = delay,
+        max_age = 120,
         child = render.Animation(
             children = frames,
         ),

--- a/apps/nixelclock/nixel_clock.star
+++ b/apps/nixelclock/nixel_clock.star
@@ -291,6 +291,7 @@ def main(config):
 
     return render.Root(
         delay = 500,  # in milliseconds
+        max_age = 120,
         child = render.Box(
             child = render.Animation(
                 children = frames,

--- a/apps/worldclock/world_clock.star
+++ b/apps/worldclock/world_clock.star
@@ -155,6 +155,7 @@ def main(config):
 
     return render.Root(
         delay = 500,
+        max_age = 120,
         child = render.Column(
             children = rows,
             main_align = "space_around",


### PR DESCRIPTION
By default, the Tidbyt will display stale images it recieves near idefinitely if it cannot get an update from our backend. In almost all cases, this is the desired behavior. The weather isn't going to change much within a 10 minute time frame. However, a 10 minute stale clock would be incredibly frustrating. We implemented a mitigation for our clock some time ago that sets the max age to two minutes for the clock, ensuring the most stale clock image the device would show would be no greater then 2 minutes. However, we never rolled out that change to all clocks. This commit updates all clocks in the community repo to not be displayed if they are stale.