### PR TITLE
Revised “till” to the more accepted spelling

### DIFF
--- a/apps/fuzzyclock/fuzzy_clock.star
+++ b/apps/fuzzyclock/fuzzy_clock.star
@@ -59,7 +59,7 @@ def fuzzy_time(config, hours, minutes):
     if up:
         hours += 1
 
-        glue = "TIL" if config.get("dialect") == "american" else "TO"
+        glue = "TILL" if config.get("dialect") == "american" else "TO"
 
     # Handle 24 hour time.
     if hours > 12:
@@ -70,7 +70,7 @@ def fuzzy_time(config, hours, minutes):
         hours = 12
 
     if rounded == 0:
-        return [words[hours], "O'CLOCK"]
+        return [words[hours], "O’CLOCK"]
 
     return [words[rounded], glue, words[hours]]
 


### PR DESCRIPTION
The word “till” is the more accepted spelling of what had been written as “til” here. “Till” is a word of its own (it’s not an abbreviation of “until”) and “till” even predates the word “until.” https://www.merriam-webster.com/words-at-play/should-you-use-until-or-till-or-til

This proposed change also changes a straight quote mark to a curly quote mark in the word “o’clock”.