### PR TITLE
New Apps: Fixed Cache key

### DIFF
--- a/apps/newapps/new_apps.star
+++ b/apps/newapps/new_apps.star
@@ -42,7 +42,7 @@ def main(config):
         print("Miss! Refreshing current app list data.")
         current_list = get_apps()
         if current_list != None:
-            cache.set("new_apps", json.encode(current_list), ttl_seconds = 1800)  #refresh current list every 30 minutes
+            cache.set("current_apps", json.encode(current_list), ttl_seconds = 1800)  #refresh current list every 30 minutes
 
     #get final frame
     if old_list == None or current_list == None:


### PR DESCRIPTION
Accidentally was setting the cache key of new apps differently than the key I was trying to get, so it was constantly hitting the tidbyt api. This app will not display anything until new apps are merged. It seemed to be working yesterday, so we'll see if this works. I think the logic on line 37 should be right (we want it to update a current list if it just got a new old list).