### PR TITLE
Nightscout: Enable Display In mmol/L

### DIFF
--- a/apps/nightscout/nightscout.star
+++ b/apps/nightscout/nightscout.star
@@ -23,7 +23,7 @@ COLOR_GREEN = "#2b3"
 COLOR_GREY = "#777"
 COLOR_WHITE = "#fff"
 COLOR_NIGHT = "#444"
-COLOR_HOURS = "#222"
+COLOR_HOURS = "#111"
 
 DEFAULT_SHOW_MMOL = False
 DEFAULT_NORMAL_HIGH = 180
@@ -632,8 +632,8 @@ def get_schema():
             ),
             schema.Toggle(
                 id = "show_mmol",
-                name = "Display mmol",
-                desc = "Display readings and delta as mmol (Settings values should remain mg/dL)",
+                name = "Display mmol/L",
+                desc = "Display readings and delta as mmol/L (Settings values should remain mg/dL)",
                 icon = "gear",
                 default = False,
             ),

--- a/apps/nightscout/nightscout.star
+++ b/apps/nightscout/nightscout.star
@@ -106,18 +106,18 @@ def main(config):
         return display_failure("Nightscout Error: " + str(status_code))
 
     # Pull the data from the cache
-    sgv_current = int(nightscout_data_json["sgv_current"])
-    sgv_delta = int(nightscout_data_json["sgv_delta"])
+    sgv_current_mgdl = int(nightscout_data_json["sgv_current"])
+    sgv_delta_mgdl = int(nightscout_data_json["sgv_delta"])
     latest_reading_dt = time.parse_time(nightscout_data_json["latest_reading_date_string"])
     direction = nightscout_data_json["direction"]
     history = nightscout_data_json["history"]
     
-    #sgv_delta = 40
-    #sgv_current = 420
+    #sgv_delta_mgdl = 10
+    #sgv_current_mgdl = 106
     print ("show_mmol:" + show_mmol)
     if show_mmol=="true":
-        sgv_current = mgdl_to_mmol(sgv_current)
-        sgv_delta = mgdl_to_mmol(sgv_delta)
+        sgv_current = mgdl_to_mmol(sgv_current_mgdl)
+        sgv_delta = mgdl_to_mmol(sgv_delta_mgdl)
         
         #str_current = force_decimal_places(sgv_current, 1)
         str_current = str(sgv_current)
@@ -130,10 +130,10 @@ def main(config):
         left_col_width = 26
         graph_width = 37
     else:
-        str_current = str(int(sgv_current))
+        str_current = str(int(sgv_current_mgdl))
         # Delta
-        str_delta = str(sgv_delta)
-        if (sgv_delta >= 0):
+        str_delta = str(sgv_delta_mgdl)
+        if (sgv_delta_mgdl >= 0):
             str_delta = "+" + str_delta
         
         left_col_width = 26
@@ -183,12 +183,12 @@ def main(config):
         str_delta = "old"
         ago_dashes = ">" + str(reading_mins_ago)
         full_ago_dashes = human_reading_ago
-    elif (sgv_current <= normal_high and sgv_current >= normal_low):
+    elif (sgv_current_mgdl <= normal_high and sgv_current_mgdl >= normal_low):
         # We're in the normal range, so use green.
         color_reading = COLOR_GREEN
         color_delta = COLOR_GREEN
         color_arrow = COLOR_GREEN
-    elif (sgv_current >= urgent_high or sgv_current <= urgent_low):
+    elif (sgv_current_mgdl >= urgent_high or sgv_current_mgdl <= urgent_low):
         # We're in the urgent range, so use red.
         color_reading = COLOR_RED
         color_delta = COLOR_RED
@@ -767,7 +767,7 @@ def get_nightscout_data(nightscout_id, nightscout_host):
     return nightscout_data, resp.status_code
 
 def mgdl_to_mmol(mgdl):
-    mmol = float(int((mgdl/18) * 10)/10)
+    mmol = float(math.round((mgdl/18) * 10)/10)
     return mmol
     
 def display_failure(msg):

--- a/apps/nightscout/nightscout.star
+++ b/apps/nightscout/nightscout.star
@@ -507,7 +507,7 @@ def main(config):
                                 render.Row(
                                     children = [
                                         render.Text(
-                                            content = str_delta,
+                                            content = str_delta + " ",
                                             font = "tb-8",
                                             color = color_delta,
                                             offset = 1,


### PR DESCRIPTION
Added support for non-US users to display blood sugar readings as mmol/DL.
As a result, graph display was shortened to 3 hours and minor layout/font changes were made to accommodate.