### PR TITLE
build: Add git reference printing.

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v3
@@ -18,6 +20,13 @@ jobs:
 
       - name: Setup build agent
         run: ./.github/scripts/setup.sh
+
+      - name: Determine targets
+        id: targets
+        run: |
+          git show-ref
+          echo ${GITHUB_BASE_REF}
+          echo ${GITHUB_HEAD_REF}
 
       - name: Check all apps
         run: pixlet check -r ./


### PR DESCRIPTION
I'm working to add target determination so we only build what's changed on pull requests. In order to do that, I need to know what references are available on PRs. It's especially confusing because I need to know what the build system sees on forks. This commit adds a reference printing so I can see what PRs have available today.