### PR TITLE
build: Add printenv.

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -25,8 +25,7 @@ jobs:
         id: targets
         run: |
           git show-ref
-          echo ${GITHUB_BASE_REF}
-          echo ${GITHUB_HEAD_REF}
+          printenv
 
       - name: Check all apps
         run: pixlet check -r ./


### PR DESCRIPTION
This commit adds printenv so that I can see what environment variables exist in the builds we have today.