### PR TITLE
build: Add target determination output

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -24,8 +24,9 @@ jobs:
       - name: Determine targets
         id: targets
         run: |
-          git show-ref
-          printenv
+          OLD_COMMIT=$(git rev-list --parents -n 1 ${GITHUB_SHA} | cut -d " " -f 2)
+          NEW_COMMIT=$(git rev-list --parents -n 1 ${GITHUB_SHA} | cut -d " " -f 3)
+          pixlet community target-determinator --old ${OLD_COMMIT} --new ${NEW_COMMIT}
 
       - name: Check all apps
         run: pixlet check -r ./

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -3,7 +3,7 @@ name: Build and Test
 on:
   pull_request:
     branches:
-      - "*"
+      - "**"
 
 jobs:
   check:


### PR DESCRIPTION
# Overview
This change adds target determination output without consuming it. The GitHub Action for checkout uses a merge commit for `pull_request` events - which means getting the old/new commit to pixlet means we need to determine the parents of the commit sha that triggered the run.

# Changes
- [build: Fix branch name matching.](https://github.com/tidbyt/community/commit/5ff0d63243a9d2ba023cc0782fa28613206148e0) 
    - This commit resolves an issue where a PR to a PR wouldn't trigger the build due to there being a forward slash in the target branch name.
- [build: Add target determination output.](https://github.com/tidbyt/community/commit/dfb29c959d4323723ebefe1031045a921d84e37c) 
    - This commit adds target determination output. The checkout action from github uses a merge commit. This change ensures we get the parents from the merge commit to use as the old/new inputs to pixlet.
    
# Tests
I created a PR with changes to Zapier and ensured the output contained `apps/zapier/`. I made a branch from there and changed Yule Log, and opened a PR to my Zapier branch and ensured it _only_ printed `apps/yulelog/`