### PR TITLE
build: Use target determination

### DIFF
--- a/.github/scripts/check-apps.sh
+++ b/.github/scripts/check-apps.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+# Check apps.
+if [ ! -z "${TARGETS}" ]; then
+    pixlet check -r ${TARGETS}
+else
+    echo "✔️ No apps modified"
+fi

--- a/.github/scripts/determine-targets.sh
+++ b/.github/scripts/determine-targets.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+# Determine targets.
+OLD_COMMIT=$(git rev-list --parents -n 1 ${GITHUB_SHA} | cut -d " " -f 2)
+echo "OLD_COMMIT=${OLD_COMMIT}"
+
+NEW_COMMIT=$(git rev-list --parents -n 1 ${GITHUB_SHA} | cut -d " " -f 3)
+echo "NEW_COMMIT=${NEW_COMMIT}"
+
+TARGETS="$(pixlet community target-determinator --old ${OLD_COMMIT} --new ${NEW_COMMIT})"
+
+# Convert new lines to spaces. Maybe Pixlet should do this?
+TARGETS="$(echo "${TARGETS}" | tr "\n" " ")"
+echo "${TARGETS}"
+
+# Record output to GitHub variable.
+echo "targets=${TARGETS}" >> ${GITHUB_OUTPUT}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -26,10 +26,13 @@ jobs:
         run: |
           OLD_COMMIT=$(git rev-list --parents -n 1 ${GITHUB_SHA} | cut -d " " -f 2)
           NEW_COMMIT=$(git rev-list --parents -n 1 ${GITHUB_SHA} | cut -d " " -f 3)
-          pixlet community target-determinator --old ${OLD_COMMIT} --new ${NEW_COMMIT}
+          TARGETS=$(pixlet community target-determinator --old ${OLD_COMMIT} --new ${NEW_COMMIT})
+          echo ${TARGETS}
+          echo "targets=${TARGETS}" >> ${GITHUB_OUTPUT}
 
-      - name: Check all apps
-        run: pixlet check -r ./
+      - name: Check modified apps
+        run: |
+          [ ! -z "${{ steps.targets.outputs.targets }}" ] && pixlet check -r ${{ steps.targets.outputs.targets }} || echo "✔️ No apps modified "
 
       - name: Sanity check go embed
         run: go test tidbyt.dev/community/apps

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -23,16 +23,12 @@ jobs:
 
       - name: Determine targets
         id: targets
-        run: |
-          OLD_COMMIT=$(git rev-list --parents -n 1 ${GITHUB_SHA} | cut -d " " -f 2)
-          NEW_COMMIT=$(git rev-list --parents -n 1 ${GITHUB_SHA} | cut -d " " -f 3)
-          TARGETS=$(pixlet community target-determinator --old ${OLD_COMMIT} --new ${NEW_COMMIT})
-          echo ${TARGETS}
-          echo "targets=${TARGETS}" >> ${GITHUB_OUTPUT}
+        run: ./.github/scripts/determine-targets.sh
 
       - name: Check modified apps
-        run: |
-          [ ! -z "${{ steps.targets.outputs.targets }}" ] && pixlet check -r ${{ steps.targets.outputs.targets }} || echo "✔️ No apps modified "
+        run: ./.github/scripts/check-apps.sh
+        env:
+          TARGETS: "${{ steps.targets.outputs.targets }}"
 
       - name: Sanity check go embed
         run: go test tidbyt.dev/community/apps


### PR DESCRIPTION
# Overview
This change updates the build to only build the differential to the merge commit. This means we no longer have to test all apps 🎉 . I'm going to follow up with more changes so that we no longer are using the merge commit and instead are using the HEAD of the branch, which would allow us to only build what's being modified in the pull request.

# Changes
- [build: Utilize targets in pixlet check.](https://github.com/tidbyt/community/pull/1085/commits/f8f286b7dd6fd7cd373c63ed33dabf9c0e938401) 
[f8f286b](https://github.com/tidbyt/community/pull/1085/commits/f8f286b7dd6fd7cd373c63ed33dabf9c0e938401)
    - This commit uses the output from the target determination step in pixlet check.
- [Move to shell scripts](https://github.com/tidbyt/community/pull/1085/commits/6e85f1986c7a124c7e158fbe20e84bca235a4406)
