### PR TITLE
build: Use pull request head on checkout.

### DIFF
--- a/.github/scripts/check-apps.sh
+++ b/.github/scripts/check-apps.sh
@@ -2,8 +2,12 @@
 
 set -e
 
+# Trim quotes in case any were introduced.
+TARGETS=$(echo ${TARGETS} | tr -d '"' | awk '{$1=$1};1')
+
 # Check apps.
 if [ ! -z "${TARGETS}" ]; then
+    echo "$ pixlet check -r ${TARGETS}"
     pixlet check -r ${TARGETS}
 else
     echo "✔️ No apps modified"

--- a/.github/scripts/determine-targets.sh
+++ b/.github/scripts/determine-targets.sh
@@ -2,13 +2,14 @@
 
 set -e
 
+# Determine base commit.
+echo "GITHUB_BASE_REF=${GITHUB_BASE_REF}"
+echo "GITHUB_HEAD_REF=${GITHUB_HEAD_REF}"
+OLD_COMMIT=$(git merge-base remotes/origin/${GITHUB_HEAD_REF} remotes/origin/${GITHUB_BASE_REF})
+
 # Determine targets.
-OLD_COMMIT=$(git rev-list --parents -n 1 ${GITHUB_SHA} | cut -d " " -f 2)
 echo "OLD_COMMIT=${OLD_COMMIT}"
-
-NEW_COMMIT=$(git rev-list --parents -n 1 ${GITHUB_SHA} | cut -d " " -f 3)
 echo "NEW_COMMIT=${NEW_COMMIT}"
-
 TARGETS="$(pixlet community target-determinator --old ${OLD_COMMIT} --new ${NEW_COMMIT})"
 
 # Convert new lines to spaces. Maybe Pixlet should do this?
@@ -16,4 +17,4 @@ TARGETS="$(echo "${TARGETS}" | tr "\n" " ")"
 echo "${TARGETS}"
 
 # Record output to GitHub variable.
-echo "targets=${TARGETS}" >> ${GITHUB_OUTPUT}
+printf 'targets="%s"' "${TARGETS}" >> ${GITHUB_OUTPUT}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Go
         uses: actions/setup-go@v3

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -25,6 +25,8 @@ jobs:
       - name: Determine targets
         id: targets
         run: ./.github/scripts/determine-targets.sh
+        env:
+          NEW_COMMIT: ${{ github.event.pull_request.head.sha }}
 
       - name: Check modified apps
         run: ./.github/scripts/check-apps.sh


### PR DESCRIPTION
# Overview
This change updates our build to use the head ref as defined in the [checkout plugin docs](https://github.com/actions/checkout#Checkout-pull-request-HEAD-commit-instead-of-merge-commit) instead of a merge commit. Traditionally, building off of the merge commit is safer given it's also testing the integration of the main branch and your feature branch. However, in the community repo, each app is self-contained and all we really care about is the changes being introduced since the branch was created.

# Changes
- [build: Use pull request head on checkout.](https://github.com/tidbyt/community/pull/1096/commits/74b19e1632dcd6ae2f522260f0647a685446c812) 
    - This commit updates the checkout action to use the head of the pull request as the reference to checkout instead of the merge commit.
- [build: Update commits used for td.](https://github.com/tidbyt/community/pull/1096/commits/f7e90dc9cc6374351d83d9c1b8ed23c1f0b5dbe7) 
    - This commit updates the commits to use the base of the branch and the sha that triggered the build for target determination.
    
# Tests
- Changes not touching `apps/` will output `✔️ No apps modified`
- Changes touching a single app will only run pixlet check against the app that changed
- Changes to more then one app will run pixlet check against all apps that changed
- A PR to a PR will only run pixlet check agains the new changes in the new PR
