### PR TITLE
build: Use merge base

### DIFF
--- a/.github/scripts/determine-targets.sh
+++ b/.github/scripts/determine-targets.sh
@@ -7,6 +7,8 @@ echo "GITHUB_BASE_REF=${GITHUB_BASE_REF}"
 echo "GITHUB_HEAD_REF=${GITHUB_HEAD_REF}"
 
 # Determine targets.
+OLD_COMMIT=$(git merge-base ${BASE_SHA} ${HEAD_SHA})
+NEW_COMMIT=${HEAD_SHA}
 echo "OLD_COMMIT=${OLD_COMMIT}"
 echo "NEW_COMMIT=${NEW_COMMIT}"
 TARGETS="$(pixlet community target-determinator --old ${OLD_COMMIT} --new ${NEW_COMMIT})"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,7 +12,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Go
         uses: actions/setup-go@v3
@@ -26,8 +25,8 @@ jobs:
         id: targets
         run: ./.github/scripts/determine-targets.sh
         env:
-          OLD_COMMIT: ${{ github.event.pull_request.base.sha }}
-          NEW_COMMIT: ${{ github.event.pull_request.head.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 
       - name: Check modified apps
         run: ./.github/scripts/check-apps.sh

--- a/apps/zapier/zapier.star
+++ b/apps/zapier/zapier.star
@@ -14,6 +14,8 @@ def main(config):
     secondary = config.str("secondary", "")
     alternate = config.str("alternate", "")
 
+    # revert me.
+
     notification_type = config.str("type", DEFAULT_TYPE)
     icon = MESSAGE_TYPES[notification_type]["icon"]
     alt_color = MESSAGE_TYPES[notification_type]["color"]


### PR DESCRIPTION
# Overview
This change does two things. It goes back to using the merge commit and it uses the merge-base of the GitHub base SHA and the head sha of the branch being committed. I tried to do this before using the references passed into the build, but they broke on PRs from forks. 