### PR TITLE
Tetris Clock: Add max age

### DIFF
--- a/apps/tetrisclock/tetris_clock.star
+++ b/apps/tetrisclock/tetris_clock.star
@@ -621,6 +621,7 @@ def main(config):
     if (TOP_BAR):
         return render.Root(
             delay = DELAY,
+            max_age = 120,
             child = render.Stack(
                 children = [
                     render.Box(


### PR DESCRIPTION
Tetris clock on my tidbyt is like 10 minutes behind so added max_age to see if that helps.

cc @MarkGamed7794 for review.

I know it's likely not your app that is causing this issue and it may be something on Tidbyt's side, but this should at least allow it to not show times where it is like 10 to 20 minutes off hopefully. I know not everyone is having this issue though, but I would like to keep this on my tidbyt so want to try this first.  

I've seen it be on time in the preview and then when I resave configs it corrects itself, but then it starts to drift and becomes 10 minutes off, I am keeping an eye on it to at least see if the slippage gets larger. But because the preview in the app is right, but what's being displayed is wrong I'm not sure what's up. 


Info on `max_age` can be found here (also listed in the widgets under `Root`): https://tidbyt.dev/docs/publish/advanced