### PR TITLE
Nightscout: Moved Sample Data out of global (v2.2.4)

### DIFF
--- a/apps/nightscout/manifest.yaml
+++ b/apps/nightscout/manifest.yaml
@@ -2,7 +2,7 @@
 id: nightscout
 name: Nightscout
 summary: Shows Nightscout CGM Data
-desc: Displays Continuous Glucose Monitoring (CGM) blood sugar data from the Nightscout Open Source project (https://nightscout.github.io/). Will display blood sugar as mg/dL or mmol/L. Optionally display historical readings on a graph. Also a clock. (v2.2.3).
+desc: Displays Continuous Glucose Monitoring (CGM) blood sugar data from the Nightscout Open Source project (https://nightscout.github.io/). Will display blood sugar as mg/dL or mmol/L. Optionally display historical readings on a graph. Also a clock. (v2.2.4).
 author: Jeremy Tavener, Paul Murphy
 fileName: nightscout.star
 packageName: nightscout

--- a/apps/nightscout/nightscout.star
+++ b/apps/nightscout/nightscout.star
@@ -1,7 +1,7 @@
 """
 Applet: Nightscout
 Summary: Shows Nightscout CGM Data
-Description: Displays Continuous Glucose Monitoring (CGM) blood sugar data from the Nightscout Open Source project (https://nightscout.github.io/). Will display blood sugar as mg/dL or mmol/L. Optionally display historical readings on a graph. Also a clock. (v2.2.3).
+Description: Displays Continuous Glucose Monitoring (CGM) blood sugar data from the Nightscout Open Source project (https://nightscout.github.io/). Will display blood sugar as mg/dL or mmol/L. Optionally display historical readings on a graph. Also a clock. (v2.2.4).
 Authors: Jeremy Tavener, Paul Murphy
 """
 
@@ -97,7 +97,57 @@ def main(config):
         nightscout_data_json, status_code = get_nightscout_data(nightscout_id, nightscout_host, show_mgdl)
         sample_data = False
     else:
-        nightscout_data_json, status_code = EXAMPLE_DATA, 0
+        nightscout_data_json, status_code = {
+            "sgv_current": "85",
+            "sgv_delta": "-2",
+            "latest_reading_date_string": (time.now() - time.parse_duration("3m")).format("2006-01-02T15:04:05.999999999Z07:00"),
+            "direction": "Flat",
+            "history": [
+                ((time.now() - time.parse_duration("213m")).unix, 125),
+                ((time.now() - time.parse_duration("208m")).unix, 130),
+                ((time.now() - time.parse_duration("203m")).unix, 135),
+                ((time.now() - time.parse_duration("198m")).unix, 132),
+                ((time.now() - time.parse_duration("193m")).unix, 131),
+                ((time.now() - time.parse_duration("188m")).unix, 137),
+                ((time.now() - time.parse_duration("183m")).unix, 142),
+                ((time.now() - time.parse_duration("178m")).unix, 147),
+                ((time.now() - time.parse_duration("173m")).unix, 155),
+                ((time.now() - time.parse_duration("168m")).unix, 160),
+                ((time.now() - time.parse_duration("163m")).unix, 172),
+                ((time.now() - time.parse_duration("158m")).unix, 184),
+                ((time.now() - time.parse_duration("153m")).unix, 175),
+                ((time.now() - time.parse_duration("148m")).unix, 170),
+                ((time.now() - time.parse_duration("143m")).unix, 167),
+                ((time.now() - time.parse_duration("138m")).unix, 156),
+                ((time.now() - time.parse_duration("133m")).unix, 152),
+                ((time.now() - time.parse_duration("128m")).unix, 140),
+                ((time.now() - time.parse_duration("123m")).unix, 137),
+                ((time.now() - time.parse_duration("118m")).unix, 129),
+                ((time.now() - time.parse_duration("113m")).unix, 121),
+                ((time.now() - time.parse_duration("108m")).unix, 118),
+                ((time.now() - time.parse_duration("103m")).unix, 113),
+                ((time.now() - time.parse_duration("98m")).unix, 108),
+                ((time.now() - time.parse_duration("93m")).unix, 106),
+                ((time.now() - time.parse_duration("88m")).unix, 104),
+                ((time.now() - time.parse_duration("83m")).unix, 101),
+                ((time.now() - time.parse_duration("78m")).unix, 97),
+                ((time.now() - time.parse_duration("73m")).unix, 95),
+                ((time.now() - time.parse_duration("68m")).unix, 93),
+                ((time.now() - time.parse_duration("63m")).unix, 91),
+                ((time.now() - time.parse_duration("58m")).unix, 87),
+                ((time.now() - time.parse_duration("53m")).unix, 87),
+                ((time.now() - time.parse_duration("48m")).unix, 85),
+                ((time.now() - time.parse_duration("43m")).unix, 84),
+                ((time.now() - time.parse_duration("38m")).unix, 83),
+                ((time.now() - time.parse_duration("33m")).unix, 80),
+                ((time.now() - time.parse_duration("28m")).unix, 83),
+                ((time.now() - time.parse_duration("23m")).unix, 88),
+                ((time.now() - time.parse_duration("18m")).unix, 90),
+                ((time.now() - time.parse_duration("13m")).unix, 88),
+                ((time.now() - time.parse_duration("8m")).unix, 87),
+                ((time.now() - time.parse_duration("3m")).unix, 85),
+            ],
+        }, 0
         sample_data = True
 
     if status_code == 503:
@@ -867,56 +917,4 @@ ARROWS = {
     "Error": "?",
     "Dash": "-",
     "NOT COMPUTABLE": "?",
-}
-
-EXAMPLE_DATA = {
-    "sgv_current": "85",
-    "sgv_delta": "-2",
-    "latest_reading_date_string": (time.now() - time.parse_duration("3m")).format("2006-01-02T15:04:05.999999999Z07:00"),
-    "direction": "Flat",
-    "history": [
-        ((time.now() - time.parse_duration("213m")).unix, 141),
-        ((time.now() - time.parse_duration("208m")).unix, 133),
-        ((time.now() - time.parse_duration("203m")).unix, 129),
-        ((time.now() - time.parse_duration("198m")).unix, 125),
-        ((time.now() - time.parse_duration("193m")).unix, 131),
-        ((time.now() - time.parse_duration("188m")).unix, 137),
-        ((time.now() - time.parse_duration("183m")).unix, 142),
-        ((time.now() - time.parse_duration("178m")).unix, 147),
-        ((time.now() - time.parse_duration("173m")).unix, 155),
-        ((time.now() - time.parse_duration("168m")).unix, 160),
-        ((time.now() - time.parse_duration("163m")).unix, 172),
-        ((time.now() - time.parse_duration("158m")).unix, 184),
-        ((time.now() - time.parse_duration("153m")).unix, 175),
-        ((time.now() - time.parse_duration("148m")).unix, 170),
-        ((time.now() - time.parse_duration("143m")).unix, 167),
-        ((time.now() - time.parse_duration("138m")).unix, 156),
-        ((time.now() - time.parse_duration("133m")).unix, 152),
-        ((time.now() - time.parse_duration("128m")).unix, 140),
-        ((time.now() - time.parse_duration("123m")).unix, 137),
-        ((time.now() - time.parse_duration("118m")).unix, 129),
-        ((time.now() - time.parse_duration("113m")).unix, 121),
-        ((time.now() - time.parse_duration("108m")).unix, 118),
-        ((time.now() - time.parse_duration("103m")).unix, 113),
-        ((time.now() - time.parse_duration("98m")).unix, 108),
-        ((time.now() - time.parse_duration("93m")).unix, 106),
-        ((time.now() - time.parse_duration("88m")).unix, 104),
-        ((time.now() - time.parse_duration("83m")).unix, 101),
-        ((time.now() - time.parse_duration("78m")).unix, 97),
-        ((time.now() - time.parse_duration("73m")).unix, 95),
-        ((time.now() - time.parse_duration("68m")).unix, 93),
-        ((time.now() - time.parse_duration("63m")).unix, 91),
-        ((time.now() - time.parse_duration("58m")).unix, 87),
-        ((time.now() - time.parse_duration("53m")).unix, 87),
-        ((time.now() - time.parse_duration("48m")).unix, 85),
-        ((time.now() - time.parse_duration("43m")).unix, 84),
-        ((time.now() - time.parse_duration("38m")).unix, 83),
-        ((time.now() - time.parse_duration("33m")).unix, 80),
-        ((time.now() - time.parse_duration("28m")).unix, 83),
-        ((time.now() - time.parse_duration("23m")).unix, 88),
-        ((time.now() - time.parse_duration("18m")).unix, 90),
-        ((time.now() - time.parse_duration("13m")).unix, 88),
-        ((time.now() - time.parse_duration("8m")).unix, 87),
-        ((time.now() - time.parse_duration("3m")).unix, 85),
-    ],
 }


### PR DESCRIPTION
Moved Sample Data out of global to avoid caching and expiration of default data display