### PR TITLE
Airthings: add option 'onlyDisplayNotNormal'

### DIFF
--- a/apps/airthings/airthings.star
+++ b/apps/airthings/airthings.star
@@ -154,7 +154,7 @@ def main(config):
             continue
 
         if onlyDisplayNotNormal and not displayName in nonNormalValues:
-                continue
+            continue
 
         items.append(
             render.Row(
@@ -269,8 +269,7 @@ def get_schema():
                 name = "Only display non-normal readings",
                 desc = "Only displays readings that are not normal (green). NOTE: Ignores individual preferences below when enabled.",
                 icon = "arrowLeft",
-                default = False
-
+                default = False,
             ),
             schema.Toggle(
                 id = "hidePm25",

--- a/apps/airthings/airthings.star
+++ b/apps/airthings/airthings.star
@@ -41,6 +41,7 @@ def main(config):
 
     # Options
     skipRenderIfAllGreen = config.bool("skipRenderIfAllGreen")
+    onlyDisplayNotNormal = config.bool("onlyDisplayNotNormal")
 
     hidePm25 = config.bool("hidePm25")
     hideVoc = config.bool("hideVoc")
@@ -119,18 +120,21 @@ def main(config):
         humidity_color = "#ff0"
 
     allGreen = True
-    for (sample, hidden) in [
-        (co2_color, hideCo2),
-        (pm25_color, hidePm25),
-        (temp_color, hideTemp),
-        (voc_color, hideVoc),
-        (humidity_color, hideHumidity),
+    nonNormalValues = []
+    for (sample, hidden, displayName) in [
+        (co2_color, hideCo2, "Co2"),
+        (pm25_color, hidePm25, "Pm2.5"),
+        (temp_color, hideTemp, "Temp"),
+        (voc_color, hideVoc, "VOC"),
+        (humidity_color, hideHumidity, "Humidity"),
     ]:
-        if hidden:
+        if not onlyDisplayNotNormal and hidden:
             continue
 
         if not sample == "#0f0":
             allGreen = False
+            if onlyDisplayNotNormal:
+                nonNormalValues.append(displayName)
             break
 
     if skipRenderIfAllGreen and allGreen:
@@ -146,8 +150,11 @@ def main(config):
         (hideVoc, voc, voc_color, "VOC"),
         (hideHumidity, humidity, humidity_color, "Humidity"),
     ]:
-        if hide:
+        if not onlyDisplayNotNormal and hide:
             continue
+
+        if onlyDisplayNotNormal and not displayName in nonNormalValues:
+                continue
 
         items.append(
             render.Row(
@@ -235,19 +242,19 @@ def get_schema():
             schema.Text(
                 id = "clientSecret",
                 name = "AirThings API Client Secret",
-                desc = "API secret from https://dashboard.airthings.com/integrations/api-integration",
+                desc = "REQUIRED: API secret from https://dashboard.airthings.com/integrations/api-integration",
                 icon = "gear",
             ),
             schema.Text(
                 id = "clientId",
                 name = "AirThings API Client Id",
-                desc = "Client Id from https://dashboard.airthings.com/integrations/api-integration",
+                desc = "REQUIRED: Client Id from https://dashboard.airthings.com/integrations/api-integration",
                 icon = "gear",
             ),
             schema.Text(
                 id = "serialNumber",
                 name = "Serial Number for AirThings Device",
-                desc = "Taken from the target device on https://dashboard.airthings.com/",
+                desc = "REQUIRED: Taken from the target device on https://dashboard.airthings.com/",
                 icon = "gear",
             ),
             schema.Toggle(
@@ -256,6 +263,14 @@ def get_schema():
                 desc = "If all readings are normal, skip rendering this applet",
                 icon = "arrowLeft",
                 default = False,
+            ),
+            schema.Toggle(
+                id = "onlyDisplayNotNormal",
+                name = "Only display non-normal readings",
+                desc = "Only displays readings that are not normal (green). NOTE: Ignores individual preferences below when enabled.",
+                icon = "arrowLeft",
+                default = False
+
             ),
             schema.Toggle(
                 id = "hidePm25",


### PR DESCRIPTION
Adds an option to the 'Airthings' applet to only display "not normal" values (values that are in the yellow or red range).

Example:

<img width="1553" alt="image" src="https://user-images.githubusercontent.com/23246594/221444551-9698b41b-395b-45d1-b635-f659383b0cd2.png">
