### PR TITLE
Fix Surf Forecast bar height bug

### DIFF
--- a/apps/surfforecast/surf_forecast.star
+++ b/apps/surfforecast/surf_forecast.star
@@ -248,10 +248,13 @@ def get_wave_ft_to_pixel(state):
 def get_top_bar_height(wave, wave_ft_to_pixel):
     min_height = wave["surf"]["raw"]["min"]
     max_height = wave["surf"]["raw"]["max"]
-    return max(1, wave_ft_to_pixel * int(math.round(max_height - min_height)))
+    scaled_bar_height = int(math.round((wave_ft_to_pixel * (max_height - min_height))))
+    return max(1, scaled_bar_height)
 
 def get_bottom_bar_height(wave, wave_ft_to_pixel):
-    return max(1, wave_ft_to_pixel * int(math.round(wave["surf"]["raw"]["min"])))
+    min_height = wave["surf"]["raw"]["min"]
+    scaled_bar_height = int(math.round(min_height * wave_ft_to_pixel))
+    return max(1, scaled_bar_height)
 
 def get_rating_color(rating):
     return COLOR_BY_SURFLINE_RATING[rating["rating"]["key"]]


### PR DESCRIPTION
Sometimes these bar height functions return floats rather than ints if the values returned from the surfline API are just right. Floats are not a valid type for Box heights.

I've also put off rounding until the final step of the calculation to allow the bar heights be more precise.