### PR TITLE
build: Only build changes on main branch

### DIFF
--- a/.github/scripts/determine-targets.sh
+++ b/.github/scripts/determine-targets.sh
@@ -3,14 +3,12 @@
 set -e
 
 # Determine base commit.
-echo "GITHUB_BASE_REF=${GITHUB_BASE_REF}"
-echo "GITHUB_HEAD_REF=${GITHUB_HEAD_REF}"
-
-# Determine targets.
 OLD_COMMIT=$(git merge-base ${BASE_SHA} ${HEAD_SHA})
 NEW_COMMIT=${HEAD_SHA}
 echo "OLD_COMMIT=${OLD_COMMIT}"
 echo "NEW_COMMIT=${NEW_COMMIT}"
+
+# Determine targets.
 TARGETS="$(pixlet community target-determinator --old ${OLD_COMMIT} --new ${NEW_COMMIT})"
 
 # Convert new lines to spaces. Maybe Pixlet should do this?

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v3
@@ -21,8 +23,26 @@ jobs:
       - name: Setup build agent
         run: ./.github/scripts/setup.sh
 
-      - name: Check all apps
-        run: pixlet check -r ./
+      - name: Find last successful build
+        id: lastsuccess
+        uses: SamhammerAG/last-successful-build-action@v2
+        with:
+          branch: "main"
+          workflow: "Build and Release"
+          verify: true
+          token: "${{ secrets.TIDBYT_GITHUB_TOKEN }}"
+
+      - name: Determine targets
+        id: targets
+        run: ./.github/scripts/determine-targets.sh
+        env:
+          BASE_SHA: ${{ steps.lastsuccess.outputs.sha }}
+          HEAD_SHA: ${{ github.sha }}
+
+      - name: Check modified apps
+        run: ./.github/scripts/check-apps.sh
+        env:
+          TARGETS: "${{ steps.targets.outputs.targets }}"
 
       - name: Sanity check go embed
         run: go test tidbyt.dev/community/apps


### PR DESCRIPTION
# Overview
Right now, the main branch builds everything. This change updates the main branch to only build the difference between the last successful build and the current build. While not overly useful at the moment, we will be able to deploy only what changed once this repo can deploy itself.

# Changes
- [feat: Only build what changed.](https://github.com/tidbyt/community/pull/1194/commits/b75db8a51c3012e9b665628003ad81f448f6936c) 
    - This commit updates the main branch to only build what has changed.
