### PR TITLE
GitHub Activity and GitHub Repo: Add show_full_animation

### DIFF
--- a/apps/githubactivity/github_activity.star
+++ b/apps/githubactivity/github_activity.star
@@ -7,7 +7,7 @@ Author: rs7q5
 
 #github_activity.star
 #Created 20221117 RIS
-#Last Modified 20221224 RIS
+#Last Modified 20230308 RIS
 
 load("cache.star", "cache")
 load("encoding/base64.star", "base64")
@@ -116,6 +116,7 @@ def main(config):
 
     return render.Root(
         delay = 100,  #speed up scroll text
+        show_full_animation = True,
         child = frame_final,
     )
 

--- a/apps/githubrepo/github_repo.star
+++ b/apps/githubrepo/github_repo.star
@@ -7,7 +7,7 @@ Author: rs7q5
 
 #github_repo.star
 #Created 20221223 RIS
-#Last Modified 20230112 RIS
+#Last Modified 20230308 RIS
 
 load("cache.star", "cache")
 load("encoding/base64.star", "base64")
@@ -134,6 +134,7 @@ def main(config):
 
     return render.Root(
         delay = 100,  #speed up scroll text
+        show_full_animation = True,
         child = frame_final,
     )
 


### PR DESCRIPTION
After displaying these for a bit on my tidbyt, relized these should have the full animation flag otherwise you'll never see some of the content