### PR TITLE
Add .editorconfig file to clarify indentation requirements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*.{star}]
+indent_style = space
+indent_size = 4
+insert_final_newline = false


### PR DESCRIPTION
I’ve added an `.editorconfig` file to help future developers avoid [this issue](https://github.com/tidbyt/community/issues/1207). It isn’t a panacea - `.editorconfig` doesn’t work out of the box with VS Code and some other editors, and [this extension](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig) is needed to apply the rules. However, I think it's a good first step.

Starlark itself specifies [some editor config settings](https://github.com/bazelbuild/starlark/blob/master/.editorconfig).

Additionally, perhaps this limitation could be mentioned on the FAQ page [here](https://tidbyt.dev/docs/publish/FAQ#why-is-the-linter-so-opinionated).

Long term, I would heavily recommend adding support for tabs for accessibility reasons and general DX (yes, I’m extremely biased but we don’t need to continue the indentation holy wars here).