### PR TITLE
surf apps : add minimum swell/wave size options

### DIFF
--- a/apps/surfforecast/surf_forecast.star
+++ b/apps/surfforecast/surf_forecast.star
@@ -279,7 +279,7 @@ def main(config):
     state = get_state(config)
 
     # skip render if waves are smaller than specified in config min_height
-    if get_current_max_height(state) < int(config.get("min_height","0")):
+    if get_current_max_height(state) < int(config.get("min_height", "0")):
         return []
 
     return render.Root(
@@ -540,7 +540,7 @@ def get_schema():
                 icon = "pencil",
                 desc = "The minimum wave size to display",
                 options = min_height_options,
-                default = "0"
+                default = "0",
             ),
         ],
     )

--- a/apps/surfforecast/surf_forecast.star
+++ b/apps/surfforecast/surf_forecast.star
@@ -527,6 +527,13 @@ def get_schema():
                 icon = "magnifyingGlass",
                 handler = search_handler,
             ),
+            schema.Text(
+                id = "display_name",
+                name = "Display Name",
+                icon = "pencil",
+                desc = "Optional spot name to display",
+                default = "",
+            ),
             schema.Dropdown(
                 id = "min_height",
                 name = "Mininum Size",
@@ -534,13 +541,6 @@ def get_schema():
                 desc = "The minimum wave size to display",
                 options = min_height_options,
                 default = "0"
-            ),
-            schema.Text(
-                id = "display_name",
-                name = "Display Name",
-                icon = "pencil",
-                desc = "Optional spot name to display",
-                default = "",
             ),
         ],
     )

--- a/apps/surfforecast/surf_forecast.star
+++ b/apps/surfforecast/surf_forecast.star
@@ -277,6 +277,11 @@ def get_bar_data(state):
 
 def main(config):
     state = get_state(config)
+
+    # skip render if waves are smaller than specified in config min_height
+    if get_current_max_height(state) < int(config.get("min_height","0")):
+        return []
+
     return render.Root(
         child = render.Stack(
             children = [
@@ -498,6 +503,20 @@ def search_handler(text):
     return [schema.Option(display = s["name"], value = s["_id"]) for s in response["spots"]]
 
 def get_schema():
+    min_height_options = [
+        schema.Option(display = "0 ft", value = "0"),
+        schema.Option(display = "1 ft", value = "1"),
+        schema.Option(display = "2 ft", value = "2"),
+        schema.Option(display = "3 ft", value = "3"),
+        schema.Option(display = "4 ft", value = "4"),
+        schema.Option(display = "6 ft", value = "6"),
+        schema.Option(display = "8 ft", value = "8"),
+        schema.Option(display = "10 ft", value = "10"),
+        schema.Option(display = "15 ft", value = "15"),
+        schema.Option(display = "20 ft", value = "20"),
+        schema.Option(display = "25 ft", value = "25"),
+        schema.Option(display = "30 ft", value = "30"),
+    ]
     return schema.Schema(
         version = "1",
         fields = [
@@ -507,6 +526,14 @@ def get_schema():
                 desc = "Find spot on Surfline",
                 icon = "magnifyingGlass",
                 handler = search_handler,
+            ),
+            schema.Dropdown(
+                id = "min_height",
+                name = "Mininum Size",
+                icon = "pencil",
+                desc = "The minimum wave size to display",
+                options = min_height_options,
+                default = "0"
             ),
             schema.Text(
                 id = "display_name",

--- a/apps/surflive/surflive.star
+++ b/apps/surflive/surflive.star
@@ -334,14 +334,6 @@ def get_schema():
                 icon = "compass",
                 handler = search_handler,
             ),
-            schema.Dropdown(
-                id = "min_height",
-                name = "Mininum Size",
-                icon = "pencil",
-                desc = "The minimum wave size to display",
-                options = min_height_options,
-                default = "0"
-            ),
             schema.Text(
                 id = "spot_name",
                 name = "Display Name",
@@ -356,5 +348,14 @@ def get_schema():
                 icon = "gear",
                 default = False,
             ),
+            schema.Dropdown(
+                id = "min_height",
+                name = "Mininum Size",
+                icon = "gear",
+                desc = "Minimum wave size to display",
+                options = min_height_options,
+                default = "0"
+            ),
+
         ],
     )

--- a/apps/surflive/surflive.star
+++ b/apps/surflive/surflive.star
@@ -74,6 +74,14 @@ def main(config):
             render.Row(expanded = True, main_align = "center", children = [render.Text(content = "ERROR", color = "#f00")]),
         ]
 
+    # skip render if waves are smaller than specified in config min_height
+    if config.bool("use_wave_height"):
+        if conditions["wave"]["max"] < int(config.get("min_height","0")):
+            return []
+    else:
+        if conditions["wave"]["swell_height"] < int(config.get("min_height","0")):
+            return []
+
     return render.Root(
         child = render.Column(
             expanded = True,
@@ -302,6 +310,20 @@ def search_handler(query):
     return [schema.Option(display = s["name"], value = s["_id"]) for s in spots]
 
 def get_schema():
+    min_height_options = [
+        schema.Option(display = "0 ft", value = "0"),
+        schema.Option(display = "1 ft", value = "1"),
+        schema.Option(display = "2 ft", value = "2"),
+        schema.Option(display = "3 ft", value = "3"),
+        schema.Option(display = "4 ft", value = "4"),
+        schema.Option(display = "6 ft", value = "6"),
+        schema.Option(display = "8 ft", value = "8"),
+        schema.Option(display = "10 ft", value = "10"),
+        schema.Option(display = "15 ft", value = "15"),
+        schema.Option(display = "20 ft", value = "20"),
+        schema.Option(display = "25 ft", value = "25"),
+        schema.Option(display = "30 ft", value = "30"),
+    ]
     return schema.Schema(
         version = "1",
         fields = [
@@ -311,6 +333,14 @@ def get_schema():
                 desc = "Spot Name in Surfline",
                 icon = "compass",
                 handler = search_handler,
+            ),
+            schema.Dropdown(
+                id = "min_height",
+                name = "Mininum Size",
+                icon = "pencil",
+                desc = "The minimum wave size to display",
+                options = min_height_options,
+                default = "0"
             ),
             schema.Text(
                 id = "spot_name",

--- a/apps/surflive/surflive.star
+++ b/apps/surflive/surflive.star
@@ -76,11 +76,10 @@ def main(config):
 
     # skip render if waves are smaller than specified in config min_height
     if config.bool("use_wave_height"):
-        if conditions["wave"]["max"] < int(config.get("min_height","0")):
+        if conditions["wave"]["max"] < int(config.get("min_height", "0")):
             return []
-    else:
-        if conditions["wave"]["swell_height"] < int(config.get("min_height","0")):
-            return []
+    elif conditions["wave"]["swell_height"] < int(config.get("min_height", "0")):
+        return []
 
     return render.Root(
         child = render.Column(
@@ -354,8 +353,7 @@ def get_schema():
                 icon = "gear",
                 desc = "Minimum wave size to display",
                 options = min_height_options,
-                default = "0"
+                default = "0",
             ),
-
         ],
     )


### PR DESCRIPTION
Edited both surflive and surfforecast to have minimum wave/swell height option.
App will skip render (ie not display) if the wave/swell height is below the user set threshold from 0 to 30ft
Option defaults to 0 ft so that by default the apps will not change behaviour.
@smith-kyle is original author of surf_forecast
@rcarton is the original author of surf_live