### PR TITLE
hass_entity: Convert numeric attribute to string

### DIFF
--- a/apps/hassentity/hass_entity.star
+++ b/apps/hassentity/hass_entity.star
@@ -31,7 +31,7 @@ def main(config):
     if is_string_blank(attribute):
         state = states["state"]
     else:
-        state = states["attributes"][attribute]
+        state = "{}".format(states["attributes"][attribute])
 
     if "unit_of_measurement" in states["attributes"].keys():
         state = state + states["attributes"]["unit_of_measurement"]


### PR DESCRIPTION
# Description
This app allows one to pick a value to display from the attributes returned from Home Assistant instead of the state. The problem occurs when the attribute is a JSON number rather than a string. The state will always be a string but this is not true for the values in the attribute block. This change simply converts whatever value is pulled from the attribute block to a string.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b8892dd</samp>

### Summary
🐛📝🏠

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the pull request.
2.  📝 - This emoji represents a text or string change, which is the specific change made to the state variable.
3.  🏠 - This emoji represents Home Assistant, which is the platform that the app integrates with and the source of the entity data.
-->
Fixed a bug in `hass_entity.star` that caused the app to crash with some Home Assistant entities. The fix involved formatting the state variable as a string before concatenating it with the unit of measurement.

> _`get_state` converts_
> _string state avoids errors_
> _autumn bug is fixed_

### Walkthrough
*  Format state variable as string to prevent errors when concatenating with unit of measurement ([link](https://github.com/tidbyt/community/pull/1294/files?diff=unified&w=0#diff-b1015afd4a7bf1bd7ef1399d6ef38b33b4226d3da44219e7609a530c82b646bfL34-R34))


