### PR TITLE
Fix: IPL

### DIFF
--- a/apps/ipl/ipl.star
+++ b/apps/ipl/ipl.star
@@ -67,7 +67,7 @@ def main(config):
     T20_Status4 = ""
 
     MatchID = str(MatchID)
-    Match_URL = "https://hs-consumer-api.espncricinfo.com/v1/pages/match/details?lang=en&seriesId=" + MatchID + "&matchId=" + MatchID + "&latest=true"
+    Match_URL = "https://hs-consumer-api.espncricinfo.com/v1/pages/match/details?lang=en&seriesId=1345038&matchId=" + MatchID + "&latest=true"
 
     #print(Match_URL)
     # cache specific match data for 1 minute


### PR DESCRIPTION
# Description
Cricinfo changed the format for the API URL. This has been fixed now

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7229333</samp>

### Summary
🐛🏏🆔

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the change to the `Match_URL` variable. It indicates that the app had a problem that needed to be resolved and that the change improved the functionality or performance of the app.
2.  🏏 - This emoji represents cricket, which is the sport that the app is focused on. It indicates that the change is related to the IPL, which is a cricket league, and that the app provides information about cricket matches and teams.
3.  🆔 - This emoji represents an ID, which is the type of value that the seriesId parameter represents. It indicates that the change involved specifying a fixed identifier for the IPL season, rather than relying on a dynamic or variable one.
-->
Fixed a bug in the `ipl` app that showed wrong match details. Changed the `Match_URL` variable to use a specific seriesId for IPL 2021 in `apps/ipl/ipl.star`.

> _`Match_URL` fixed_
> _SeriesId set to IPL_
> _Spring cricket scores_

### Walkthrough
* Fix match details bug by using fixed seriesId value of 1345038 for `Match_URL` ([link](https://github.com/tidbyt/community/pull/1308/files?diff=unified&w=0#diff-1b261b4634779291fabe5a41f79d2f194b85218d22d75ab17ac17813f83e525dL70-R70))


