### PR TITLE
Update septatransit.star

### DIFF
--- a/apps/septatransit/septatransit.star
+++ b/apps/septatransit/septatransit.star
@@ -191,7 +191,15 @@ def get_schedule(route, stopid):
             )
             list_of_departures.append(item)
 
-    return list_of_departures
+    if len(list_of_departures) < 1:
+        return [render.Box(
+            height = 6,
+            width = 64,
+            color = "#000",
+            child = render.Text("Select a stop"),
+        )]
+    else:
+        return list_of_departures
 
 def select_stop(route):
     return [
@@ -210,13 +218,26 @@ def main(config):
     stop = config.str("stop", DEFAULT_STOP)
     user_text = config.str("banner", "")
     schedule = get_schedule(route, stop)
-    route_bg_color = get_route_bg_color(route)
-    route_text_color = get_route_text_color(route)
+
+    if config.bool("use_custom_banner_color"):
+        route_bg_color = config.str("custom_banner_color")
+    else:
+        route_bg_color = get_route_bg_color(route)
+
+    if config.bool("use_custom_text_color"):
+        route_text_color = config.str("custom_text_color")
+    else:
+        route_text_color = get_route_text_color(route)
 
     if user_text == "":
         banner_text = route
     else:
         banner_text = user_text
+
+    if config.bool("show_time"):
+        timezone = config.get("timezone") or "America/New_York"
+        now = time.now().in_location(timezone)
+        banner_text = banner_text + " " + now.format("3:04 PM")
 
     return render.Root(
         delay = 100,
@@ -242,10 +263,45 @@ def get_schema():
         fields = [
             schema.Text(
                 id = "banner",
-                name = "Banner",
+                name = "Custom banner text",
                 desc = "Custom text for the top bar. Leave blank to show the selected route.",
                 icon = "penNib",
                 default = "",
+            ),
+            schema.Toggle(
+                id = "use_custom_banner_color",
+                name = "Use custom banner color",
+                desc = "Use a custom background color for the top banner.",
+                icon = "palette",
+                default = False,
+            ),
+            schema.Color(
+                id = "custom_banner_color",
+                name = "Custom banner color",
+                desc = "A custom background color for the top banner.",
+                icon = "brush",
+                default = "#7AB0FF",
+            ),
+            schema.Toggle(
+                id = "use_custom_text_color",
+                name = "Use custom text color",
+                desc = "Use a custom text color for the top banner.",
+                icon = "palette",
+                default = False,
+            ),
+            schema.Color(
+                id = "custom_text_color",
+                name = "Custom banner color",
+                desc = "A custom text color for the top banner.",
+                icon = "brush",
+                default = "#FFFFFF",
+            ),
+            schema.Toggle(
+                id = "show_time",
+                name = "Show time",
+                desc = "Show the current time in the top banner.",
+                icon = "clock",
+                default = False,
             ),
             schema.Dropdown(
                 id = "route",

--- a/apps/septatransit/septatransit.star
+++ b/apps/septatransit/septatransit.star
@@ -291,7 +291,7 @@ def get_schema():
             ),
             schema.Color(
                 id = "custom_text_color",
-                name = "Custom banner color",
+                name = "Custom text color",
                 desc = "A custom text color for the top banner.",
                 icon = "brush",
                 default = "#FFFFFF",


### PR DESCRIPTION
# Description

- Added an option for custom background and text colors for the top banner
- Added an option to display the time in the top banner
- Added error handling when no stop is selected

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5353939</samp>

### Summary
🎨🕒🙅

<!--
1.  🎨 - This emoji can be used to indicate the addition of new customization options, such as choosing colors or themes. It conveys the idea of creativity and personalization.
2.  🕒 - This emoji can be used to indicate the addition of a feature that shows the current time on the banner. It conveys the idea of timeliness and convenience.
3.  🙅 - This emoji can be used to indicate the improvement of handling empty departures gracefully. It conveys the idea of rejection or avoidance of a negative situation.
-->
This pull request enhances the `septatransit` app with more user preferences and better display logic. It lets the user customize the banner and text colors, optionally show the time, and avoid showing blank screens when no departures are available.

> _Sing, O Muse, of the skillful coder who devised_
> _Many splendid options for the `septatransit` app,_
> _To delight the users with their chosen hues and shades,_
> _And to show them the time and the departures that lapse._

### Walkthrough
*  Add customization options for banner color, text color, and time display ([link](https://github.com/tidbyt/community/pull/1313/files?diff=unified&w=0#diff-b1fdab8189161d4f11593fce619cf6d6ff03f6798efb8a651cbe1aba9632d6f9L213-R231), [link](https://github.com/tidbyt/community/pull/1313/files?diff=unified&w=0#diff-b1fdab8189161d4f11593fce619cf6d6ff03f6798efb8a651cbe1aba9632d6f9R237-R241), [link](https://github.com/tidbyt/community/pull/1313/files?diff=unified&w=0#diff-b1fdab8189161d4f11593fce619cf6d6ff03f6798efb8a651cbe1aba9632d6f9L245-R305))
* Handle empty departures list gracefully ([link](https://github.com/tidbyt/community/pull/1313/files?diff=unified&w=0#diff-b1fdab8189161d4f11593fce619cf6d6ff03f6798efb8a651cbe1aba9632d6f9L194-R202))


