### PR TITLE
pollecount: lat/lng are strings in location object

### DIFF
--- a/apps/pollencount/pollen_count.star
+++ b/apps/pollencount/pollen_count.star
@@ -13,8 +13,8 @@ load("render.star", "render")
 load("schema.star", "schema")
 
 DEFAULT_LOC = {
-    "lat": 40.63,
-    "lng": -74.02,
+    "lat": "40.63",
+    "lng": "-74.02",
     "locality": "",
 }
 
@@ -34,8 +34,8 @@ def main(config):
     loc = json.decode(location) if location else DEFAULT_LOC
 
     #Round to 1 decimal place (1.1km)
-    lat = roundToHalf(loc.get("lat"))
-    lng = roundToHalf(loc.get("lng"))
+    lat = roundToHalf(float(loc.get("lat")))
+    lng = roundToHalf(float(loc.get("lng")))
     latLngStr = str(lat) + "," + str(lng)
     dev_key = config.get("dev_key", "1234")
 


### PR DESCRIPTION
# Description
Replace this with a description of your changes.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 764d285</samp>

### Summary
🐛🔄🌎

<!--
1.  🐛 Bug fix: This emoji indicates that a bug or error was fixed in the code, such as the type inconsistencies that caused rounding errors or invalid comparisons.
2.  🔄 Refactor: This emoji indicates that the code was restructured or improved without changing its functionality, such as changing the default location values to strings and converting them to numbers before rounding. This could make the code more readable, consistent, or flexible.
3.  🌎 Location: This emoji indicates that the code involves geographic or spatial data, such as latitude and longitude values. This could help to convey the context or purpose of the code.
-->
Fixed a bug in `pollen_count.star` that caused errors when using non-numeric location values. Improved the usability of the app by allowing users to enter location values as strings.

> _The code for the pollen count star_
> _Had some types that were not up to par_
> _So the default location_
> _Got a string notation_
> _And was parsed to a number so far_

### Walkthrough
*  Convert latitude and longitude values to strings for consistency ([link](https://github.com/tidbyt/community/pull/1315/files?diff=unified&w=0#diff-00133a65ae7da9f81156760be9c40a7f90eb43b25cbae8a811493cad9f031331L16-R17))
*  Convert latitude and longitude values to numbers for rounding ([link](https://github.com/tidbyt/community/pull/1315/files?diff=unified&w=0#diff-00133a65ae7da9f81156760be9c40a7f90eb43b25cbae8a811493cad9f031331L37-R38))


