### PR TITLE
SEPTA Transit: Current time layout fix

### DIFF
--- a/apps/septatransit/septatransit.star
+++ b/apps/septatransit/septatransit.star
@@ -191,7 +191,15 @@ def get_schedule(route, stopid):
             )
             list_of_departures.append(item)
 
-    return list_of_departures
+    if len(list_of_departures) < 1:
+        return [render.Box(
+            height = 6,
+            width = 64,
+            color = "#000",
+            child = render.Text("Select a stop"),
+        )]
+    else:
+        return list_of_departures
 
 def select_stop(route):
     return [
@@ -210,13 +218,26 @@ def main(config):
     stop = config.str("stop", DEFAULT_STOP)
     user_text = config.str("banner", "")
     schedule = get_schedule(route, stop)
-    route_bg_color = get_route_bg_color(route)
-    route_text_color = get_route_text_color(route)
+
+    if config.bool("use_custom_banner_color"):
+        route_bg_color = config.str("custom_banner_color")
+    else:
+        route_bg_color = get_route_bg_color(route)
+
+    if config.bool("use_custom_text_color"):
+        route_text_color = config.str("custom_text_color")
+    else:
+        route_text_color = get_route_text_color(route)
 
     if user_text == "":
         banner_text = route
     else:
         banner_text = user_text
+
+    if config.bool("show_time"):
+        timezone = config.get("timezone") or "America/New_York"
+        now = time.now().in_location(timezone)
+        banner_text = banner_text + " " + now.format("3:04 PM")
 
     return render.Root(
         delay = 100,
@@ -242,10 +263,45 @@ def get_schema():
         fields = [
             schema.Text(
                 id = "banner",
-                name = "Banner",
+                name = "Custom banner text",
                 desc = "Custom text for the top bar. Leave blank to show the selected route.",
                 icon = "penNib",
                 default = "",
+            ),
+            schema.Toggle(
+                id = "use_custom_banner_color",
+                name = "Use custom banner color",
+                desc = "Use a custom background color for the top banner.",
+                icon = "palette",
+                default = False,
+            ),
+            schema.Color(
+                id = "custom_banner_color",
+                name = "Custom banner color",
+                desc = "A custom background color for the top banner.",
+                icon = "brush",
+                default = "#7AB0FF",
+            ),
+            schema.Toggle(
+                id = "use_custom_text_color",
+                name = "Use custom text color",
+                desc = "Use a custom text color for the top banner.",
+                icon = "palette",
+                default = False,
+            ),
+            schema.Color(
+                id = "custom_text_color",
+                name = "Custom banner color",
+                desc = "A custom text color for the top banner.",
+                icon = "brush",
+                default = "#FFFFFF",
+            ),
+            schema.Toggle(
+                id = "show_time",
+                name = "Show time",
+                desc = "Show the current time in the top banner.",
+                icon = "clock",
+                default = False,
             ),
             schema.Dropdown(
                 id = "route",

--- a/apps/septatransit/septatransit.star
+++ b/apps/septatransit/septatransit.star
@@ -291,7 +291,7 @@ def get_schema():
             ),
             schema.Color(
                 id = "custom_text_color",
-                name = "Custom banner color",
+                name = "Custom text color",
                 desc = "A custom text color for the top banner.",
                 icon = "brush",
                 default = "#FFFFFF",

--- a/apps/septatransit/septatransit.star
+++ b/apps/septatransit/septatransit.star
@@ -1,7 +1,7 @@
 """
 Applet: SEPTA Transit
-Summary: SEPTA transit departures
-Description: Displays departure times for SEPTA buses, trolleys, and MFL/BSL.
+Summary: SEPTA Transit Departures
+Description: Displays departure times for SEPTA buses, trolleys, and MFL/BSL in and around Philadelphia.
 Author: radiocolin
 """
 
@@ -218,6 +218,9 @@ def main(config):
     stop = config.str("stop", DEFAULT_STOP)
     user_text = config.str("banner", "")
     schedule = get_schedule(route, stop)
+    timezone = config.get("timezone") or "America/New_York"
+    now = time.now().in_location(timezone)
+    left_pad = 1
 
     if config.bool("use_custom_banner_color"):
         route_bg_color = config.str("custom_banner_color")
@@ -235,9 +238,9 @@ def main(config):
         banner_text = user_text
 
     if config.bool("show_time"):
-        timezone = config.get("timezone") or "America/New_York"
-        now = time.now().in_location(timezone)
-        banner_text = banner_text + " " + now.format("3:04 PM")
+        banner_text = now.format("3:04p") + " " + banner_text
+        if now.format("3") not in ["10", "11", "12"]:
+            left_pad = 4
 
     return render.Root(
         delay = 100,
@@ -248,7 +251,7 @@ def main(config):
                     children = [
                         render.Stack(children = [
                             render.Box(height = 6, width = 64, color = route_bg_color),
-                            render.Padding(pad = (1, 0, 0, 0), child = render.Text(banner_text, font = "tom-thumb", color = route_text_color)),
+                            render.Padding(pad = (left_pad, 0, 0, 0), child = render.Text(banner_text, font = "tom-thumb", color = route_text_color)),
                         ]),
                     ],
                 ),


### PR DESCRIPTION
# Description
Repositions the current time to align with the departure times.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 38472d1</samp>

### Summary
🕒🚍♻️

<!--
1.  🕒 - This emoji can represent the improvement of the time display in the banner, as it shows a clock face with different hours. It can also suggest that the applet is more accurate and timely in showing the transit information.
2.  🚍 - This emoji can represent the improvement of the route name display in the banner, as it shows a bus that is commonly used for public transit. It can also suggest that the applet is more user-friendly and informative in showing the route details.
3.  ♻️ - This emoji can represent the refactoring of some variables to avoid duplication and enable reuse, as it shows a recycling symbol that implies reducing waste and improving efficiency. It can also suggest that the applet is more maintainable and modular in its code structure.
-->
Improved septatransit applet's banner layout and code quality. Refactored `septatransit.star` to use more consistent and reusable variables for time and route name.

> _Sing, O Muse, of the skillful coder who updated_
> _The `septatransit` applet, a gift to the city dwellers_
> _Who rely on the swift and shining chariots of iron_
> _To traverse the wide and crowded streets of Philadelphia._

### Walkthrough
*  Update summary and description of applet to be more informative and consistent ([link](https://github.com/tidbyt/community/pull/1316/files?diff=unified&w=0#diff-b1fdab8189161d4f11593fce619cf6d6ff03f6798efb8a651cbe1aba9632d6f9L3-R4))
*  Move timezone and now variables outside of show_time condition to avoid repetition and enable other uses ([link](https://github.com/tidbyt/community/pull/1316/files?diff=unified&w=0#diff-b1fdab8189161d4f11593fce619cf6d6ff03f6798efb8a651cbe1aba9632d6f9R221-R223))
*  Modify banner_text to show time before route name and use lowercase p for PM ([link](https://github.com/tidbyt/community/pull/1316/files?diff=unified&w=0#diff-b1fdab8189161d4f11593fce619cf6d6ff03f6798efb8a651cbe1aba9632d6f9L238-R243))
*  Introduce left_pad variable to adjust padding of text depending on hour length ([link](https://github.com/tidbyt/community/pull/1316/files?diff=unified&w=0#diff-b1fdab8189161d4f11593fce619cf6d6ff03f6798efb8a651cbe1aba9632d6f9L238-R243))
*  Use left_pad variable to set horizontal padding of text within banner ([link](https://github.com/tidbyt/community/pull/1316/files?diff=unified&w=0#diff-b1fdab8189161d4f11593fce619cf6d6ff03f6798efb8a651cbe1aba9632d6f9L251-R254))


