### PR TITLE
Update: ATP Tennis

### DIFF
--- a/apps/atptennis/atp_tennis.star
+++ b/apps/atptennis/atp_tennis.star
@@ -6,6 +6,9 @@ Author: M0ntyP
 
 Note:
 ESPN sometimes shows completed matches as stil being "In Progress" well after they have been completed so those matches will continue to appear as in progress matches. 
+
+v1.1
+Used "post" state for completed matches, this will capture both Final and Retired
 """
 
 load("cache.star", "cache")
@@ -97,8 +100,8 @@ def main(config):
                 EventIndex = x
                 if len(ATP_JSON["events"][x]) == 10:
                     for y in range(0, len(ATP_JSON["events"][x]["competitions"]), 1):
-                        # if the match is "Final" and its a singles match and the start time of the match was < 24 hrs ago, lets add it to the list of completed matches
-                        if ATP_JSON["events"][x]["competitions"][y]["status"]["type"]["description"] == "Final":
+                        # if the match is completed ("post") and its a singles match ("athlete") and the start time of the match was < 24 hrs ago, lets add it to the list of completed matches
+                        if ATP_JSON["events"][x]["competitions"][y]["status"]["type"]["state"] == "post":
                             if ATP_JSON["events"][x]["competitions"][y]["competitors"][0]["type"] == "athlete":
                                 MatchTime = ATP_JSON["events"][EventIndex]["competitions"][y]["date"]
                                 MatchTime = time.parse_time(MatchTime, format = "2006-01-02T15:04Z").in_location(timezone)

--- a/apps/atptennis/atp_tennis.star
+++ b/apps/atptennis/atp_tennis.star
@@ -9,6 +9,8 @@ ESPN sometimes shows completed matches as stil being "In Progress" well after th
 
 v1.1
 Used "post" state for completed matches, this will capture both Final and Retired
+Added handling for when no tournaments are on
+
 """
 
 load("cache.star", "cache")
@@ -525,15 +527,25 @@ def get_schema():
             EventsID.append(Event_ID)
             ActualEvents = ActualEvents + 1
 
-    for y in range(0, ActualEvents, 1):
-        # lint being a pain, so...
-        y = y
-        EventName = Events.pop(0)
-        EventID = EventsID.pop(0)
+    if ActualEvents != 0:
+        for y in range(0, ActualEvents, 1):
+            # lint being a pain, so...
+            y = y
+            EventName = Events.pop(0)
+            EventID = EventsID.pop(0)
 
+            Value = schema.Option(
+                display = EventName,
+                value = EventID,
+            )
+
+            TournamentOptions.append(Value)
+
+        # if there are no tournaments on then put that in the dropdown
+    else:
         Value = schema.Option(
-            display = EventName,
-            value = EventID,
+            display = "No active events",
+            value = "1",
         )
 
         TournamentOptions.append(Value)


### PR DESCRIPTION
# Description
Using different field in API to capture a completed match. This covers a normal win and a retirement

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d389980</samp>

### Summary
🆕🛠️🎾

<!--
1.  🆕 - This emoji can be used to indicate that new features or information have been added to the file, such as the version and feature metadata and the improved retired match logic.
2.  🛠️ - This emoji can be used to signify that a bug or issue has been fixed or improved, such as the incorrect identification of completed matches based on the `Final` description.
3.  🎾 - This emoji can be used to represent the domain or topic of the file, which is tennis. It can also convey a sense of fun or excitement for the sport.
-->
Update `atp_tennis.star` app to show version and features, and fix retired match issue. Use `post` state to check for finished matches.

> _To track tennis matches that are done_
> _We use `post` instead of `Final` fun_
> _We also add version_
> _And feature insertion_
> _To the file `atp_tennis.star` for everyone_

### Walkthrough
*  Add comment with version and feature update ([link](https://github.com/tidbyt/community/pull/1325/files?diff=unified&w=0#diff-2fe7726a8148e3fb23a64991e8b2661bd9c098395de1a2f1ea0092f21db623bcR9-R11))
*  Use "post" state to capture both final and retired matches ([link](https://github.com/tidbyt/community/pull/1325/files?diff=unified&w=0#diff-2fe7726a8148e3fb23a64991e8b2661bd9c098395de1a2f1ea0092f21db623bcL100-R104))


