### PR TITLE
Update: WTA Tennis

### DIFF
--- a/apps/wtatennis/wta_tennis.star
+++ b/apps/wtatennis/wta_tennis.star
@@ -6,6 +6,10 @@ Author: M0ntyP
 
 Note:
 ESPN sometimes shows completed matches as stil being "In Progress" well after they have been completed so those matches will continue to appear as in progress matches. 
+
+v1.1
+Used "post" state for completed matches, this will capture both Final and Retired
+Added handling for when no tournaments are on
 """
 
 load("cache.star", "cache")
@@ -98,8 +102,8 @@ def main(config):
                 EventIndex = x
                 if len(WTA_JSON["events"][x]) == 10:
                     for y in range(0, len(WTA_JSON["events"][x]["competitions"]), 1):
-                        # if the match is "Final" and its a singles match and the start time of the match was < 24 hrs ago, lets add it to the list of completed matches
-                        if WTA_JSON["events"][x]["competitions"][y]["status"]["type"]["description"] == "Final":
+                        # if the match is completed ("post") and its a singles match ("athlete") and the start time of the match was < 24 hrs ago, lets add it to the list of completed matches
+                        if WTA_JSON["events"][x]["competitions"][y]["status"]["type"]["state"] == "post":
                             if WTA_JSON["events"][x]["competitions"][y]["competitors"][0]["type"] == "athlete":
                                 MatchTime = WTA_JSON["events"][EventIndex]["competitions"][y]["date"]
                                 MatchTime = time.parse_time(MatchTime, format = "2006-01-02T15:04Z").in_location(timezone)
@@ -525,15 +529,25 @@ def get_schema():
             EventsID.append(Event_ID)
             ActualEvents = ActualEvents + 1
 
-    for y in range(0, ActualEvents, 1):
-        # lint being a pain, so...
-        y = y
-        EventName = Events.pop(0)
-        EventID = EventsID.pop(0)
+    if ActualEvents != 0:
+        for y in range(0, ActualEvents, 1):
+            # lint being a pain, so...
+            y = y
+            EventName = Events.pop(0)
+            EventID = EventsID.pop(0)
 
+            Value = schema.Option(
+                display = EventName,
+                value = EventID,
+            )
+
+            TournamentOptions.append(Value)
+
+        # if there are no tournaments on then put that in the dropdown
+    else:
         Value = schema.Option(
-            display = EventName,
-            value = EventID,
+            display = "No active events",
+            value = "1",
         )
 
         TournamentOptions.append(Value)


### PR DESCRIPTION
# Description
Using different field in API to capture a completed match. This covers a normal win and a retirement 
Added handling for when no tournaments are being played - display "No active events" in the dropdown


# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4b43c43</samp>

### Summary
🎾🛠️🆕

<!--
1.  🎾 - This emoji represents the sport of tennis and the main topic of the app, so it can be used to indicate any general improvement or enhancement to the app's functionality or appearance.
2.  🛠️ - This emoji represents a tool or a fix, so it can be used to indicate the improved reliability and criterion for completed matches, which are bug fixes or performance improvements that make the app more accurate and stable.
3.  🆕 - This emoji represents something new or updated, so it can be used to indicate the handling of the case of no active events and the addition of a version comment, which are new features or information that make the app more user-friendly and informative.
-->
Improved `wtatennis` app by fixing match logic, handling empty events, and adding version comment.

> _Oh we're the crew of the `wtatennis` app_
> _And we work hard to make it better_
> _We use a smarter way to check the match stats_
> _And we handle the no-event setter_

### Walkthrough
*  Add comment with version and update features ([link](https://github.com/tidbyt/community/pull/1328/files?diff=unified&w=0#diff-bacac371ef4450963bfae6cc2618e0ce8278c5d02f808e88e0cff7243efed67dR9-R12))
*  Use "post" state to identify completed matches instead of "Final" description ([link](https://github.com/tidbyt/community/pull/1328/files?diff=unified&w=0#diff-bacac371ef4450963bfae6cc2618e0ce8278c5d02f808e88e0cff7243efed67dL101-R106))
*  Handle empty events list and display message when no tournaments are on ([link](https://github.com/tidbyt/community/pull/1328/files?diff=unified&w=0#diff-bacac371ef4450963bfae6cc2618e0ce8278c5d02f808e88e0cff7243efed67dL528-R550))


