### PR TITLE
craftnft-app : fix off by one error

### DIFF
--- a/apps/craftnft/craftnft.star
+++ b/apps/craftnft/craftnft.star
@@ -93,7 +93,7 @@ def fetch_random_nft(address):
     random.seed(time.now().unix)  # // 15)
     key_list = image_dict.keys()
     cur_url = ""
-    for i in range(len(key_list) - 1):
+    for i in range(len(key_list)):
         print(str(i))
         num = random.number(0, len(key_list) - 1)
         print("picking #" + str(num + 1) + " of " + str(len(key_list)))


### PR DESCRIPTION
# Description
Silly error that only noticeably effected a user with only 1 nft in their wallet but still.
# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5e71c7c</samp>

### Summary
🐛🎨🎲

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the pull request.
2.  🎨 - This emoji represents an improvement to the UI or UX of the app, which is the result of the bug fix. The app now displays all the available NFT images instead of skipping some of them.
3.  🎲 - This emoji represents randomness or chance, which is the mechanism used to select the `cur_url` variable from the `key_list`. The app uses a random number generator to pick a different image every time the app runs.
-->
Fixed a bug in the `craftnft` app that prevented some NFT images from being displayed. Modified the for loop in `apps/craftnft/craftnft.star` to include the last element of the `key_list`.

> _`key_list` expands_
> _all NFTs can be chosen_
> _winter of the bug_

### Walkthrough
* Fix bug that prevented some NFT images from displaying on the device by iterating over the entire key list in the for loop ([link](https://github.com/tidbyt/community/pull/1341/files?diff=unified&w=0#diff-c72bd607076c590a63af074ed24507b18b6df75c07ad5b2224114c3c474f56c0L96-R96))


