### PR TITLE
New App: RestDbIoDashboard

### DIFF
--- a/apps/restdbiodashboard/manifest.yaml
+++ b/apps/restdbiodashboard/manifest.yaml
@@ -1,0 +1,8 @@
+---
+id: restdbiodashboard
+name: RestDbIoDashboard
+summary: Restdb.io dashboard
+desc: Generic dashboard based on a restdb.io database. Head to https://restdb.io/docs/quick-start and create a new database with this snapp key 17920b10cb9b7d23e59850c35e14d47d.
+author: romerod
+fileName: restdbiodashboard.star
+packageName: restdbiodashboard

--- a/apps/restdbiodashboard/restdbiodashboard.star
+++ b/apps/restdbiodashboard/restdbiodashboard.star
@@ -53,6 +53,7 @@ def main(config):
     icons = dict()
 
     db_name = config.str("db_name")
+    table_name = config.str("table_name")
     vertical_layout = config.bool("vertical")
     api_key = config.str("api_key")
     offline_page = config.str("offline_page")
@@ -74,7 +75,7 @@ def main(config):
 
     if not use_offline_data:
         rep = http.get(
-            "https://{}.restdb.io/rest/home?max=3&q={{%22visible%22:true}}&sort=order".format(db_name),
+            "https://{}.restdb.io/rest/{}?max=3&q={{%22visible%22:true}}&sort=order".format(db_name, table_name),
             headers = {
                 "Accept": "application/json",
                 "x-apikey": api_key,
@@ -193,6 +194,13 @@ def get_schema():
                 name = "Database name",
                 desc = "The name of the database on restdb.io",
                 icon = "database",
+            ),
+            schema.Text(
+                id = "table_name",
+                name = "Table name",
+                desc = "The name of the table on restdb.io",
+                icon = "table",
+                default = "home"
             ),
             schema.Text(
                 id = "api_key",

--- a/apps/restdbiodashboard/restdbiodashboard.star
+++ b/apps/restdbiodashboard/restdbiodashboard.star
@@ -1,0 +1,200 @@
+"""
+Applet: RestDbIoDashboard
+Summary: Restdb.io dashboard
+Description: Generic dashboard based on a restdb.io database.
+Author: romerod
+"""
+
+load("cache.star", "cache")
+load("encoding/base64.star", "base64")
+load("encoding/json.star", "json")
+load("http.star", "http")
+load("render.star", "render")
+load("schema.star", "schema")
+
+TTL_ICONS = 216000
+
+def render_fail(rep):
+    return render.Root(render.Box(render.WrappedText("%s" % rep.status_code), color = "#AA0000"))
+
+def get_col(text, subtext, coltext, colsubtext, icon):
+    return render.Column(
+        cross_align = "center",
+        main_align = "space_evenly",
+        expanded = True,
+        children = [
+            render.Image(src = icon, height = 15),
+            render.Column(
+                cross_align = "center",
+                children = [
+                    render.Text(text, color = coltext),
+                    render.Text(subtext, color = colsubtext),
+                ],
+            ),
+        ],
+    )
+
+def get_row(text, subtext, coltext, colsubtext, icon):
+    return render.Row(
+        expanded = True,
+        cross_align = "center",
+        main_align = "left",
+        children = [
+            render.Padding(pad = (2, 0, 0, 0), child = render.Image(src = icon, height = 10, width = 10)),
+            render.Padding(pad = (2, 1, 0, 0), child = render.Text(text, color = coltext)),
+            render.Padding(pad = (2, 1, 0, 0), child = render.Text(subtext, color = colsubtext)),
+        ],
+    )
+
+def main(config):
+    icons = dict()
+
+    db_name = config.get("db_name")
+
+    if not db_name:
+        return []
+
+    db_name = "%s" % db_name
+    api_key = "%s" % config.get("api_key")
+
+    if config.bool("reset_icon_cache"):
+        return reset_icon_cache(db_name, api_key)
+
+    rep = http.get(
+        "https://{}.restdb.io/rest/home?max=3&q={{%22visible%22:true}}&sort=order".format(db_name),
+        headers = {
+            "Accept": "application/json",
+            "x-apikey": api_key,
+        },
+    )
+
+    if rep.status_code != 200:
+        print(rep.body())
+        return render_fail(rep)
+
+    items = json.decode(rep.body())
+
+    icons_to_load = list()
+
+    for item in items:
+        icon_cache_key = "{}-icon-{}".format(db_name, item["icon"])
+        icon = cache.get(icon_cache_key)
+        if not icon:
+            icons_to_load.insert(-1, item["icon"])
+        else:
+            icons.update([(item["icon"], icon)])
+
+    if len(icons_to_load) > 0:
+        fail = load_icons(icons_to_load, icons, db_name, api_key)
+        if fail:
+            return fail
+
+    for name in icons:
+        icon_cache_key = "{}-icon-{}".format(db_name, name)
+        cache.set(icon_cache_key, icons[name], ttl_seconds = TTL_ICONS)
+
+    if len(items) == 0:
+        return []
+
+    if config.bool("vertical"):
+        rows = list()
+        for item in items:
+            rows.append(get_row(item["text"], item["subtext"], item["colortext"], item["colorsubtext"], base64.decode(icons.get(item["icon"]))))
+
+        return render.Root(child =
+                               render.Column(
+                                   children = rows,
+                                   main_align = "space_around",
+                                   cross_align = "center",
+                                   expanded = True,
+                               ))
+
+    columns = list()
+    for item in items:
+        columns.append(get_col(item["text"], item["subtext"], item["colortext"], item["colorsubtext"], base64.decode(icons.get(item["icon"]))))
+
+    return render.Root(
+        child = render.Row(
+            expanded = True,
+            main_align = "space_evenly",
+            children = columns,
+        ),
+    )
+
+def reset_icon_cache(db_name, api_key):
+    load_icon_names = 'https://{}.restdb.io/rest/icons?&h={{"$fields":{{"name":1}}}}'
+    load_icon_names = load_icon_names.format(db_name)
+
+    rep = http.get(
+        load_icon_names,
+        headers = {
+            "Accept": "application/json",
+            "x-apikey": api_key,
+        },
+    )
+
+    if rep.status_code != 200:
+        print(rep.body())
+        return render_fail(rep)
+
+    for icon in json.decode(rep.body()):
+        icon_cache_key = "{}-icon-{}".format(db_name, icon["name"])
+        cache.set(icon_cache_key, "", ttl_seconds = TTL_ICONS)
+
+    return render.Root(render.Box(render.WrappedText("icon cache reset"), color = "#FFA500"))
+
+def load_icons(icons_to_load, icons, db_name, api_key):
+    load_icon_url = 'https://{}.restdb.io/rest/icons?q={{"name":{{"$in":{}}}}}'
+    load_icon_url = load_icon_url.format(db_name, json.encode(icons_to_load))
+
+    rep = http.get(
+        load_icon_url,
+        headers = {
+            "Accept": "application/json",
+            "x-apikey": api_key,
+        },
+    )
+
+    if rep.status_code != 200:
+        print(rep.body())
+        return render_fail(rep)
+
+    print("loaded icons")
+
+    for icon in json.decode(rep.body()):
+        icons.update([(icon["name"], icon["data"])])
+
+    return None
+
+def get_schema():
+    return schema.Schema(
+        version = "1",
+        fields = [
+            schema.Text(
+                id = "db_name",
+                name = "Database name",
+                desc = "The name of the database on restdb.io",
+                icon = "database",
+            ),
+            schema.Text(
+                id = "api_key",
+                name = "API key",
+                desc = "The API key to access restdb.io (read only is enough)",
+                icon = "user",
+            ),
+            schema.Toggle(
+                id = "vertical",
+                name = "Vertical layout?",
+                desc = "Show lines instead of columns",
+                icon = "gripLines",
+                default = False,
+            ),
+            schema.Toggle(
+                id = "reset_icon_cache",
+                name = "Reset icon caching",
+                desc = "If the script fails due to a badly encoded icon or you change want to change an image, use this to clear the cache",
+                icon = "trash",
+                default = False,
+            ),
+        ],
+    )

--- a/apps/restdbiodashboard/restdbiodashboard.star
+++ b/apps/restdbiodashboard/restdbiodashboard.star
@@ -200,7 +200,7 @@ def get_schema():
                 name = "Table name",
                 desc = "The name of the table on restdb.io",
                 icon = "table",
-                default = "home"
+                default = "home",
             ),
             schema.Text(
                 id = "api_key",

--- a/apps/restdbiodashboard/restdbiodashboard.star
+++ b/apps/restdbiodashboard/restdbiodashboard.star
@@ -63,11 +63,11 @@ def main(config):
     if not db_name:
         use_offline_data = True
         db_name = "offline"
-        vertical_layout = True
         print("using offline data")
         if not offline_page:
             offline_page = DEMO_PAGE
             offline_icons = DEMO_ICONS
+            vertical_layout = True
 
     if config.bool("reset_icon_cache") and not use_offline_data:
         return reset_icon_cache(db_name, api_key)


### PR DESCRIPTION
# Description
An application to show a generic dashboard with icons, text and subtext with different colors.

Data and icons are fetched from any database at restdb.io. Icons are cached to lower traffic.

From a database as simple as the following:
![image](https://user-images.githubusercontent.com/3213790/233648130-2fae5355-01b8-4329-b163-1555240541f2.png)
a vertical or horizonal dashboard is created:
![restdbiodashboard](https://user-images.githubusercontent.com/3213790/233648273-945ed388-91b1-412d-83ff-c58a3cb86690.gif)
![restdbiodashboard_vertical](https://user-images.githubusercontent.com/3213790/233648293-d4c6320b-7323-4b73-bada-c80511e67072.gif)


# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 049f44d</samp>

### Summary
📄📊🗄️

<!--
1.  📄 for adding a manifest file
2.  📊 for creating a dashboard applet
3.  🗄️ for using a restdb.io database
-->
This pull request adds a new applet called RestDbIoDashboard, which shows data from a restdb.io database on the tidbyt device. It includes a `manifest.yaml` file with the applet metadata and a `restdbiodashboard.star` file with the applet logic and configuration schema. The applet can display text and icons in different layouts and cache the icons for faster rendering.

> _`RestDbIoDashboard`_
> _A generic applet for tidbyt_
> _Spring data in bloom_

### Walkthrough
* Create and register a new applet for displaying restdb.io dashboards ([link](https://github.com/tidbyt/community/pull/1356/files?diff=unified&w=0#diff-62978f8a4a3a1dd5433e9193f0a8e61ef6cf3a7928ff41c549ec7941069504d0R1-R8), [link](https://github.com/tidbyt/community/pull/1356/files?diff=unified&w=0#diff-351fab91346ef43c9afcc919abdd2f77042a21f5fa93e9f1730d819560ae2befR1-R200))
  - Add a `manifest.yaml` file with applet metadata and configuration schema ([link](https://github.com/tidbyt/community/pull/1356/files?diff=unified&w=0#diff-62978f8a4a3a1dd5433e9193f0a8e61ef6cf3a7928ff41c549ec7941069504d0R1-R8))
  - Add a `restdbiodashboard.star` file with the main applet logic and rendering ([link](https://github.com/tidbyt/community/pull/1356/files?diff=unified&w=0#diff-351fab91346ef43c9afcc919abdd2f77042a21f5fa93e9f1730d819560ae2befR1-R200))


