### PR TITLE
yahoofantasyfootball: swap client secret and id

### DIFF
--- a/apps/yahoofantasyfootball/yahoofantasynfl.star
+++ b/apps/yahoofantasyfootball/yahoofantasynfl.star
@@ -17,8 +17,8 @@ load("xpath.star", "xpath")
 #TIDBYT_OAUTH_CALLBACK_URL = "https%3A%2F%2Flocalhost%2Foauth-callback"  # registered https://localhost/oauth-callback as redirect_uri at Yahoo
 TIDBYT_OAUTH_CALLBACK_URL = "https%3A%2F%2Fappauth.tidbyt.com%2Fyahoofantasynfl"
 
-YAHOO_CLIENT_ID = secret.decrypt("AV6+xWcEYFqiuL0ikmBqRskRbczq0U9oQlXXeeF5sQxNVAeVbkVgpV8dRGt2/idNEmnbcoSwSK5w/EeRf0tDpMH2//7c98Gwr4REc1P2wsdXLfmkxAu+2NujiMKrAc8uPq2DaxKKOg+up9XXEXJzFch2dSLXeCA0M4VPNnfiPQPljTXlLRkeP9u+IOalmw==") or ""
-YAHOO_CLIENT_SECRET = secret.decrypt("AV6+xWcEImWJue0AdaZn2Vv6NpO6eDNO46/s99T+iff9gdGx4Jp7+BVTEaPgA4BD5oNd2qc1DVhrmL+X7ndO2YS18LnkEYDYQMKthvJMBT5Dln5zq8dG9j7XyV55pHV7ZGUdCM5odPNqXLAwjcM1MUn+GNN6sd3DBJPFtTIfwn7t9UFxTa4R8/WJc47DaHglR0Q9XZYiB0VQnlgo112HUkzLpquTFqpOc/cH62O/UZAeGNKRkAZc1XJ1fyhsGRoJG6fD5Uw8") or ""
+YAHOO_CLIENT_ID = secret.decrypt("AV6+xWcEImWJue0AdaZn2Vv6NpO6eDNO46/s99T+iff9gdGx4Jp7+BVTEaPgA4BD5oNd2qc1DVhrmL+X7ndO2YS18LnkEYDYQMKthvJMBT5Dln5zq8dG9j7XyV55pHV7ZGUdCM5odPNqXLAwjcM1MUn+GNN6sd3DBJPFtTIfwn7t9UFxTa4R8/WJc47DaHglR0Q9XZYiB0VQnlgo112HUkzLpquTFqpOc/cH62O/UZAeGNKRkAZc1XJ1fyhsGRoJG6fD5Uw8") or ""
+YAHOO_CLIENT_SECRET = secret.decrypt("AV6+xWcEYFqiuL0ikmBqRskRbczq0U9oQlXXeeF5sQxNVAeVbkVgpV8dRGt2/idNEmnbcoSwSK5w/EeRf0tDpMH2//7c98Gwr4REc1P2wsdXLfmkxAu+2NujiMKrAc8uPq2DaxKKOg+up9XXEXJzFch2dSLXeCA0M4VPNnfiPQPljTXlLRkeP9u+IOalmw==") or ""
 YAHOO_CLIENT_ID_AND_SECRET_BASE_64 = base64.encode(YAHOO_CLIENT_ID + ":" + YAHOO_CLIENT_SECRET)
 YAHOO_OAUTH_AUTHORIZATION_URL = "https://api.login.yahoo.com/oauth2/request_auth"
 YAHOO_OAUTH_TOKEN_URL = "https://api.login.yahoo.com/oauth2/get_token"


### PR DESCRIPTION
# Description
Replace this with a description of your changes.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4c59937</samp>

### Summary
🔐🏈🛠️

<!--
1.  🔐 - This emoji represents the encryption and authentication aspects of the change, as well as the security fix that was applied.
2.  🏈 - This emoji represents the Yahoo Fantasy Football app and the domain of the change, as well as the fun and excitement of the game.
3.  🛠️ - This emoji represents the bug fix and the improvement of the app functionality, as well as the work and effort that went into the change.
-->
This change corrects the authentication credentials for the Yahoo Fantasy Football app by swapping the values of `YAHOO_CLIENT_ID` and `YAHOO_CLIENT_SECRET` in `yahoofantasynfl.star`.

> _Yahoo Fantasy app_
> _`CLIENT_ID` and `SECRET`_
> _swapped in the fall_

### Walkthrough
*  Swap the values of `YAHOO_CLIENT_ID` and `YAHOO_CLIENT_SECRET` to fix authentication errors ([link](https://github.com/tidbyt/community/pull/1364/files?diff=unified&w=0#diff-75f335a8c54fe7a16c95482fc222e6c295eaab813305fb16ecf5dc7d62809fecL20-R21))


