### PR TITLE
yahoofantasynfl: reencrypted creds. again...

### DIFF
--- a/apps/yahoofantasyfootball/yahoofantasynfl.star
+++ b/apps/yahoofantasyfootball/yahoofantasynfl.star
@@ -17,8 +17,8 @@ load("xpath.star", "xpath")
 #TIDBYT_OAUTH_CALLBACK_URL = "https%3A%2F%2Flocalhost%2Foauth-callback"  # registered https://localhost/oauth-callback as redirect_uri at Yahoo
 TIDBYT_OAUTH_CALLBACK_URL = "https%3A%2F%2Fappauth.tidbyt.com%2Fyahoofantasynfl"
 
-YAHOO_CLIENT_ID = secret.decrypt("AV6+xWcEImWJue0AdaZn2Vv6NpO6eDNO46/s99T+iff9gdGx4Jp7+BVTEaPgA4BD5oNd2qc1DVhrmL+X7ndO2YS18LnkEYDYQMKthvJMBT5Dln5zq8dG9j7XyV55pHV7ZGUdCM5odPNqXLAwjcM1MUn+GNN6sd3DBJPFtTIfwn7t9UFxTa4R8/WJc47DaHglR0Q9XZYiB0VQnlgo112HUkzLpquTFqpOc/cH62O/UZAeGNKRkAZc1XJ1fyhsGRoJG6fD5Uw8") or ""
-YAHOO_CLIENT_SECRET = secret.decrypt("AV6+xWcEYFqiuL0ikmBqRskRbczq0U9oQlXXeeF5sQxNVAeVbkVgpV8dRGt2/idNEmnbcoSwSK5w/EeRf0tDpMH2//7c98Gwr4REc1P2wsdXLfmkxAu+2NujiMKrAc8uPq2DaxKKOg+up9XXEXJzFch2dSLXeCA0M4VPNnfiPQPljTXlLRkeP9u+IOalmw==") or ""
+YAHOO_CLIENT_ID = secret.decrypt("AV6+xWcESOzU0+vxd/pD9p6eJsSh+fkgPTLUMzJbnS00CHWXmoKWQbvmTpVIUUE3Y/J2LeplFDCPh3zEwpX0XEyHZubCkNlgu2CrTnGcGYRv4H7xOtS+BTwiEQUu40mgSarmMkxR/uo2BetzoVEctK3SkbEdVW5mZBJTPjoHZwfwPFhzXMyYKqO8EejDPYOg48beUv3MnNRx+nrtbtWf8Ip8Vj0riv9lceqgbGT5KiM5AgBNLSPHKyFwDLnj2R/3dhqyVBTR") or ""
+YAHOO_CLIENT_SECRET = secret.decrypt("AV6+xWcEUbzKOHZ63pL4mNLO8MGfmkVomrRiBERdm2WxRiPjMdymwN9lROH88N5pCfo5ZSUiNlOt9J3WeM9dUe1kGTPT6AykhXEXOXPjjqhVjKBGy3UOBDeYll33K6XxYiS06WP5Au6EBK6bc3gQd6+Y1h+zZyYL4NTzh2R4U/y1Xkj7sx/0wWQEmfhBww==") or ""
 YAHOO_CLIENT_ID_AND_SECRET_BASE_64 = base64.encode(YAHOO_CLIENT_ID + ":" + YAHOO_CLIENT_SECRET)
 YAHOO_OAUTH_AUTHORIZATION_URL = "https://api.login.yahoo.com/oauth2/request_auth"
 YAHOO_OAUTH_TOKEN_URL = "https://api.login.yahoo.com/oauth2/get_token"


### PR DESCRIPTION
# Description
Replace this with a description of your changes.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 58c990d</samp>

### Summary
🔒🔄🆗

<!--
1.  🔒 This emoji represents encryption or security, and can be used to indicate that the client ID and secret values were encrypted before being stored as environment variables.
2.  🔄 This emoji represents refresh or update, and can be used to indicate that the client ID and secret values were changed to new ones that are valid for the Yahoo Fantasy API.
3.  🆗 This emoji represents OK or success, and can be used to indicate that the authorization URL variable was unchanged and still works as expected.
-->
Updated the app's credentials for the Yahoo Fantasy API. Changed the `YAHOO_CLIENT_ID`, `YAHOO_CLIENT_SECRET`, and `YAHOO_CLIENT_ID_AND_SECRET_BASE_64` variables in `yahoofantasynfl.star`.

> _`YAHOO_CLIENT_ID`_
> _and secret, encrypted, changed_
> _autumn leaves renew_

### Walkthrough
* Refresh the Yahoo Fantasy API credentials and update the base 64 encoding ([link](https://github.com/tidbyt/community/pull/1365/files?diff=unified&w=0#diff-75f335a8c54fe7a16c95482fc222e6c295eaab813305fb16ecf5dc7d62809fecL20-R21),  )


