### PR TITLE
Add Dutch (Belgium) version to Dutch Fuzzy Clock

### DIFF
--- a/apps/dutchfuzzyclock/dutch_fuzzy_clock.star
+++ b/apps/dutchfuzzyclock/dutch_fuzzy_clock.star
@@ -51,6 +51,7 @@ numbersPerLang = {
     },
 }
 numbersPerLang["en-GB"] = numbersPerLang["en-US"]
+numbersPerLang["nl-BE"] = numbersPerLang["nl-NL"]
 
 wordsPerLang = {
     "nl-NL": {
@@ -58,6 +59,12 @@ wordsPerLang = {
         "half": "HALF",
         "to": "VOOR",
         "past": "OVER",
+    },
+    "nl-BE": {
+        "hour": "UUR",
+        "half": "HALF",
+        "to": "VOOR",
+        "past": "NA",
     },
     "en-US": {
         "hour": "O'CLOCK",
@@ -141,6 +148,10 @@ def get_schema():
         schema.Option(
             display = "Dutch",
             value = "nl-NL",
+        ),
+        schema.Option(
+            display = "Dutch (Belgium)",
+            value = "nl-BE",
         ),
         schema.Option(
             display = "American English",


### PR DESCRIPTION
# Description

This PR adds a Belgian Dutch variation to the Dutch Fuzzy Clock.

The main difference with the existing Dutch version is that we say `na` instead of `over`.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5bbf08c</samp>

### Summary
🇧🇪🕒🗣️

<!--
1.  🇧🇪 - This emoji represents Belgium, the country where the new language option is spoken. It can be used to indicate that the pull request adds a new localization or region-specific feature.
2. 🕒 - This emoji represents a clock, the main subject of the `dutch_fuzzy_clock` app. It can be used to indicate that the pull request modifies or improves the functionality or appearance of the clock app.
3. 🗣️ - This emoji represents a speaking mouth, which can symbolize language, communication, or translation. It can be used to indicate that the pull request adds or updates a language option or a word dictionary.
-->
This pull request adds a new feature to the `dutch_fuzzy_clock` app, which allows users to display the time in a fuzzy way using the Dutch language as spoken in Belgium. It does this by adding a new language option and a new word dictionary in the `apps/dutchfuzzyclock/dutch_fuzzy_clock.star` file.

> _`dutch_fuzzy_clock`_
> _now speaks Belgian Dutch too_
> _a winter update_

### Walkthrough
*  Add support for Dutch language in Belgium in `dutch_fuzzy_clock.star` ([link](https://github.com/tidbyt/community/pull/1367/files?diff=unified&w=0#diff-e57a2b8c81874208fc6516529d189a94cd5d259014dec356657fcce8cb11e909R54), [link](https://github.com/tidbyt/community/pull/1367/files?diff=unified&w=0#diff-e57a2b8c81874208fc6516529d189a94cd5d259014dec356657fcce8cb11e909R63-R68), [link](https://github.com/tidbyt/community/pull/1367/files?diff=unified&w=0#diff-e57a2b8c81874208fc6516529d189a94cd5d259014dec356657fcce8cb11e909R153-R156))


