### PR TITLE
Fixed Display Issues

### DIFF
--- a/apps/todoisttasks/todoisttasks.star
+++ b/apps/todoisttasks/todoisttasks.star
@@ -12,7 +12,6 @@ load("render.star", "render")
 load("schema.star", "schema")
 load("secret.star", "secret")
 
-TTL = 60 * 4
 DEFAULT_FILTER = "today | overdue"
 DEFAULT_SHOW_IF_EMPTY = True
 
@@ -26,6 +25,9 @@ OAUTH2_CLIENT_SECRET = secret.decrypt("AV6+xWcECKJKREuOP2zxW2vKM0jgROWMLwjR0Pyjs
 def main(config):
     token = config.get("auth") or config.get("dev_api_key")
     children = []
+    task_priority = []
+    content = ""
+    cache_key = ""
     circle_children = []  # Initialize circle_children here
 
     if token:
@@ -34,6 +36,7 @@ def main(config):
         cache_key = "%s/%s" % (token, filter)
         content = cache.get(cache_key)
         if not content:
+            print("Querying for tasks.")
             rep = http.get(TODOIST_URL, headers = {"Authorization": "Bearer %s" % token}, params = {"filter": filter})
             if rep.status_code == 200:
                 tasks = rep.json()
@@ -97,13 +100,44 @@ def main(config):
                         color = circle_colors[i],
                         child = render.Circle(color = "#332726", diameter = 2),
                     ))
-
-            cache.set(cache_key, json.encode(content), TTL)
+            print("Content before caching:", content)
+            cache.set(cache_key, json.encode(content), ttl_seconds = 60)
+            cache.set(cache_key + "_priority", json.encode(task_priority), ttl_seconds = 60)
 
         else:
             content = json.decode(content)
+            print("Content after decoding from cache:", content)
 
-        if (content == NO_TASKS_CONTENT and not config.bool("show")):
+    if content != NO_TASKS_CONTENT:
+        colors = ["#9b9b9b", "#48a9e6", "#f8b43a", "#ed786c"]
+
+        children = []
+        for i, task_desc in enumerate(content):
+            children.append(render.Marquee(
+                child = render.Text(content = task_desc),
+                offset_start = 2,
+                width = 46,
+            ))
+
+        # Retrieve task priorities from the cache
+        task_priority = cache.get(cache_key + "_priority")
+
+        if task_priority:
+            task_priority = json.decode(task_priority)
+
+            # Update circle colors based on the priority of the tasks
+            circle_colors = [colors[int(priority) - 1] for priority in task_priority]
+
+            # Generate circle children based on the number of tasks
+            circle_children = []
+            for i in range(len(content)):
+                circle_children.append(render.Circle(
+                    diameter = 6,
+                    color = circle_colors[i],
+                    child = render.Circle(color = "#332726", diameter = 2),
+                ))
+
+        if content == NO_TASKS_CONTENT and not config.bool("show"):
             # Don't display the app in the user's rotation
             return []
 


### PR DESCRIPTION
Content in cache wasn't being displayed, should be fixed now.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at dfdffda</samp>

### Summary
🌟📝🐛

<!--
1.  🌟 - This emoji can represent the addition of task priority, which is a feature that can help users prioritize their tasks and see them more clearly in the app.
2.  📝 - This emoji can represent the addition of task content, which is the actual text of the task that the user wants to accomplish. This can help users see more details about their tasks and avoid confusion.
3.  🐛 - This emoji can represent the removal of an unnecessary global variable and the addition of a print statement for debugging, which are both changes that can help fix bugs and improve the code quality of the app.
-->
This pull request enhances the `todoist_tasks` app by showing task priority with colored circles and adding more task details. It also refactors the code to use local variables and a cache key, and adds a debug print.

> _We are the todoist tasks, we have priority and content_
> _We don't need a global var, we have our own cache key_
> _We print our debug messages, we show our true colors_
> _We are the todoist tasks, we defy the doom of deadlines_

### Walkthrough
* Remove global cache expiration variable and pass it as an argument to `cache.set` ([link](https://github.com/tidbyt/community/pull/1371/files?diff=unified&w=0#diff-b4d897772b749cd6ae9c7a823f9f5281b673cff764e37f9ee33f505429d391abL15))
* Add variables for task priority, content, and cache key to `todoist_tasks` function ([link](https://github.com/tidbyt/community/pull/1371/files?diff=unified&w=0#diff-b4d897772b749cd6ae9c7a823f9f5281b673cff764e37f9ee33f505429d391abR28-R30))
* Print a message when querying the Todoist API for tasks ([link](https://github.com/tidbyt/community/pull/1371/files?diff=unified&w=0#diff-b4d897772b749cd6ae9c7a823f9f5281b673cff764e37f9ee33f505429d391abR39))
  - Using a dictionary to map priority levels to colors ([link](https://github.com/tidbyt/community/pull/1371/files?diff=unified&w=0#diff-b4d897772b749cd6ae9c7a823f9f5281b673cff764e37f9ee33f505429d391abL100-R140))


