### PR TITLE
SEPTA Transit bug fix release

### DIFF
--- a/apps/septatransit/manifest.yaml
+++ b/apps/septatransit/manifest.yaml
@@ -1,7 +1,7 @@
 ---
 id: septatransit
 name: SEPTA Transit
-summary: SEPTA transit departures
+summary: SEPTA Transit Departures
 desc: Displays departure times for SEPTA buses, trolleys, MFL/BSL, and NHSL in and around Philadelphia.
 author: radiocolin
 fileName: septatransit.star

--- a/apps/septatransit/septatransit.star
+++ b/apps/septatransit/septatransit.star
@@ -220,7 +220,7 @@ def main(config):
     schedule = get_schedule(route, stop)
     timezone = config.get("timezone") or "America/New_York"
     now = time.now().in_location(timezone)
-    left_pad = 1
+    left_pad = 4
 
     if config.bool("use_custom_banner_color"):
         route_bg_color = config.str("custom_banner_color")
@@ -239,8 +239,8 @@ def main(config):
 
     if config.bool("show_time"):
         banner_text = now.format("3:04p") + " " + banner_text
-        if now.format("3") not in ["10", "11", "12"]:
-            left_pad = 4
+        if now.format("3") in ["10", "11", "12"]:
+            left_pad = 0
 
     return render.Root(
         delay = 100,


### PR DESCRIPTION
# Description
This is a small bug fix release which changes the app "summary" to use title case, and fixes a padding bug regarding clock positioning.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a52b973</samp>

### Summary
📝🛠️🎨

<!--
1.  📝 - This emoji can be used to indicate that the summary of the app was edited or rewritten.
2.  🛠️ - This emoji can be used to indicate that the layout and alignment of the app elements were fixed or improved.
3.  🎨 - This emoji can be used to indicate that the appearance and style of the app were enhanced or refined.
-->
Improved the layout and summary of the `septatransit` app. Increased the padding and fixed the alignment of the text in `septatransit.star` and capitalized the summary in `manifest.yaml`.

> _Sing, O Muse, of the skillful coder who refined the app_
> _That shows the faithful travelers the swift and timely path_
> _Of SEPTA's chariots of steel, with `padding` and `align`_
> _He made the `time` and `banner` shine like stars in the night sky_

### Walkthrough
*  Capitalize app summary to match style ([link](https://github.com/tidbyt/community/pull/1377/files?diff=unified&w=0#diff-40c4ce2ec7288ca253dc7a5ab333dc471f35ca0683f6a39f5141a4fce7570319L4-R8))
*  Increase left pad variable to create more space between time and banner text ([link](https://github.com/tidbyt/community/pull/1377/files?diff=unified&w=0#diff-b1fdab8189161d4f11593fce619cf6d6ff03f6798efb8a651cbe1aba9632d6f9L223-R223))
*  Invert condition for adjusting left pad variable to align time and banner text properly ([link](https://github.com/tidbyt/community/pull/1377/files?diff=unified&w=0#diff-b1fdab8189161d4f11593fce619cf6d6ff03f6798efb8a651cbe1aba9632d6f9L242-R243))


