### PR TITLE
Corrected Previous Mistake

### DIFF
--- a/apps/mnmetrotransit/mn_metro_transit.star
+++ b/apps/mnmetrotransit/mn_metro_transit.star
@@ -189,12 +189,12 @@ def main(config):
         CT2 = "#222"
 
     elif route2 == "Gold":
-        CB = "#FB0"
-        CT = "#222"
+        CB2 = "#FB0"
+        CT2 = "#222"
 
     elif route2 == "Purple":
-        CB = "#A0C"
-        CT = "#222"
+        CB2 = "#A0C"
+        CT2 = "#222"
 
     if route2[2:7] == "Line":
         CB2 = "#FFF"


### PR DESCRIPTION
# Description
added four "2"s for the color blocks (CB -> CB2) that were missed in the last update adding the gold and purple lines

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 87842fd</samp>

### Summary
🚇🎨🔁

<!--
1.  🚇 This emoji represents the subway or metro, which is the mode of transportation that the second route uses. It also suggests that the second route is different from the first one, which uses a bus.
2.  🎨 This emoji represents the colors or palette that the user can choose for the second route's background and text. It also implies that the user has some customization options for the display.
3.  🔁 This emoji represents the loop or cycle that the tidbyt device goes through to show both routes alternately. It also indicates that the user can see both routes on the same device without having to switch manually.
-->
Renamed some variables in `mn_metro_transit.star` to fix a color bug for the second route.

> _`CB` and `CT`_
> _renamed for second route_
> _colors change in fall_

### Walkthrough
*  Rename variables `CB` and `CT` to `CB2` and `CT2` for the second route colors ([link](https://github.com/tidbyt/community/pull/1386/files?diff=unified&w=0#diff-624266226ea28008d23630d452f7c973118b3d7c0a56a26c11a06bc11c21d8c5L192-R197))


