### PR TITLE
Updated user-input handling from the Tidbyt Schema

### DIFF
--- a/apps/wordlebyt/wordlebyt.star
+++ b/apps/wordlebyt/wordlebyt.star
@@ -28,9 +28,14 @@ def main(config):
 
     shared_text = config.get("wordle_score", "Paste Your Wordle⬛⬛🟩⬛⬛⬛⬛⬛🟩⬛🟩🟩🟩🟩🟩⬛⬛⬛🟩⬛⬛⬛🟩⬛⬛")
 
-    if len(shared_text.rstrip("⬛🟩🟨").split()) > 3:
-        score_text = shared_text.rstrip("⬛🟩🟨").split()
+    #Take shared text (that the user pasted into the Wordlebyt Schema field) and remove all the boxes)
+    score_text=re.sub(r"[⬛🟩🟨]", "", shared_text)
 
+    #Check that "score_text" has 3 elements: The Wordle Title, The Game Number, and the Number of Guesses
+    if len(score_text.split()) >= 3:
+        score_text = score_text.split()
+
+    #If it doesn't, prefil the score_text with canned text to make the app happy
     else:
         score_text = ["Paste", "Your", "Wordle"]
 

--- a/apps/wordlebyt/wordlebyt.star
+++ b/apps/wordlebyt/wordlebyt.star
@@ -5,6 +5,7 @@ Description: Display your daily Wordle score on your Tidbyt.
 Author: skola28
 """
 
+load("re.star", "re")
 load("render.star", "render")
 load("schema.star", "schema")
 
@@ -16,39 +17,45 @@ def draw_box(color):
         child = render.Box(width = 4, height = 4, color = color),
     )
 
-#Constants
-#EXAMPLETWEET = "Paste Your Wordle\n\n⬛⬛🟩⬛⬛\n⬛⬛⬛🟩⬛\n🟩🟩🟩🟩🟩\n⬛⬛⬛🟩⬛\n⬛⬛🟩⬛⬛"
-#EXAMPLETWEET2 = "Wordle 383 4/6  ⬛⬛🟩⬛⬛ 🟨⬛🟩⬛🟩 🟩🟨🟩⬛🟩 🟩🟩🟩🟩🟩"
-
 def main(config):
     """Intent is to take your Wordle Score and have it display on your Tidbyt"""
 
-    board = str(config.get("wordle_score", "Paste Your Wordle\n\n⬛⬛🟩⬛⬛\n⬛⬛⬛🟩⬛\n🟩🟩🟩🟩🟩\n⬛⬛⬛🟩⬛\n⬛⬛🟩⬛⬛")).replace("\\n", "\n").split()
+    #Constants
+    #EXAMPLETWEET = "Paste Your Wordle\n\n⬛⬛🟩⬛⬛\n⬛⬛⬛🟩⬛\n🟩🟩🟩🟩🟩\n⬛⬛⬛🟩⬛\n⬛⬛🟩⬛⬛"
+    #EXAMPLETWEET2 = "Wordle 383 4/6  ⬛⬛🟩⬛⬛ 🟨⬛🟩⬛🟩 🟩🟨🟩⬛🟩 🟩🟩🟩🟩🟩"
+    #board = str(config.get("wordle_score", "Paste Your Wordle\n\n⬛⬛🟩⬛⬛\n⬛⬛⬛🟩⬛\n🟩🟩🟩🟩🟩\n⬛⬛⬛🟩⬛\n⬛⬛🟩⬛⬛")).replace("\\n", "\n").split()
+    #Original Board Print = ["Paste", "Your", "Wordle", "⬛⬛🟩⬛⬛", "⬛⬛⬛🟩⬛", "🟩🟩🟩🟩🟩", "⬛⬛⬛🟩⬛", "⬛⬛🟩⬛⬛"]
 
-    #To avoid errors, check that the board is at least 3 elements long (Worldle-Title, Wordle-Game-Number, Guesses)
-    if len(board) > 3:
-        #Break the Latest Tweet into usable pieces
-        #POP off the Wordle Title Text from the First Element
-        wordle_title = board.pop(0)
+    shared_text = config.get("wordle_score", "Paste Your Wordle⬛⬛🟩⬛⬛⬛⬛⬛🟩⬛🟩🟩🟩🟩🟩⬛⬛⬛🟩⬛⬛⬛🟩⬛⬛")
 
-        #POP off the Wordle Game Number from the New First Element
-        wordle_number = board.pop(0)
+    if len(shared_text.rstrip("⬛🟩🟨").split()) > 3:
+        score_text = shared_text.rstrip("⬛🟩🟨").split()
 
-        #Pop off the Wordle Score Numeric from the New First Element(again!)
-        wordle_score_number = board.pop(0)
-
-        #If not 3 elements long, fill with static, valid text
     else:
-        wordle_title = "Paste"
+        score_text = ["Paste", "Your", "Wordle"]
 
-        #POP off the Wordle Game Number from the New First Element
-        wordle_number = "Your"
+    #Next, take shared_text (that the user pasted into the Wordlebyt Schema field) and remove everything except the boxes...
+    boxes_text = re.sub(r"[^⬛🟩🟨]", "", shared_text)
 
-        #Pop off the Wordle Score Numeric from the New First Element(again!)
-        wordle_score_number = "Wordle"
+    #count the number of boxex....
+    number_of_boxes = boxes_text.count("⬛") + boxes_text.count("🟩") + boxes_text.count("🟨")
 
-    #Set the number of total guesses from what remains of board
-    number_of_guesses = len(board)
+    #Make sure that the board has between 30 and 5 total boxes since max guesses is 6 with 5 boxes per guess which comes out to 30.  5 is the least as that is a single guess.
+    #Also makes sure that the total number of boxes is divisible by 5.  Otherwise, you clearly have a bad input as only full guesses are allowed.
+    if 5 <= number_of_boxes and number_of_boxes <= 30 and number_of_boxes % 5 == 0:
+        #Make a list of boxes by looking for groups of five and generating a list.
+        boxes_list = re.findall(".....", boxes_text)
+    else:
+        #Since the user input failed error handling above, prefill some data into the necessary variables to allow the program to continue gracefully
+        boxes_list = ("⬛⬛🟩⬛⬛", "⬛⬛⬛🟩⬛", "🟩🟩🟩🟩🟩", "⬛⬛⬛🟩⬛", "⬛⬛🟩⬛⬛")
+
+    #Fill the Text Variables out of elements of score_text
+    wordle_title = score_text[0]
+    wordle_number = score_text[1]
+    wordle_score_number = score_text[2]
+
+    #Set the number of total guesses from elements in boxes_list
+    number_of_guesses = len(boxes_list)
 
     #Creating board_as_list with Each Entry from board broken into individual squares
     #Ex: print(board_as_list)
@@ -57,7 +64,7 @@ def main(config):
     # ["⬛", "⬛", "🟨", "🟨", "🟨"],
     # ["🟩", "🟩", "🟩", "🟩", "🟩"]]
 
-    board_as_list = [list(row.codepoints()) for row in board]
+    board_as_list = [list(row.codepoints()) for row in boxes_list]
 
     #Dictionary for Colors
     colordictionary = {
@@ -110,7 +117,7 @@ def get_schema():
                 name = "Wordle Score",
                 desc = "Paste your Wordle Score from the Wordle App",
                 icon = "paste",
-                default = "Paste Your Wordle\n\n⬛⬛🟩⬛⬛\n⬛⬛⬛🟩⬛\n🟩🟩🟩🟩🟩\n⬛⬛⬛🟩⬛\n⬛⬛🟩⬛⬛",
+                default = "Paste Your Wordle⬛⬛🟩⬛⬛⬛⬛⬛🟩⬛🟩🟩🟩🟩🟩⬛⬛⬛🟩⬛⬛⬛🟩⬛⬛",
             ),
         ],
     )

--- a/apps/wordlebyt/wordlebyt.star
+++ b/apps/wordlebyt/wordlebyt.star
@@ -29,13 +29,13 @@ def main(config):
     shared_text = config.get("wordle_score", "Paste Your Wordle⬛⬛🟩⬛⬛⬛⬛⬛🟩⬛🟩🟩🟩🟩🟩⬛⬛⬛🟩⬛⬛⬛🟩⬛⬛")
 
     #Take shared text (that the user pasted into the Wordlebyt Schema field) and remove all the boxes)
-    score_text=re.sub(r"[⬛🟩🟨]", "", shared_text)
+    score_text = re.sub(r"[⬛🟩🟨]", "", shared_text)
 
     #Check that "score_text" has 3 elements: The Wordle Title, The Game Number, and the Number of Guesses
     if len(score_text.split()) >= 3:
         score_text = score_text.split()
 
-    #If it doesn't, prefil the score_text with canned text to make the app happy
+        #If it doesn't, prefil the score_text with canned text to make the app happy
     else:
         score_text = ["Paste", "Your", "Wordle"]
 


### PR DESCRIPTION
# Description
The server-side schema handles /n (and likely other /characters!) differently from the local pixlet serve schema emulation.  As such, some error handling needed to be added to account for the server-side schema stripping out all of the /n.  The previous code relied on the /n characters for knowing where to create new lines in the game board.

The new version simply counts the boxes and divides by 5.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2e63d7b</samp>

### Summary
🧹🧠🔄

<!--
1.  🧹 This emoji conveys the idea of cleaning or tidying up, which is what refactoring does to the code. It also suggests improving the quality and readability of the code, which is another benefit of refactoring.
2.  🧠 This emoji conveys the idea of intelligence or logic, which is what regex uses to parse the user input. It also suggests that the code is more robust and flexible, as it can handle different formats and cases of the user input.
3.  🔄 This emoji conveys the idea of updating or changing, which is what the variable names and default value do to reflect the new logic. It also suggests that the code is more consistent and coherent, as it uses the same naming convention and value range throughout.
-->
Refactored the `wordle_score` config parameter in the `wordlebyt` app to use regex and improve input validation. Changed variable names and default value to match the new logic. Updated the code in `apps/wordlebyt/wordlebyt.star`.

> _`wordle_score` changed_
> _regex parses input well_
> _autumn of refactoring_

### Walkthrough
*  Refactor the parsing of the user input for the Wordle score using regex and error handling ([link](https://github.com/tidbyt/community/pull/1395/files?diff=unified&w=0#diff-fcc27b1c17c37b6ad5be68f56ff4086eee89fcc5807ad92e05394b13e5bf587dR8), [link](https://github.com/tidbyt/community/pull/1395/files?diff=unified&w=0#diff-fcc27b1c17c37b6ad5be68f56ff4086eee89fcc5807ad92e05394b13e5bf587dL19-R59), [link](https://github.com/tidbyt/community/pull/1395/files?diff=unified&w=0#diff-fcc27b1c17c37b6ad5be68f56ff4086eee89fcc5807ad92e05394b13e5bf587dL60-R67), [link](https://github.com/tidbyt/community/pull/1395/files?diff=unified&w=0#diff-fcc27b1c17c37b6ad5be68f56ff4086eee89fcc5807ad92e05394b13e5bf587dL113-R120))
  * Import the `re` module to enable regex functions in `wordlebyt.star` ([link](https://github.com/tidbyt/community/pull/1395/files?diff=unified&w=0#diff-fcc27b1c17c37b6ad5be68f56ff4086eee89fcc5807ad92e05394b13e5bf587dR8))
  * Rewrite the `get_text_and_boxes` function to remove non-box characters and find groups of five boxes from the input ([link](https://github.com/tidbyt/community/pull/1395/files?diff=unified&w=0#diff-fcc27b1c17c37b6ad5be68f56ff4086eee89fcc5807ad92e05394b13e5bf587dL19-R59))
  * Update the variable name `board` to `boxes_list` to reflect the new logic ([link](https://github.com/tidbyt/community/pull/1395/files?diff=unified&w=0#diff-fcc27b1c17c37b6ad5be68f56ff4086eee89fcc5807ad92e05394b13e5bf587dL60-R67))
  * Update the default value for the `wordle_score` config parameter to match the new input format ([link](https://github.com/tidbyt/community/pull/1395/files?diff=unified&w=0#diff-fcc27b1c17c37b6ad5be68f56ff4086eee89fcc5807ad92e05394b13e5bf587dL113-R120))


