### PR TITLE
Coingecko decimal display fix

### DIFF
--- a/apps/coingeckoprice/coingecko_price.star
+++ b/apps/coingeckoprice/coingecko_price.star
@@ -280,8 +280,12 @@ def format_price_string(currency_price, currency_symbol, currency_symbol_setting
     currency_price_integer = str(int(math.round(float(currency_price))))
 
     # Trim and format price
-    if len(currency_price_integer) <= 1:
-        currency_price = str(int(math.round(currency_price * 1000)))
+    if currency_price < 0.001:
+        # values is a small decimal, display in sci notation
+        #print("displaying in sci notation")
+        currency_price = str(currency_price)
+
+    elif len(currency_price_integer) <= 1:        currency_price = str(int(math.round(currency_price * 1000)))
         if len(currency_price) < 4:
             currency_price = "0" + currency_price
         if len(currency_price) < 4:

--- a/apps/coingeckoprice/coingecko_price.star
+++ b/apps/coingeckoprice/coingecko_price.star
@@ -285,7 +285,8 @@ def format_price_string(currency_price, currency_symbol, currency_symbol_setting
         #print("displaying in sci notation")
         currency_price = str(currency_price)
 
-    elif len(currency_price_integer) <= 1:        currency_price = str(int(math.round(currency_price * 1000)))
+    elif len(currency_price_integer) <= 1:
+        currency_price = str(int(math.round(currency_price * 1000)))
         if len(currency_price) < 4:
             currency_price = "0" + currency_price
         if len(currency_price) < 4:


### PR DESCRIPTION
# Description
coins with very low value less 0.0001 displayed as all zeros.  check for this and display as scientific notation instead.
@aschober 

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d5441a8</samp>

### Summary
:money_with_wings::mag::bulb:

<!--
1.  :money_with_wings: - This emoji represents money, currency, or finance, and can be used to indicate that the change is related to the coingecko price app, which shows the current prices of various cryptocurrencies.
2.  :mag: - This emoji represents a magnifying glass, or zooming in, and can be used to indicate that the change is related to displaying very small values more clearly and accurately, instead of trimming or rounding them off.
3.  :bulb: - This emoji represents a light bulb, or an idea, and can be used to indicate that the change is part of a pull request that aims to improve the coingecko price app for tidbyt, a smart display device that can show various apps and widgets.
-->
Improved the coingecko price app to handle very small currency values. Added a condition to display prices in scientific notation if they are less than 0.001 in `coingecko_price.star`.

> _`coingecko` app_
> _tiny prices need more care_
> _show them in winter_

### Walkthrough
*  Display currency price in scientific notation if less than 0.001 ([link](https://github.com/tidbyt/community/pull/1399/files?diff=unified&w=0#diff-2dd48b01d2499861721aab76a815d758827afb6cbbfd95da2aeb53c2e7867f0dL283-R288))


