### PR TITLE
Fix crash between 12:15 and 13:00

### DIFF
--- a/apps/dutchfuzzyclock/dutch_fuzzy_clock.star
+++ b/apps/dutchfuzzyclock/dutch_fuzzy_clock.star
@@ -107,6 +107,8 @@ def fuzzy_time(hours, minutes, language):
 
     # next 45 mins we already talk about the next hour
     hours += 1
+    if hours == 13:
+        hours = 1
 
     if rounded < 30:
         return [numbers[30 - rounded], words["to"] + " " + words["half"], numbers[hours]]

--- a/apps/dutchfuzzyclock/dutch_fuzzy_clock.star
+++ b/apps/dutchfuzzyclock/dutch_fuzzy_clock.star
@@ -106,9 +106,7 @@ def fuzzy_time(hours, minutes, language):
         return [numbers[rounded], words["past"], numbers[hours]]
 
     # next 45 mins we already talk about the next hour
-    hours += 1
-    if hours == 13:
-        hours = 1
+    hours = (hours + 1) % 12
 
     if rounded < 30:
         return [numbers[30 - rounded], words["to"] + " " + words["half"], numbers[hours]]


### PR DESCRIPTION
# Description

Between 12:15 and 13:00 the `hour + 1` was trying to reference a 13th hour which made the clock crash and remain fixed after 12:15 until 13:00 passed.

This will fix:

```
error running script: Traceback (most recent call last): apps/clock.star:91:24: in main apps/clock.star:75:85: in fuzzy_time Error: key 13 not in dict
```

<img width="975" alt="image" src="https://user-images.githubusercontent.com/194377/235415554-8f31ab40-4cd6-4425-a8a4-d8ede5586a0e.png">


# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 220a2a2</samp>

### Summary
🐛🕒🇳🇱

<!--
1.  🐛 - This emoji represents a bug, and can be used to indicate that the change fixes a bug or an error in the code.
2.  🕒 - This emoji represents a clock, and can be used to indicate that the change affects the time or date functionality of the code.
3.  🇳🇱 - This emoji represents the flag of the Netherlands, and can be used to indicate that the change is specific to the Dutch language or locale.
-->
Fixed a bug in `dutch_fuzzy_clock.star` that caused incorrect hour display in the afternoon. Changed the hours variable to use 12-hour format.

> _`hours` was too high_
> _bug made clock say dertien uur_
> _fixed with modulo_

### Walkthrough
* Fix bug where clock displays "dertien uur" instead of "een uur" in the afternoon by using 12-hour format for hours variable ([link](https://github.com/tidbyt/community/pull/1408/files?diff=unified&w=0#diff-e57a2b8c81874208fc6516529d189a94cd5d259014dec356657fcce8cb11e909R110-R111))


