### PR TITLE
Update: ATP & WTA Tennis

### DIFF
--- a/apps/atptennis/manifest.yaml
+++ b/apps/atptennis/manifest.yaml
@@ -2,7 +2,7 @@
 id: atp-tennis
 name: ATP Tennis
 summary: Shows ATP scores
-desc: Display tennis scores from a tournament chosen in the dropdown. Shows live matches and if selected, any match completed in the past 24 hours.
+desc: Display tennis scores from an ATP tournament chosen in the dropdown. Shows live matches and if selected, any match completed in the past 24 hours.
 author: M0ntyP
 fileName: atp_tennis.star
 packageName: atptennis

--- a/apps/wtatennis/wta_tennis.star
+++ b/apps/wtatennis/wta_tennis.star
@@ -18,6 +18,9 @@ Extended player surname field by 2 chars
 
 v1.2b
 Update title bar color to distinguish between WTA & ATP apps
+
+v1.3
+Sometimes the data feed will still show matches as "In Progress" after they have completed. Have added a 24hr limit so that if the start date is > 24 hrs ago then don't list the match
 """
 
 load("cache.star", "cache")
@@ -65,10 +68,16 @@ def main(config):
             if len(WTA_JSON["events"][x]) == 10:
                 for y in range(0, len(WTA_JSON["events"][x]["competitions"]), 1):
                     # if the match is "In Progress" and its a singles match, lets add it to the list of in progress matches
+                    # And the "In Progress" match started < 24 hrs ago , sometimes the data feed will still show matches as "In Progress" after they have completed
+                    # Adding a 24hr limit will remove them out of the list
                     if WTA_JSON["events"][x]["competitions"][y]["status"]["type"]["description"] == "In Progress":
                         if WTA_JSON["events"][x]["competitions"][y]["competitors"][0]["type"] == "athlete":
-                            InProgressMatchList.append(y)
-                            InProgress = InProgress + 1
+                            MatchTime = WTA_JSON["events"][EventIndex]["competitions"][y]["date"]
+                            MatchTime = time.parse_time(MatchTime, format = "2006-01-02T15:04Z").in_location(timezone)
+                            diff = MatchTime - now
+                            if diff.hours > -24:
+                                InProgressMatchList.append(y)
+                                InProgress = InProgress + 1
             else:
                 Display1.extend([
                     render.Column(


### PR DESCRIPTION
# Description
Sometimes the data feed will still show matches as "In Progress" after they have completed. Have added a 24hr limit so that if the match is over 24 hrs old then don't list it. We can assume its finished

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c097ab1</samp>

### Summary
🎾📝🕒

<!--
1.  🎾 - This emoji represents the sport of tennis and the topic of the apps that are being updated. It can be used to indicate that the changes are related to tennis scores or data.
2.  📝 - This emoji represents writing or editing text, such as the description of the app in the manifest.yaml file. It can be used to indicate that the changes are related to improving the clarity or accuracy of the app's information or documentation.
3.  🕒 - This emoji represents a clock or time, and can be used to indicate that the changes are related to filtering or displaying matches based on their duration or status. It can also suggest that the changes are intended to improve the timeliness or relevance of the app's data.
-->
This pull request improves the tennis apps for the tidbyt by filtering out stale matches and clarifying the app descriptions. It modifies `atp_tennis.star`, `wta_tennis.star`, and `atptennis/manifest.yaml`.

> _Sing, O Muse, of the skillful tidbyt makers, who craft the apps_
> _That show the glorious deeds of tennis players, swift and strong_
> _How they refined their code with care, and changed the manifest_
> _To clarify the scope of `atp_tennis.star`, the shining app_

### Walkthrough
*  Add a 24 hour limit to the in progress matches for both ATP and WTA tennis apps, to avoid showing outdated or incorrect data ([link](https://github.com/tidbyt/community/pull/1409/files?diff=unified&w=0#diff-2fe7726a8148e3fb23a64991e8b2661bd9c098395de1a2f1ea0092f21db623bcL64-R76), [link](https://github.com/tidbyt/community/pull/1409/files?diff=unified&w=0#diff-bacac371ef4450963bfae6cc2618e0ce8278c5d02f808e88e0cff7243efed67dR21-R23), [link](https://github.com/tidbyt/community/pull/1409/files?diff=unified&w=0#diff-bacac371ef4450963bfae6cc2618e0ce8278c5d02f808e88e0cff7243efed67dL68-R80))
*  Update the description of the `atp_tennis.star` app in the `manifest.yaml` file, to clarify that it only shows scores from the ATP tour ([link](https://github.com/tidbyt/community/pull/1409/files?diff=unified&w=0#diff-6967e64c8388b0664797ca0f6d7a906ee4791d3b6dfa3556dc3cc5c278eb722fL5-R5))
*  Change the TestID variable in the `atp_tennis.star` app, to use a different tournament ID for testing purposes ([link](https://github.com/tidbyt/community/pull/1409/files?diff=unified&w=0#diff-2fe7726a8148e3fb23a64991e8b2661bd9c098395de1a2f1ea0092f21db623bcL47-R50))
*  Add comments with the version number and ideas for future improvements to the `atp_tennis.star` and `wta_tennis.star` apps ([link](https://github.com/tidbyt/community/pull/1409/files?diff=unified&w=0#diff-2fe7726a8148e3fb23a64991e8b2661bd9c098395de1a2f1ea0092f21db623bcR18-R20), [link](https://github.com/tidbyt/community/pull/1409/files?diff=unified&w=0#diff-bacac371ef4450963bfae6cc2618e0ce8278c5d02f808e88e0cff7243efed67dR21-R23))
*  Add a print statement to debug the Player1_Name variable in the `atp_tennis.star` app ([link](https://github.com/tidbyt/community/pull/1409/files?diff=unified&w=0#diff-2fe7726a8148e3fb23a64991e8b2661bd9c098395de1a2f1ea0092f21db623bcR213))


