### PR TITLE
Fix bug introduced by modulo rewrite

### DIFF
--- a/apps/dutchfuzzyclock/dutch_fuzzy_clock.star
+++ b/apps/dutchfuzzyclock/dutch_fuzzy_clock.star
@@ -106,7 +106,9 @@ def fuzzy_time(hours, minutes, language):
         return [numbers[rounded], words["past"], numbers[hours]]
 
     # next 45 mins we already talk about the next hour
-    hours = (hours + 1) % 12
+    hours += 1
+    if hours > 12:
+        hours -= 12
 
     if rounded < 30:
         return [numbers[30 - rounded], words["to"] + " " + words["half"], numbers[hours]]


### PR DESCRIPTION
# Description

In my previous PR I fixed a reference issue when the hour was incremented beyond 12; https://github.com/tidbyt/community/pull/1408

The additional rewrite I did to turn into a "one-liner" introduced another bug where `12 % 12` resulted in `0` while it should be `1`. I've now used the exact same code used a couple of lines before for correctness and consistency.

<img width="942" alt="image" src="https://user-images.githubusercontent.com/194377/235604625-fdc0b73e-12e4-49ce-8ebe-41abe86435f2.png">

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at aebe5a7</samp>

### Summary
🐛🕒🇳🇱

<!--
1.  🐛 This emoji represents a bug, and can be used to indicate that the change was made to fix a bug or an error in the code.
2.  🕒 This emoji represents a clock, and can be used to indicate that the change was related to the time or the clock functionality of the code.
3.  🇳🇱 This emoji represents the flag of the Netherlands, and can be used to indicate that the change was specific to the Dutch fuzzy clock logic or the Dutch language.
-->
Fixed a bug in `dutch_fuzzy_clock.star` that caused incorrect times for some hours. Simplified the code to avoid modulo operator and ensure hours are within 1 to 12 range.

> _`hours` increments_
> _no more modulo issues_
> _autumn bug is fixed_

### Walkthrough
*  Simplify hour calculation to avoid modulo issues ([link](https://github.com/tidbyt/community/pull/1411/files?diff=unified&w=0#diff-e57a2b8c81874208fc6516529d189a94cd5d259014dec356657fcce8cb11e909L109-R111))


