### PR TITLE
Fix: IPL

### DIFF
--- a/apps/ipl/ipl.star
+++ b/apps/ipl/ipl.star
@@ -69,7 +69,7 @@ def main(config):
     MatchID = str(MatchID)
     Match_URL = "https://hs-consumer-api.espncricinfo.com/v1/pages/match/details?lang=en&seriesId=1345038&matchId=" + MatchID + "&latest=true"
 
-    #print(Match_URL)
+    print(Match_URL)
     # cache specific match data for 1 minute
     MatchData = get_cachable_data(Match_URL, MATCH_CACHE)
     Match_JSON = json.decode(MatchData)
@@ -345,8 +345,8 @@ def main(config):
 
             # only 1 innings got started, eg washout
         else:
-            Team1_Abbr = Match_JSON["scorecardSummary"]["innings"][0]["team"]["name"]
-            Team2_Abbr = Match_JSON["match"]["teams"][1]["team"]["name"]
+            Team1_Abbr = Match_JSON["scorecardSummary"]["innings"][0]["team"]["abbreviation"]
+            Team2_Abbr = Match_JSON["match"]["teams"][1]["team"]["abbreviation"]
             Team1_ID = Match_JSON["match"]["teams"][0]["team"]["id"]
             Team2_ID = Match_JSON["match"]["teams"][1]["team"]["id"]
 

--- a/apps/ipl/ipl.star
+++ b/apps/ipl/ipl.star
@@ -69,7 +69,7 @@ def main(config):
     MatchID = str(MatchID)
     Match_URL = "https://hs-consumer-api.espncricinfo.com/v1/pages/match/details?lang=en&seriesId=1345038&matchId=" + MatchID + "&latest=true"
 
-    print(Match_URL)
+    #print(Match_URL)
     # cache specific match data for 1 minute
     MatchData = get_cachable_data(Match_URL, MATCH_CACHE)
     Match_JSON = json.decode(MatchData)


### PR DESCRIPTION
# Description
Matches that finished with no result was showing full team name not abbreviation in the summary screen

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c7803b8</samp>

### Summary
🏏📝🗜️

<!--
1.  🏏 - This emoji represents the sport of cricket, which is the context of the IPL app and the scorecard summary. It can be used to indicate that the changes are related to the cricket-related features or data of the app.
2.  📝 - This emoji represents a document or a report, which is what the scorecard summary is. It can be used to indicate that the changes are related to the format or layout of the scorecard summary, or the way it displays the information.
3.  🗜️ - This emoji represents a compression or a reduction, which is what the team abbreviation does to the team name. It can be used to indicate that the changes are related to making the scorecard summary more compact or efficient, or to fit the tidbyt device better.
-->
Updated the `ipl` app to show team abbreviations instead of names on the scorecard. This makes the display more readable and consistent for the tidbyt device.

> _`tidbyt` shows scores_
> _team abbreviations used_
> _autumn cricket match_

### Walkthrough
*  Use team abbreviation instead of team name for scorecard summary ([link](https://github.com/tidbyt/community/pull/1416/files?diff=unified&w=0#diff-1b261b4634779291fabe5a41f79d2f194b85218d22d75ab17ac17813f83e525dL348-R349))


