### PR TITLE
bugfix RestDbIoDashboard: introduce cache time, constantly hitting ra…

### DIFF
--- a/apps/restdbiodashboard/restdbiodashboard.star
+++ b/apps/restdbiodashboard/restdbiodashboard.star
@@ -58,6 +58,7 @@ def main(config):
     api_key = config.str("api_key")
     offline_page = config.str("offline_page")
     offline_icons = config.str("offline_icons")
+    data_cache_time = int(config.get("cache_time", "5"))
 
     use_offline_data = False
 
@@ -74,19 +75,24 @@ def main(config):
         return reset_icon_cache(db_name, api_key)
 
     if not use_offline_data:
-        rep = http.get(
-            "https://{}.restdb.io/rest/{}?max=3&q={{%22visible%22:true}}&sort=order".format(db_name, table_name),
-            headers = {
-                "Accept": "application/json",
-                "x-apikey": api_key,
-            },
-        )
+        data_cache_key = "{}-data".format(db_name)
+        body = cache.get(data_cache_key)
+        if not body:
+            rep = http.get(
+                "https://{}.restdb.io/rest/{}?max=3&q={{%22visible%22:true}}&sort=order".format(db_name, table_name),
+                headers = {
+                    "Accept": "application/json",
+                    "x-apikey": api_key,
+                },
+            )
 
-        if rep.status_code != 200:
-            print(rep.body())
-            return render_fail(rep)
+            if rep.status_code != 200:
+                print(rep.body())
+                return render_fail(rep)
+            body = rep.body()
+            cache.set(data_cache_key, body, ttl_seconds = data_cache_time)
 
-        items = json.decode(rep.body())
+        items = json.decode(body)
     else:
         items = json.decode(offline_page)
         for icon in json.decode(offline_icons):
@@ -207,6 +213,13 @@ def get_schema():
                 name = "API key",
                 desc = "The API key to access restdb.io (read only is enough)",
                 icon = "user",
+            ),
+            schema.Text(
+                id = "cache_time",
+                name = "Cache time",
+                desc = "How long to cache data from the database (api rate limit)",
+                icon = "clock",
+                default = "5",
             ),
             schema.Toggle(
                 id = "vertical",


### PR DESCRIPTION
…te limit

# Description
Bug fix: Add cache as it is constantly hitting the rate limit. Looks like the server executes the app much more often then when it's displayed.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 80bd661</samp>

### Summary
🚀🗄️⏱️

<!--
1.  🚀 - This emoji represents the improved performance of the app due to caching, as well as the new feature of being able to configure the cache time.
2.  🗄️ - This emoji represents the database that is being cached, and the reduced load on it due to fewer API calls.
3.  ⏱️ - This emoji represents the cache time parameter that can be set by the user, and the effect it has on the freshness of the data displayed on the dashboard.
-->
Add caching to `restdbiodashboard` app to reduce API calls and improve performance. Use `cache` module and new app config field `cache_time` to control cache duration.

> _`restdbiodashboard`_
> _Caches data, saves API calls_
> _Spring of performance_

### Walkthrough
*  Add a cache layer for the data from the database ([link](https://github.com/tidbyt/community/pull/1423/files?diff=unified&w=0#diff-351fab91346ef43c9afcc919abdd2f77042a21f5fa93e9f1730d819560ae2befR61), [link](https://github.com/tidbyt/community/pull/1423/files?diff=unified&w=0#diff-351fab91346ef43c9afcc919abdd2f77042a21f5fa93e9f1730d819560ae2befL77-R96), [link](https://github.com/tidbyt/community/pull/1423/files?diff=unified&w=0#diff-351fab91346ef43c9afcc919abdd2f77042a21f5fa93e9f1730d819560ae2befR218-R224))
  - Declare a variable `data_cache_time` to store the cache time in seconds, read from the app config or default to 5 ([link](https://github.com/tidbyt/community/pull/1423/files?diff=unified&w=0#diff-351fab91346ef43c9afcc919abdd2f77042a21f5fa93e9f1730d819560ae2befR61))
  - Import the `cache` module and use it to check and store the data in a global variable `data_cache` ([link](https://github.com/tidbyt/community/pull/1423/files?diff=unified&w=0#diff-351fab91346ef43c9afcc919abdd2f77042a21f5fa93e9f1730d819560ae2befL77-R96))
  - Make an HTTP request to the database only if the cache is empty or expired, and store the response body in the cache with the `data_cache_time` as the TTL ([link](https://github.com/tidbyt/community/pull/1423/files?diff=unified&w=0#diff-351fab91346ef43c9afcc919abdd2f77042a21f5fa93e9f1730d819560ae2befL77-R96))
  - Add a new field `cache_time` to the app config schema, with a text input, a default value, a description and an icon ([link](https://github.com/tidbyt/community/pull/1423/files?diff=unified&w=0#diff-351fab91346ef43c9afcc919abdd2f77042a21f5fa93e9f1730d819560ae2befR218-R224))


