### PR TITLE
SEPTA Transit: Fix am/pm issue

### DIFF
--- a/apps/septatransit/septatransit.star
+++ b/apps/septatransit/septatransit.star
@@ -220,7 +220,7 @@ def main(config):
     schedule = get_schedule(route, stop)
     timezone = config.get("timezone") or "America/New_York"
     now = time.now().in_location(timezone)
-    left_pad = 0
+    left_pad = 4
 
     if config.bool("use_custom_banner_color"):
         route_bg_color = config.str("custom_banner_color")
@@ -243,8 +243,8 @@ def main(config):
         else:
             meridian = "p"
         banner_text = now.format("3:04") + meridian + " " + banner_text
-        if now.format("3") not in ["10", "11", "12"]:
-            left_pad = 4
+        if now.format("3") in ["10", "11", "12"]:
+            left_pad = 0
 
     return render.Root(
         delay = 100,

--- a/apps/septatransit/septatransit.star
+++ b/apps/septatransit/septatransit.star
@@ -220,7 +220,7 @@ def main(config):
     schedule = get_schedule(route, stop)
     timezone = config.get("timezone") or "America/New_York"
     now = time.now().in_location(timezone)
-    left_pad = 4
+    left_pad = 0
 
     if config.bool("use_custom_banner_color"):
         route_bg_color = config.str("custom_banner_color")
@@ -238,9 +238,13 @@ def main(config):
         banner_text = user_text
 
     if config.bool("show_time"):
-        banner_text = now.format("3:04p") + " " + banner_text
-        if now.format("3") in ["10", "11", "12"]:
-            left_pad = 0
+        if int(now.format("15")) < 12:
+            meridian = "a"
+        else:
+            meridian = "p"
+        banner_text = now.format("3:04") + meridian + " " + banner_text
+        if now.format("3") not in ["10", "11", "12"]:
+            left_pad = 4
 
     return render.Root(
         delay = 100,


### PR DESCRIPTION
# Description
Fixes an issue where "am" is always "pm"

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 381ed37</samp>

### Summary
🪡🕒🛠️

<!--
1.  🪡 - This emoji can be used to represent the reduced left padding, as it suggests the idea of sewing or stitching something closer together. Alternatively, one could use 📏 to indicate the adjustment of the spacing or margin.
2. 🕒 - This emoji can be used to represent the changed time format, as it shows a clock face with a different hour and minute hand position than the default 🕐 emoji. Alternatively, one could use ⏱️ to indicate a stopwatch or timer, or 🗓️ to indicate a calendar or date.
3. 🛠️ - This emoji can be used to represent the overall improvement of the alignment and consistency of the display elements, as it suggests the idea of fixing or repairing something. Alternatively, one could use ✅ to indicate a check mark or completion, or 🌟 to indicate a star or excellence.
-->
Improved the layout and appearance of the `septatransit` app by adjusting the banner text padding and format.

> _Sing, O Muse, of the skillful coder who refined the `septatransit` app_
> _And made the banner text more pleasing to the eyes of mortal men_
> _He trimmed the excess padding from the left, as one would prune a vine_
> _And changed the time format to match the sun's unerring course in heaven_

### Walkthrough
*  Reduced left padding and customized time format for banner text ([link](https://github.com/tidbyt/community/pull/1431/files?diff=unified&w=0#diff-b1fdab8189161d4f11593fce619cf6d6ff03f6798efb8a651cbe1aba9632d6f9L223-R223), [link](https://github.com/tidbyt/community/pull/1431/files?diff=unified&w=0#diff-b1fdab8189161d4f11593fce619cf6d6ff03f6798efb8a651cbe1aba9632d6f9L241-R247)). This aligns the text with the transit icons and saves space on the display.


