### PR TITLE
New app: LibreNMS Alerts

### DIFF
--- a/apps/librenmsalerts/librenms_alerts.star
+++ b/apps/librenmsalerts/librenms_alerts.star
@@ -54,7 +54,7 @@ def get_schema():
         ],
     )
 
-# Print the logo centered on a row by iteself
+# Print the logo centered on a row by itself
 def render_logo():
     return render.Row(
         main_align = "center",

--- a/apps/librenmsalerts/librenms_alerts.star
+++ b/apps/librenmsalerts/librenms_alerts.star
@@ -189,8 +189,8 @@ def main(config):
         return render_output(0)
 
     else:  # Number of alerts is > 1
-        alert_hash_cached = cache.get(librenms_url + '_alert_hash')
-        alerting_devices_cached = cache.get(librenms_url + '_alerting_devices')
+        alert_hash_cached = cache.get(librenms_url + "_alert_hash")
+        alerting_devices_cached = cache.get(librenms_url + "_alerting_devices")
 
         # See if the alert data has already been cached before fetching device info
         if (alert_hash_cached != None) and (alerting_devices_cached != None):
@@ -201,13 +201,12 @@ def main(config):
             else:
                 # Hash of cached data does not match HTTP response hash. Calling LibreNMS API.
                 alerting_devices = get_alerting_devices(librenms_url, headers, alerts)
-                cache.set(librenms_url + '_alert_hash', hash.sha1(r_alerts.body()), ttl_seconds = CACHE_TTL_SECONDS)
-                cache.set(librenms_url + '_alerting_devices', alerting_devices, ttl_seconds = CACHE_TTL_SECONDS)
+                cache.set(librenms_url + "_alert_hash", hash.sha1(r_alerts.body()), ttl_seconds = CACHE_TTL_SECONDS)
+                cache.set(librenms_url + "_alerting_devices", alerting_devices, ttl_seconds = CACHE_TTL_SECONDS)
         else:
             # Cache miss. Calling LibreNMS API.
             alerting_devices = get_alerting_devices(librenms_url, headers, alerts)
-            cache.set(librenms_url + '_alert_hash', hash.sha1(r_alerts.body()), ttl_seconds = CACHE_TTL_SECONDS)
-            cache.set(librenms_url + '_alerting_devices', alerting_devices, ttl_seconds = CACHE_TTL_SECONDS)
+            cache.set(librenms_url + "_alert_hash", hash.sha1(r_alerts.body()), ttl_seconds = CACHE_TTL_SECONDS)
+            cache.set(librenms_url + "_alerting_devices", alerting_devices, ttl_seconds = CACHE_TTL_SECONDS)
 
         return render_output(len(alerts), alerting_devices)
-

--- a/apps/librenmsalerts/librenms_alerts.star
+++ b/apps/librenmsalerts/librenms_alerts.star
@@ -1,0 +1,212 @@
+# librenms_alerts.star
+# Gets the current count of alerts from a LibreNMS server.  If alerts are
+# present, displays a marquee listing the hosts which are alerting.
+# Justin Tinel 2023-05 jt@justintinel.com
+
+load("cache.star", "cache")
+load("encoding/base64.star", "base64")
+load("hash.star", "hash")
+load("http.star", "http")
+load("re.star", "re")
+load("render.star", "render")
+load("schema.star", "schema")
+
+# Caching: The list of devices which are in an alert state is cached when it
+# is first resolved. This avoids subsequent API calls to repeatedly resolve
+# device info. The cached device data is then used when a hash of the http
+# response data matches the hash of the cached response data.
+CACHE_TTL_SECONDS = 60
+
+# LibreNMS endpoint definitions
+ENDPOINT_ALERTS = "/api/v0/alerts"
+ENDPOINT_DEVICES = "/api/v0/devices"
+
+# Output colors
+RED = "F92323"
+GREEN = "#2AF923"
+
+LIBRENMS_ICON = base64.decode("""
+iVBORw0KGgoAAAANSUhEUgAAAA0AAAANCAYAAABy6+R8AAAAiklEQVQoU42SQRLAEAxF6wws
+a6dXcWhXqZ0u6wwpHTFEaG1MIn+en0Rsk3PrA1Q4BffMJu/dgLq8iNqADH6oGRIxEWRDsNaC
+c66r64KYCDITyo0CKqwiLEQPtLCNX9EXgRLrV5Dwh8iSZp6QOPW0Ii67R4loYZxTaffMY86z
+G0G7SVeJFbVj4HbvAYKAnd83qTc7AAAAAElFTkSuQmCC
+""")
+
+HTTP_REGEXP = "^((http|https)://)[-a-zA-Z0-9@:%._\\+~#?&//=]{2,256}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%._\\+~#?&//=]*)$"
+
+# Define the configuration schema
+def get_schema():
+    return schema.Schema(
+        version = "1",
+        fields = [
+            schema.Text(
+                id = "librenms_url",
+                name = "LibreNMS URL:",
+                desc = "URL of the LibreNMS server. Include the protocol and [optionally] port, e.g. https://my.nms, or https://my.nms:8443. TLS connections must use a publicly trusted TLS certificate such as LetsEncrypt, Digicert, etc.",
+                icon = "globe",
+            ),
+            schema.Text(
+                id = "api_key",
+                name = "LibreNMS API Key:",
+                desc = "API Key for the LibreNMS server. Create/manage keys from the LibreNMS web interface at Home -> Settings -> API Settings",
+                icon = "key",
+            ),
+        ],
+    )
+
+# Print the logo centered on a row by iteself
+def render_logo():
+    return render.Row(
+        main_align = "center",
+        expanded = True,
+        children = [
+            render.Image(src = LIBRENMS_ICON),
+        ],
+    )
+
+# Get the list of rows to be added to the body of the output.
+# If the alert count is 0, a single row is returned, indicating that there
+# are no alerts. If the alert count > 0, an additional row is displayed,
+# containing a marquee of the devices which are in an alert status.
+def get_body_rows(alert_count, alerting_devices = ""):
+    rows = []
+
+    row_alert_count = render.Row(
+        main_align = "center",
+        expanded = True,
+        children = [
+            render.Text(
+                content = "Alerts:" + str(alert_count),
+                font = "6x13",
+                color = RED if alert_count > 0 else GREEN,
+                height = 11,
+            ),
+        ],
+    )
+    rows.append(row_alert_count)
+
+    if (alert_count > 0):
+        row_marquee_alerting_devices = render.Marquee(
+            width = 64,
+            offset_start = 64,
+            offset_end = 64,
+            align = "center",
+            child = render.Text(
+                content = alerting_devices,
+                font = "5x8",
+            ),
+        )
+        rows.append(row_marquee_alerting_devices)
+
+    return rows
+
+# Display an error message using render.Marquee.
+def render_error(error_msg):
+    return render.Root(
+        child = render.Box(
+            child = render.Column(
+                expanded = True,
+                main_align = "space_evenly",
+                children = [
+                    render_logo(),
+                    render.Marquee(
+                        width = 64,
+                        offset_start = 64,
+                        offset_end = 64,
+                        align = "center",
+                        child = render.Text(
+                            content = error_msg,
+                        ),
+                    ),
+                ],
+            ),
+        ),
+    )
+
+# Get the list of devices which are alerting. The "alerts" response only
+# includes the device ID, so we have to look up the device name separately.
+def get_alerting_devices(librenms_url, headers, alerts):
+    r_devices = http.get((librenms_url + ENDPOINT_DEVICES), headers = headers)
+    if r_devices.status_code != 200:
+        return render_error("HTTP Request failed with error {}".format(r_devices.status_code))
+
+    # Get the device list to cross-reference the alert against
+    devices = r_devices.json()["devices"]
+
+    # Iterate through the alerts and create a list of the devices which are in
+    # an alert state
+    alerting_devices = list()
+    for alert in alerts:
+        # For each alert, look for a device record match
+        for item in devices:
+            if alert["hostname"] == item["hostname"]:
+                # Use the Display name if it is set
+                if item["display"]:
+                    alerting_devices.append(item["display"])
+
+                    # Otherwise use SNMP sysName
+                else:
+                    alerting_devices.append(item["sysName"])
+
+    return ", ".join(alerting_devices)
+
+# Render the output
+def render_output(alert_count, alerting_devices = ""):
+    children = list()
+    children.append(render_logo())
+    children = children + get_body_rows(alert_count, alerting_devices)
+
+    return render.Root(
+        child = render.Box(
+            height = 32,
+            child = render.Column(
+                expanded = True,
+                main_align = "space_evenly",
+                children = children,
+            ),
+        ),
+    )
+
+def main(config):
+    librenms_url = config.str("librenms_url") or ""
+    if not (re.match(HTTP_REGEXP, librenms_url)):
+        return render_error("LibreNMS URL invalid - check config")
+
+    api_key = config.str("api_key") or ""
+    if api_key == "":
+        return render_error("LibreNMS API key not specified - check config")
+
+    headers = {"X-Auth-Token": api_key}
+
+    r_alerts = http.get((librenms_url + ENDPOINT_ALERTS), headers = headers)
+
+    if r_alerts.status_code != 200:
+        return render_error("HTTP Request failed with error {}".format(r_alerts.status_code))
+
+    alerts = r_alerts.json()["alerts"]
+
+    if len(alerts) == 0:  # There are no alerts
+        return render_output(0)
+
+    else:  # Number of alerts is > 1
+        alert_hash_cached = cache.get("alert_hash")
+        alerting_devices_cached = cache.get("alerting_devices")
+
+        # See if the alert data has already been cached before fetching device info
+        if (alert_hash_cached != None) and (alerting_devices_cached != None):
+            # Cache hit.
+            if alert_hash_cached == hash.sha1(r_alerts.body()):
+                # Cached data hash matches HTTP response hash. Using cached data.
+                alerting_devices = alerting_devices_cached
+            else:
+                # Hash of cached data does not match HTTP response hash. Calling LibreNMS API.
+                alerting_devices = get_alerting_devices(librenms_url, headers, alerts)
+                cache.set("alert_hash", hash.sha1(r_alerts.body()), ttl_seconds = CACHE_TTL_SECONDS)
+                cache.set("alerting_devices", alerting_devices, ttl_seconds = CACHE_TTL_SECONDS)
+        else:
+            # Cache miss. Calling LibreNMS API.
+            alerting_devices = get_alerting_devices(librenms_url, headers, alerts)
+            cache.set("alert_hash", hash.sha1(r_alerts.body()), ttl_seconds = CACHE_TTL_SECONDS)
+            cache.set("alerting_devices", alerting_devices, ttl_seconds = CACHE_TTL_SECONDS)
+
+        return render_output(len(alerts), alerting_devices)

--- a/apps/librenmsalerts/librenms_alerts.star
+++ b/apps/librenmsalerts/librenms_alerts.star
@@ -189,8 +189,8 @@ def main(config):
         return render_output(0)
 
     else:  # Number of alerts is > 1
-        alert_hash_cached = cache.get("alert_hash")
-        alerting_devices_cached = cache.get("alerting_devices")
+        alert_hash_cached = cache.get(librenms_url + '_alert_hash')
+        alerting_devices_cached = cache.get(librenms_url + '_alerting_devices')
 
         # See if the alert data has already been cached before fetching device info
         if (alert_hash_cached != None) and (alerting_devices_cached != None):
@@ -201,12 +201,12 @@ def main(config):
             else:
                 # Hash of cached data does not match HTTP response hash. Calling LibreNMS API.
                 alerting_devices = get_alerting_devices(librenms_url, headers, alerts)
-                cache.set("alert_hash", hash.sha1(r_alerts.body()), ttl_seconds = CACHE_TTL_SECONDS)
-                cache.set("alerting_devices", alerting_devices, ttl_seconds = CACHE_TTL_SECONDS)
+                cache.set(librenms_url + '_alert_hash', hash.sha1(r_alerts.body()), ttl_seconds = CACHE_TTL_SECONDS)
+                cache.set(librenms_url + '_alerting_devices', alerting_devices, ttl_seconds = CACHE_TTL_SECONDS)
         else:
             # Cache miss. Calling LibreNMS API.
             alerting_devices = get_alerting_devices(librenms_url, headers, alerts)
-            cache.set("alert_hash", hash.sha1(r_alerts.body()), ttl_seconds = CACHE_TTL_SECONDS)
-            cache.set("alerting_devices", alerting_devices, ttl_seconds = CACHE_TTL_SECONDS)
+            cache.set(librenms_url + '_alert_hash', hash.sha1(r_alerts.body()), ttl_seconds = CACHE_TTL_SECONDS)
+            cache.set(librenms_url + '_alerting_devices', alerting_devices, ttl_seconds = CACHE_TTL_SECONDS)
 
         return render_output(len(alerts), alerting_devices)

--- a/apps/librenmsalerts/librenms_alerts.star
+++ b/apps/librenmsalerts/librenms_alerts.star
@@ -210,3 +210,4 @@ def main(config):
             cache.set(librenms_url + '_alerting_devices', alerting_devices, ttl_seconds = CACHE_TTL_SECONDS)
 
         return render_output(len(alerts), alerting_devices)
+

--- a/apps/librenmsalerts/manifest.yaml
+++ b/apps/librenmsalerts/manifest.yaml
@@ -1,0 +1,8 @@
+---
+id: librenms-alerts
+name: LibreNMS Alerts
+summary: LibreNMS Alert Display
+desc: Displays a summary of the currently active LibreNMS alerts.
+author: '@jtinel'
+fileName: librenms_alerts.star
+packageName: librenmsalerts


### PR DESCRIPTION
# Description
New app: LibreNMS Alerts - See a count of active LibreNMS alerts as well as a summary of alerting devices.
![librenms_alerts](https://user-images.githubusercontent.com/55293152/236986046-1f5f5714-db28-48a5-a041-a869b2963c64.gif)

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 273fd95</samp>

### Summary
🚨🌐📝

<!--
1.  🚨 - This emoji represents the main purpose of the app, which is to display alerts from LibreNMS, a network monitoring system. The emoji conveys the sense of urgency and importance of the alerts, and also matches the name of the app.
2.  🌐 - This emoji represents the network aspect of the app, which connects to a LibreNMS server via HTTP and uses its API to fetch data. The emoji also suggests the global and diverse nature of the network devices that LibreNMS can monitor and alert on.
3.  📝 - This emoji represents the code and documentation aspect of the app, which uses the Starlark language and the Tidbyt API to implement the app logic and functionality. The emoji also indicates the comments and configuration schema that the app provides to explain and customize the app.
-->
This pull request adds a new app called `librenms_alerts`, which shows the number of alerts from a LibreNMS server on the Tidbyt device. The app is written in Starlark and uses the Tidbyt API to fetch and display data. The app also has a manifest.yaml file with metadata for publishing and installing the app.

> _`librenms_alerts`_
> _A new app for Tidbyt_
> _Shows alerts in spring_

### Walkthrough
* Create and publish a new app called librenms_alerts that displays the current count of alerts from a LibreNMS server on the Tidbyt device ([link](https://github.com/tidbyt/community/pull/1433/files?diff=unified&w=0#diff-09540c6f5020616f485088801d30bdd2f09d74ea6191592119b417b8aa8c4566R1-R212), [link](https://github.com/tidbyt/community/pull/1433/files?diff=unified&w=0#diff-c46cd353d73b9d1a0825076b9141fa92d53d248f047a498571b9f7226d19696fR1-R8))
  * Add the code for the app in `librenms_alerts.star` using the Starlark language and the Tidbyt API ([link](https://github.com/tidbyt/community/pull/1433/files?diff=unified&w=0#diff-09540c6f5020616f485088801d30bdd2f09d74ea6191592119b417b8aa8c4566R1-R212))
    * Define a configuration schema that requires the user to enter the LibreNMS URL and API key ([link](https://github.com/tidbyt/community/pull/1433/files?diff=unified&w=0#diff-09540c6f5020616f485088801d30bdd2f09d74ea6191592119b417b8aa8c4566R1-R212))
    * Make HTTP requests to the LibreNMS API and parse the JSON responses ([link](https://github.com/tidbyt/community/pull/1433/files?diff=unified&w=0#diff-09540c6f5020616f485088801d30bdd2f09d74ea6191592119b417b8aa8c4566R1-R212))
    * Cache the data to avoid unnecessary requests and respect the API rate limit ([link](https://github.com/tidbyt/community/pull/1433/files?diff=unified&w=0#diff-09540c6f5020616f485088801d30bdd2f09d74ea6191592119b417b8aa8c4566R1-R212))
    * Render the alert count as text, image, or marquee depending on the device orientation and the number of alerts ([link](https://github.com/tidbyt/community/pull/1433/files?diff=unified&w=0#diff-09540c6f5020616f485088801d30bdd2f09d74ea6191592119b417b8aa8c4566R1-R212))
    * Handle various error scenarios and display appropriate messages ([link](https://github.com/tidbyt/community/pull/1433/files?diff=unified&w=0#diff-09540c6f5020616f485088801d30bdd2f09d74ea6191592119b417b8aa8c4566R1-R212))
    * Add comments to explain the logic and functionality of the app ([link](https://github.com/tidbyt/community/pull/1433/files?diff=unified&w=0#diff-09540c6f5020616f485088801d30bdd2f09d74ea6191592119b417b8aa8c4566R1-R212))
  * Add the metadata for the app in `manifest.yaml` ([link](https://github.com/tidbyt/community/pull/1433/files?diff=unified&w=0#diff-c46cd353d73b9d1a0825076b9141fa92d53d248f047a498571b9f7226d19696fR1-R8))
    * Specify the app id, name, summary, description, author, file name, and package name ([link](https://github.com/tidbyt/community/pull/1433/files?diff=unified&w=0#diff-c46cd353d73b9d1a0825076b9141fa92d53d248f047a498571b9f7226d19696fR1-R8))

