### PR TITLE
Cost Calculator: Add rate multiplier

### DIFF
--- a/apps/costcalculator/cost_calculator.star
+++ b/apps/costcalculator/cost_calculator.star
@@ -6,7 +6,7 @@ Author: rs7q5
 """
 #cost_calculator.star
 #Created 20230403 RIS
-#Last Modified 20230403 RIS
+#Last Modified 20230509 RIS
 
 load("humanize.star", "humanize")
 load("math.star", "math")
@@ -17,21 +17,28 @@ load("time.star", "time")
 DEFAULT_TIMEZONE = "America/New_York"
 DEFAULT_TITLE = "Title"
 DEFAULT_RATE = "0.00"
+DEFAULT_MULTIPLIER = "1.00"
+
 DEFAULT_FONT = "CG-pixel-3x5-mono"
-DEFAULT_COLOR = "#008000"
+DEFAULT_TITLE_COLOR = "#008000"
 
 def main(config):
     duration = get_duration(config)
 
     #calcuate cost
     rate = float(config.str("rate", DEFAULT_RATE))  #duration is per hour
-    rate_str = "$" + humanize.float("#.##", rate)
+    multiplier = float(config.str("multiplier", DEFAULT_MULTIPLIER))
+
+    rate_str = "$" + humanize.float("#.##", rate * multiplier)
+
+    if multiplier != 1:
+        rate_str += " (x%s)" % humanize.float("#.##", multiplier)  #add multiplier to text
 
     cost = duration["value"] * rate
     cost_str = "$" + humanize.float("#.##", cost)
 
     #create frame
-    title_txt = render.Text(config.str("title", DEFAULT_TITLE), font = "tb-8", color = config.get("title_color", DEFAULT_COLOR))
+    title_txt = render.Text(config.str("title", DEFAULT_TITLE), font = "tb-8", color = config.get("title_color", DEFAULT_TITLE_COLOR))
 
     #create labels and values
     label_vec = []
@@ -40,7 +47,7 @@ def main(config):
 
     value_vec = []
     for value in [duration["text"], rate_str, cost_str]:
-        value_vec.append(render.Text(value, font = DEFAULT_FONT))
+        value_vec.append(render.Marquee(width = 40, align = "end", child = render.Text(value, font = DEFAULT_FONT)))
 
     final_frame = render.Column(
         main_align = "space_between",
@@ -79,7 +86,14 @@ def get_schema():
                 name = "Hourly rate",
                 desc = "The rate to use for calculating the cost.",
                 icon = "dollarSign",
-                default = "0.00",
+                default = DEFAULT_RATE,
+            ),
+            schema.Text(
+                id = "multiplier",
+                name = "Rate multiplier",
+                desc = "Add a multiplier to the rate.",
+                icon = "xmark",
+                default = DEFAULT_MULTIPLIER,
             ),
             schema.Text(
                 id = "title",
@@ -93,7 +107,7 @@ def get_schema():
                 name = "Title Color",
                 desc = "The color of the title text.",
                 icon = "brush",
-                default = "#008000",
+                default = DEFAULT_TITLE_COLOR,
             ),
         ],
     )


### PR DESCRIPTION
# Description
Add an option to apply a rate multiplier to the rate when calculating the cost

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8859bdb</samp>

### Summary
🆕🔧📝

<!--
1.  🆕 - This emoji can be used to indicate that a new feature or option was added to the app, and to draw attention to it in the changelog or release notes.
2.  🔧 - This emoji can be used to signify that some adjustments or improvements were made to the existing functionality or design of the app, such as the cost calculator display or the rate multiplier logic.
3.  📝 - This emoji can be used to convey that some text elements were modified or enhanced, such as using constants for default values or marquee widgets for long texts. This can also imply that the app is more user-friendly or readable.
-->
Added a new app `costcalculator` that shows the cost of a project based on hours and rate. Enhanced the app with user-configurable options and better text formatting.

> _The cost calculator app got a tweak_
> _With a new option for rate multiplier peak_
> _And to show long texts well_
> _Used marquee widgets for `label`_
> _And constants for defaults, not unique_

### Walkthrough
*  Add a new schema entry for the rate multiplier ([link](https://github.com/tidbyt/community/pull/1437/files?diff=unified&w=0#diff-54011991933ec853ded3668789a1c0150fe1d426188f0769e021b9f5e8044c97L82-R98))
*  Use constants for the default values of the rate multiplier and the title color ([link](https://github.com/tidbyt/community/pull/1437/files?diff=unified&w=0#diff-54011991933ec853ded3668789a1c0150fe1d426188f0769e021b9f5e8044c97L20-R23), [link](https://github.com/tidbyt/community/pull/1437/files?diff=unified&w=0#diff-54011991933ec853ded3668789a1c0150fe1d426188f0769e021b9f5e8044c97L96-R110))
*  Retrieve the rate multiplier from the config and include it in the rate string ([link](https://github.com/tidbyt/community/pull/1437/files?diff=unified&w=0#diff-54011991933ec853ded3668789a1c0150fe1d426188f0769e021b9f5e8044c97L28-R41))
*  Wrap the values for the duration, rate, and cost in marquee widgets to allow scrolling ([link](https://github.com/tidbyt/community/pull/1437/files?diff=unified&w=0#diff-54011991933ec853ded3668789a1c0150fe1d426188f0769e021b9f5e8044c97L43-R50))
*  Update the last modified date in `apps/costcalculator/cost_calculator.star` ([link](https://github.com/tidbyt/community/pull/1437/files?diff=unified&w=0#diff-54011991933ec853ded3668789a1c0150fe1d426188f0769e021b9f5e8044c97L9-R9))


