### PR TITLE
pagerduty: Switch to caching http client

### DIFF
--- a/apps/pagerduty/pagerduty.star
+++ b/apps/pagerduty/pagerduty.star
@@ -74,31 +74,21 @@ def pagerduty_api_call(config, url, use_cache = True):
     if not access_token:
         return fail("No access token")
 
-    cache_key = "%s|%s" % (access_token, url)
-    cached_res = cache.get(cache_key) if use_cache else None
+    timeout = DEFAULT_CACHE_TTL if use_cache else 0
+    res = http.get(
+        url,
+        headers = {
+            "Authorization": "Bearer %s" % access_token,
+            "Accept": "application/vnd.pagerduty+json;version=2",
+        },
+        ttl_seconds = timeout,
+    )
+    body = res.body()
 
-    if not cached_res:
-        res = http.get(
-            url,
-            headers = {
-                "Authorization": "Bearer %s" % access_token,
-                "Accept": "application/vnd.pagerduty+json;version=2",
-            },
-        )
+    if (res.status_code < 200 or res.status_code >= 300) and len(body) <= 0:
+        body = '{"status":%i}' % res.status_code
 
-        if res.status_code < 200 or res.status_code >= 300:
-            # buildifier: disable=print
-            print("pagerduty_api_call failed: %s - %s " % (res.status_code, res.body()))
-            return None
-        elif len(res.body()) > 0:
-            cached_res = res.body()
-        else:
-            cached_res = '{"status": %i}' % res.status_code
-
-        if use_cache:
-            cache.set(cache_key, cached_res, DEFAULT_CACHE_TTL)
-
-    return json.decode(cached_res)
+    return json.decode(body)
 
 # buildifier: disable=function-docstring
 def get_pagerduty_counts(config, profile = None, teams_supported = True):
@@ -441,7 +431,7 @@ def build_teams(refresh_token):
     teams_supported = are_teams_supported(config)
 
     if not teams_supported:
-        return None
+        return []
 
     options = [
         schema.Option(


### PR DESCRIPTION
# Description

Migrates API calls to use the new caching http client.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c225aa7</samp>

### Summary
🛠️📜🚀

<!--
1.  🛠️ - This emoji represents fixing a bug or improving something that was broken or not working well. It can be used for the bug fix with team options, as well as the improvement to the caching logic.
2.  📜 - This emoji represents parsing, processing, or transforming data or text. It can be used for the JSON parsing enhancement, which ensures that the app can handle different types of responses from the PagerDuty API.
3.  🚀 - This emoji represents launching, deploying, or releasing something new or updated. It can be used for the overall pull request, which delivers a new version of the pagerduty app with these changes.
-->
Improve pagerduty app by fixing bugs and optimizing caching. The changes affect `apps/pagerduty/pagerduty.star`.

> _No more complex caching, we purge the old and stale_
> _We fix the team options, no more errors to derail_
> _We parse the JSON, we decode the hidden truth_
> _We improve the pagerduty, we are the code of youth_

### Walkthrough
*  Simplify caching and error handling in `pagerduty_api_call` function ([link](https://github.com/tidbyt/community/pull/1448/files?diff=unified&w=0#diff-4c8a72ebede2af55b191911e151ee1a7a7e539b63f5ce61d37e47f7fc61fd2c1L77-R92))
*  Fix bug in `get_pagerduty_teams` function to return empty list instead of None ([link](https://github.com/tidbyt/community/pull/1448/files?diff=unified&w=0#diff-4c8a72ebede2af55b191911e151ee1a7a7e539b63f5ce61d37e47f7fc61fd2c1L444-R434))


