### PR TITLE
Multiple Apps: update apps for new cache method for http.get

### DIFF
--- a/apps/aadailyreflect/aadailyreflect.star
+++ b/apps/aadailyreflect/aadailyreflect.star
@@ -5,13 +5,12 @@ Description: Display AA Daily Refelection from the AA.org website
 Author: jvivona
 """
 
-load("cache.star", "cache")
 load("encoding/json.star", "json")
 load("http.star", "http")
 load("render.star", "render")
 load("time.star", "time")
 
-VERSION = 23082
+VERSION = 23132
 
 APPTITLE_TEXT_COLOR = "#fff"
 APPTITLE_BKG_COLOR = "#0000ff"
@@ -79,17 +78,9 @@ def main(config):
     )
 
 def get_cachable_data(url):
-    key = url
-
-    data = cache.get(key)
-    if data != None:
-        return data
-
-    res = http.get(url = url)
+    res = http.get(url = url, ttl_seconds = CACHE_TTL_SECONDS)
     if res.status_code != 200:
         fail("request to %s failed with status code: %d - %s" % (url, res.status_code, res.body()))
-
-    cache.set(key, res.body(), ttl_seconds = CACHE_TTL_SECONDS)
 
     return res.body()
 

--- a/apps/cnnnews/cnn_news.star
+++ b/apps/cnnnews/cnn_news.star
@@ -5,13 +5,12 @@ Description: Display CNN News headslines for selected section.
 Author: jvivona
 """
 
-load("cache.star", "cache")
 load("http.star", "http")
 load("render.star", "render")
 load("schema.star", "schema")
 load("xpath.star", "xpath")
 
-VERSION = 23066
+VERSION = 23132
 
 # cache data for 15 minutes
 CACHE_TTL_SECONDS = 900
@@ -165,16 +164,12 @@ def get_schema():
     )
 
 def get_cacheable_data(url, articlecount):
-    key = url
-    data = cache.get(key)
     articles = []
 
-    if data == None:
-        res = http.get(RSS_STUB.format(url))
-        if res.status_code != 200:
-            fail("request to %s failed with status code: %d - %s" % (url, res.status_code, res.body()))
-        data = res.body()
-        cache.set(key, data, ttl_seconds = CACHE_TTL_SECONDS)
+    res = http.get(RSS_STUB.format(url), ttl_seconds = CACHE_TTL_SECONDS)
+    if res.status_code != 200:
+        fail("request to %s failed with status code: %d - %s" % (url, res.status_code, res.body()))
+    data = res.body()
 
     data_xml = xpath.loads(data)
 

--- a/apps/financialtimes/financial_times.star
+++ b/apps/financialtimes/financial_times.star
@@ -6,13 +6,12 @@ Description: Gets latest new articles from Financial Time and displays up to 3 a
     for selected edition.
 """
 
-load("cache.star", "cache")
 load("http.star", "http")
 load("render.star", "render")
 load("schema.star", "schema")
 load("xpath.star", "xpath")
 
-VERSION = 23066
+VERSION = 23132
 
 # cache data for 15 minutes
 CACHE_TTL_SECONDS = 900
@@ -145,16 +144,12 @@ def get_schema():
     )
 
 def get_cacheable_data(url, articlecount):
-    key = url
-    data = cache.get(key)
     articles = []
 
-    if data == None:
-        res = http.get(RSS_STUB.format(url))
-        if res.status_code != 200:
-            fail("request to %s failed with status code: %d - %s" % (url, res.status_code, res.body()))
-        data = res.body()
-        cache.set(key, data, ttl_seconds = CACHE_TTL_SECONDS)
+    res = http.get(RSS_STUB.format(url), ttl_seconds = CACHE_TTL_SECONDS)
+    if res.status_code != 200:
+        fail("request to %s failed with status code: %d - %s" % (url, res.status_code, res.body()))
+    data = res.body()
 
     data_xml = xpath.loads(data)
 

--- a/apps/formula1/formula_1.star
+++ b/apps/formula1/formula_1.star
@@ -5,7 +5,6 @@ Description: Shows Time date and location of Next F1 race.
 Author: AmillionAir
 """
 
-load("cache.star", "cache")
 load("encoding/base64.star", "base64")
 load("encoding/json.star", "json")
 load("http.star", "http")
@@ -13,7 +12,7 @@ load("render.star", "render")
 load("schema.star", "schema")
 load("time.star", "time")
 
-VERSION = 23067
+VERSION = 23132
 
 # ############################
 # Mods - jvivona - 2023-02-04
@@ -29,6 +28,8 @@ VERSION = 23067
 # - update Aston Martin logo
 # - change WCC layout
 # - added proper case names for constructors
+# jvivona - 2023-05-12
+# - new cache method
 # ############################
 
 DEFAULTS = {
@@ -344,18 +345,13 @@ def nri_options(f1_option):
         return []
 
 def get_f1_data(url):
-    f1_details = cache.get(url)
+    http_data = http.get(url, ttl_seconds = F1_API_TTL)
+    if http_data.status_code != 200:
+        fail("HTTP request failed with status {} for URL {}".format(http_data.status_code, url))
 
-    if f1_details == None:
-        http_data = http.get(url)
-        if http_data.status_code != 200:
-            fail("HTTP request failed with status {} for URL {}".format(http_data.status_code, url))
-
-        f1_details = http_data.body()
-        if f1_details.startswith("Unable"):
-            fail("API having database issues, check again later URL {}".format(url))
-
-        cache.set(url, f1_details, ttl_seconds = F1_API_TTL)
+    f1_details = http_data.body()
+    if f1_details.startswith("Unable"):
+        fail("API having database issues, check again later URL {}".format(url))
 
     return json.decode(f1_details)["MRData"]
 

--- a/apps/foxnews/fox_news.star
+++ b/apps/foxnews/fox_news.star
@@ -5,13 +5,12 @@ Description: Display Fox News headlines.
 Author: jvivona
 """
 
-load("cache.star", "cache")
 load("http.star", "http")
 load("render.star", "render")
 load("schema.star", "schema")
 load("xpath.star", "xpath")
 
-VERSION = 23068
+VERSION = 23132
 
 # cache data for 15 minutes
 CACHE_TTL_SECONDS = 900
@@ -156,18 +155,12 @@ def get_schema():
     )
 
 def get_cacheable_data(url, articlecount):
-    key = url
-    data = cache.get(key)
     articles = []
 
-    if data == None:
-        res = http.get(RSS_STUB.format(url))
-        if res.status_code != 200:
-            fail("request to %s failed with status code: %d - %s" % (url, res.status_code, res.body()))
-        data = res.body()
-        cache.set(key, data, ttl_seconds = CACHE_TTL_SECONDS)
-
-    #print(data)
+    res = http.get(RSS_STUB.format(url), ttl_seconds = CACHE_TTL_SECONDS)
+    if res.status_code != 200:
+        fail("request to %s failed with status code: %d - %s" % (url, res.status_code, res.body()))
+    data = res.body()
 
     data_xml = xpath.loads(data)
 

--- a/apps/indycar/indy_car.star
+++ b/apps/indycar/indy_car.star
@@ -9,7 +9,6 @@ Author: jvivona
 #  changed to new color schema option
 #  samhi113 provided all the track images
 
-load("cache.star", "cache")
 load("encoding/base64.star", "base64")
 load("encoding/json.star", "json")
 load("http.star", "http")
@@ -17,7 +16,7 @@ load("render.star", "render")
 load("schema.star", "schema")
 load("time.star", "time")
 
-VERSION = 23097
+VERSION = 23132
 
 IMAGES = {
     #Indycar track type logos
@@ -269,17 +268,9 @@ def show_nri_options(datadisplay):
 #           General Funcitons
 # ##############################################
 def get_cachable_data(url):
-    key = url
-
-    data = cache.get(key)
-    if data != None:
-        return data
-
-    res = http.get(url = url)
+    res = http.get(url = url, ttl_seconds = DEFAULTS["ttl"])
     if res.status_code != 200:
         fail("request to %s failed with status code: %d - %s" % (url, res.status_code, res.body()))
-
-    cache.set(key, res.body(), ttl_seconds = DEFAULTS["ttl"])
 
     return res.body()
 

--- a/apps/nascarnextrace/nascarnextrace.star
+++ b/apps/nascarnextrace/nascarnextrace.star
@@ -6,7 +6,6 @@ Author: jvivona
 """
 
 load("animation.star", "animation")
-load("cache.star", "cache")
 load("encoding/json.star", "json")
 load("http.star", "http")
 load("math.star", "math")
@@ -14,7 +13,7 @@ load("render.star", "render")
 load("schema.star", "schema")
 load("time.star", "time")
 
-VERSION = 23060
+VERSION = 23132
 
 # cache data for 15 minutes - cycle through with cache on the API side
 CACHE_TTL_SECONDS = 900
@@ -432,17 +431,9 @@ def title_box(series, display):
     )
 
 def get_cachable_data(url):
-    key = url
-
-    data = cache.get(key)
-    if data != None:
-        return data
-
-    res = http.get(url = url)
+    res = http.get(url = url, ttl_seconds = CACHE_TTL_SECONDS)
     if res.status_code != 200:
         fail("request to %s failed with status code: %d - %s" % (url, res.status_code, res.body()))
-
-    cache.set(key, res.body(), ttl_seconds = CACHE_TTL_SECONDS)
 
     return res.body()
 

--- a/apps/soccermens/soccermens.star
+++ b/apps/soccermens/soccermens.star
@@ -5,14 +5,13 @@ Description: Displays live and upcoming soccer scores from a data feed.   Heavil
 Author: jvivona
 """
 
-load("cache.star", "cache")
 load("encoding/json.star", "json")
 load("http.star", "http")
 load("render.star", "render")
 load("schema.star", "schema")
 load("time.star", "time")
 
-VERSION = 23111
+VERSION = 23132
 
 # thanks to @jesushairdo for the new option to be able to show home or away team first.  Let's be more international :-)
 
@@ -812,16 +811,8 @@ def get_gametime_column(gameTime, textColor, leagueAbbr):
     return gameTimeColumn
 
 def get_cachable_data(url):
-    key = url
-
-    data = cache.get(key)
-    if data != None:
-        return data
-
-    res = http.get(url = url)
+    res = http.get(url = url, ttl_seconds = CACHE_TTL_SECONDS)
     if res.status_code != 200:
         fail("request to %s failed with status code: %d - %s" % (url, res.status_code, res.body()))
-
-    cache.set(key, res.body(), CACHE_TTL_SECONDS)
 
     return res.body()

--- a/apps/soccersingle/soccer_single.star
+++ b/apps/soccersingle/soccer_single.star
@@ -9,14 +9,13 @@ Author: jvivona
 # and thanks to @dinotash/@dinosaursrarr for making me think deep thoughts about connected schema fields
 # and of course - the original author of a bunch of this display code is @Lunchbox8484
 
-load("cache.star", "cache")
 load("encoding/json.star", "json")
 load("http.star", "http")
 load("render.star", "render")
 load("schema.star", "schema")
 load("time.star", "time")
 
-VERSION = 23111
+VERSION = 23132
 
 CACHE_TTL_SECONDS = 60
 
@@ -665,16 +664,8 @@ def get_gametime_column(gameTime, textColor, leagueAbbr):
     return gameTimeColumn
 
 def get_cachable_data(url):
-    key = url
-
-    data = cache.get(key)
-    if data != None:
-        return data
-
-    res = http.get(url = url)
+    res = http.get(url = url, ttl_seconds = CACHE_TTL_SECONDS)
     if res.status_code != 200:
         fail("request to %s failed with status code: %d - %s" % (url, res.status_code, res.body()))
-
-    cache.set(key, res.body(), CACHE_TTL_SECONDS)
 
     return res.body()

--- a/apps/soccerwomens/soccerwomens.star
+++ b/apps/soccerwomens/soccerwomens.star
@@ -5,14 +5,13 @@ Description: Displays live and upcoming soccer scores from a data feed.   Heavil
 Author: jvivona
 """
 
-load("cache.star", "cache")
 load("encoding/json.star", "json")
 load("http.star", "http")
 load("render.star", "render")
 load("schema.star", "schema")
 load("time.star", "time")
 
-VERSION = 23111
+VERSION = 23132
 
 # thanks to @jesushairdo for the new option to be able to show home or away team first.  Let's be more international :-)
 
@@ -827,16 +826,8 @@ def get_gametime_column(gameTime, textColor, leagueAbbr):
     return gameTimeColumn
 
 def get_cachable_data(url):
-    key = url
-
-    data = cache.get(key)
-    if data != None:
-        return data
-
-    res = http.get(url = url)
+    res = http.get(url = url, ttl_seconds = CACHE_TTL_SECONDS)
     if res.status_code != 200:
         fail("request to %s failed with status code: %d - %s" % (url, res.status_code, res.body()))
-
-    cache.set(key, res.body(), CACHE_TTL_SECONDS)
 
     return res.body()

--- a/apps/theguardiannews/theguardiannews.star
+++ b/apps/theguardiannews/theguardiannews.star
@@ -8,14 +8,13 @@ Description: Gets latest new articles from The Guardian and displays up to 3 art
 
 # update - 2023-03-07 - back to the live website feed - now that their IT group has stablized everything.  add in 1st sentence of description
 
-load("cache.star", "cache")
 load("http.star", "http")
 load("re.star", "re")
 load("render.star", "render")
 load("schema.star", "schema")
 load("xpath.star", "xpath")
 
-VERSION = 23066
+VERSION = 23132
 
 # cache data for 15 minutes - cycle through with cache on the API side
 CACHE_TTL_SECONDS = 900
@@ -140,15 +139,12 @@ def get_schema():
 def get_cacheable_data(url, articlecount):
     if url == "intl":
         url = "international"  # this was changed during the switch in dec 2022 from guardian - keep our text for display - but convert
-    key = url
-    data = cache.get(key)
+
     articles = []
-    if data == None:
-        res = http.get(RSS_STUB.format(url))
-        if res.status_code != 200:
-            fail("request to %s failed with status code: %d - %s" % (url, res.status_code, res.body()))
-        data = res.body()
-        cache.set(key, data, ttl_seconds = CACHE_TTL_SECONDS)
+    res = http.get(RSS_STUB.format(url), ttl_seconds = CACHE_TTL_SECONDS)
+    if res.status_code != 200:
+        fail("request to %s failed with status code: %d - %s" % (url, res.status_code, res.body()))
+    data = res.body()
 
     data_xml = xpath.loads(data)
 

--- a/apps/wsjnews/wsj_news.star
+++ b/apps/wsjnews/wsj_news.star
@@ -5,13 +5,12 @@ Description: Display Wall Street Journal news headlines.
 Author: jvivona
 """
 
-load("cache.star", "cache")
 load("http.star", "http")
 load("render.star", "render")
 load("schema.star", "schema")
 load("xpath.star", "xpath")
 
-VERSION = 23074
+VERSION = 23132
 
 # cache data for 15 minutes
 CACHE_TTL_SECONDS = 900
@@ -149,16 +148,12 @@ def get_schema():
     )
 
 def get_cacheable_data(url, articlecount):
-    key = url
-    data = cache.get(key)
     articles = []
 
-    if data == None:
-        res = http.get(RSS_STUB.format(url))
-        if res.status_code != 200:
-            fail("request to %s failed with status code: %d - %s" % (url, res.status_code, res.body()))
-        data = res.body()
-        cache.set(key, data, ttl_seconds = CACHE_TTL_SECONDS)
+    res = http.get(RSS_STUB.format(url), ttl_seconds = CACHE_TTL_SECONDS)
+    if res.status_code != 200:
+        fail("request to %s failed with status code: %d - %s" % (url, res.status_code, res.body()))
+    data = res.body()
 
     data_xml = xpath.loads(data)
 


### PR DESCRIPTION
# Description
update with new cache method for http.get in
AA Daily Reflection
CNN News
Formula1
Financial Times
Fox News
Indycar
NASCAR
Soccer Mens
Soccer Single Team
Soccer Womens
The Guardian News
Wall Street Journal News

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 740870b</samp>

### Summary
🚀🧹📰

<!--
1.  🚀 - This emoji represents the improved performance and speed of the apps by using the built-in caching feature of the http.get function instead of the cache.star module.
2.  🧹 - This emoji represents the removal of the unnecessary dependency on the cache.star module and the simplification of the app code by using the native caching mechanism of the http.get function.
3.  📰 - This emoji represents the news-related apps that are affected by these changes, such as cnn_news, financial_times, fox_news, theguardiannews, and wsj_news.
-->
This pull request refactors several apps in the tidbyt/community repository to use the built-in caching feature of the `http.get` function instead of the external `cache.star` module. This simplifies the code, improves the performance, and reduces the risk of errors. The affected apps are `aadailyreflect`, `cnnnews`, `financialtimes`, `formula1`, `foxnews`, `indycar`, `nascarnextrace`, `soccermens`, `soccersingle`, `soccerwomens`, `theguardiannews`, and `wsjnews`. Some apps also update their version numbers and add comments.

> _`cache.star` gone_
> _`http.get` handles caching_
> _apps run faster, smooth_

### Walkthrough
*  Remove the loading of the `cache.star` module from all apps, as it is no longer needed ([link](https://github.com/tidbyt/community/pull/1451/files?diff=unified&w=0#diff-d87b90b917b3654df75a8f45143c6161e2f6a59882611d12a8e7c76c1ba4b4cdL8), [link](https://github.com/tidbyt/community/pull/1451/files?diff=unified&w=0#diff-22065b2149e2fc3fe2e95b40d29b4e689a44a15d349be76500af1d6bf9ce9990L8), [link](https://github.com/tidbyt/community/pull/1451/files?diff=unified&w=0#diff-2ad6521a7b6fb21c64fb0119989659246a3c4c7e8c610c4b9ed43ed0ab78d4bbL9), [link](https://github.com/tidbyt/community/pull/1451/files?diff=unified&w=0#diff-ceb1de56f484321b028d7f48fe73870cc1a0e5b2f22657752934810c27f0e333L8), [link](https://github.com/tidbyt/community/pull/1451/files?diff=unified&w=0#diff-7c5fd852d27548767e4e2bd2beabd1e492931668719235a52cfe6db8484e126cL8), [link](https://github.com/tidbyt/community/pull/1451/files?diff=unified&w=0#diff-cfe68139033f465b97af504645c809b9f97f1075ef7bb1436e6ca51e8af36f63L12), [link](https://github.com/tidbyt/community/pull/1451/files?diff=unified&w=0#diff-b1c40f21af46b32ce867ca5487d2de7ca7fb741c7fe133f2fe2a2ddf06ea4ff2L9), [link](https://github.com/tidbyt/community/pull/1451/files?diff=unified&w=0#diff-790902b1ba9fd6b0dbc454e0ec3c835b69ef4727f28660901980b6c798d3d758L8), [link](https://github.com/tidbyt/community/pull/1451/files?diff=unified&w=0#diff-43a82dc095c51decf1aa17eb41bf1cb9e1116d126484d35557e2608d965b4e05L12), [link](https://github.com/tidbyt/community/pull/1451/files?diff=unified&w=0#diff-8a21d6e075c01eae333ed8a0d3a6b428635719c2860a9c9f98e78ef1f8b6ebb2L8), [link](https://github.com/tidbyt/community/pull/1451/files?diff=unified&w=0#diff-d17d0972ac57d9622fae18294fc50d9cfe8c0d047ae67ce50c716b71afc7add7L11), [link](https://github.com/tidbyt/community/pull/1451/files?diff=unified&w=0#diff-1f4909095b29bd33819481b32a79b7329a8b0ed820a034ff2d2f578fc270b93dL8))
* Update the `VERSION` variable to reflect the latest version of the app, which is 23132, in all apps ([link](https://github.com/tidbyt/community/pull/1451/files?diff=unified&w=0#diff-d87b90b917b3654df75a8f45143c6161e2f6a59882611d12a8e7c76c1ba4b4cdL14-R13), [link](https://github.com/tidbyt/community/pull/1451/files?diff=unified&w=0#diff-22065b2149e2fc3fe2e95b40d29b4e689a44a15d349be76500af1d6bf9ce9990L14-R13), [link](https://github.com/tidbyt/community/pull/1451/files?diff=unified&w=0#diff-2ad6521a7b6fb21c64fb0119989659246a3c4c7e8c610c4b9ed43ed0ab78d4bbL15-R14), [link](https://github.com/tidbyt/community/pull/1451/files?diff=unified&w=0#diff-ceb1de56f484321b028d7f48fe73870cc1a0e5b2f22657752934810c27f0e333L16-R15), [link](https://github.com/tidbyt/community/pull/1451/files?diff=unified&w=0#diff-7c5fd852d27548767e4e2bd2beabd1e492931668719235a52cfe6db8484e126cL14-R13), [link](https://github.com/tidbyt/community/pull/1451/files?diff=unified&w=0#diff-cfe68139033f465b97af504645c809b9f97f1075ef7bb1436e6ca51e8af36f63L20-R19), [link](https://github.com/tidbyt/community/pull/1451/files?diff=unified&w=0#diff-b1c40f21af46b32ce867ca5487d2de7ca7fb741c7fe133f2fe2a2ddf06ea4ff2L17-R16), [link](https://github.com/tidbyt/community/pull/1451/files?diff=unified&w=0#diff-790902b1ba9fd6b0dbc454e0ec3c835b69ef4727f28660901980b6c798d3d758L15-R14), [link](https://github.com/tidbyt/community/pull/1451/files?diff=unified&w=0#diff-43a82dc095c51decf1aa17eb41bf1cb9e1116d126484d35557e2608d965b4e05L19-R18), [link](https://github.com/tidbyt/community/pull/1451/files?diff=unified&w=0#diff-8a21d6e075c01eae333ed8a0d3a6b428635719c2860a9c9f98e78ef1f8b6ebb2L15-R14), [link](https://github.com/tidbyt/community/pull/1451/files?diff=unified&w=0#diff-d17d0972ac57d9622fae18294fc50d9cfe8c0d047ae67ce50c716b71afc7add7L18-R17), [link](https://github.com/tidbyt/community/pull/1451/files?diff=unified&w=0#diff-1f4909095b29bd33819481b32a79b7329a8b0ed820a034ff2d2f578fc270b93dL14-R13))
* Simplify the `get_cacheable_data` function or its equivalent by removing the `cache.get` and `cache.set` calls and using the `ttl_seconds` parameter in the `http.get` call instead, in all apps ([link](https://github.com/tidbyt/community/pull/1451/files?diff=unified&w=0#diff-d87b90b917b3654df75a8f45143c6161e2f6a59882611d12a8e7c76c1ba4b4cdL82-R84), [link](https://github.com/tidbyt/community/pull/1451/files?diff=unified&w=0#diff-22065b2149e2fc3fe2e95b40d29b4e689a44a15d349be76500af1d6bf9ce9990L168-R172), [link](https://github.com/tidbyt/community/pull/1451/files?diff=unified&w=0#diff-2ad6521a7b6fb21c64fb0119989659246a3c4c7e8c610c4b9ed43ed0ab78d4bbL148-R152), [link](https://github.com/tidbyt/community/pull/1451/files?diff=unified&w=0#diff-ceb1de56f484321b028d7f48fe73870cc1a0e5b2f22657752934810c27f0e333L347-R355), [link](https://github.com/tidbyt/community/pull/1451/files?diff=unified&w=0#diff-7c5fd852d27548767e4e2bd2beabd1e492931668719235a52cfe6db8484e126cL159-R164), [link](https://github.com/tidbyt/community/pull/1451/files?diff=unified&w=0#diff-cfe68139033f465b97af504645c809b9f97f1075ef7bb1436e6ca51e8af36f63L272-R274), [link](https://github.com/tidbyt/community/pull/1451/files?diff=unified&w=0#diff-b1c40f21af46b32ce867ca5487d2de7ca7fb741c7fe133f2fe2a2ddf06ea4ff2L435-R437), [link](https://github.com/tidbyt/community/pull/1451/files?diff=unified&w=0#diff-790902b1ba9fd6b0dbc454e0ec3c835b69ef4727f28660901980b6c798d3d758L815-R817), [link](https://github.com/tidbyt/community/pull/1451/files?diff=unified&w=0#diff-43a82dc095c51decf1aa17eb41bf1cb9e1116d126484d35557e2608d965b4e05L668-R670), [link](https://github.com/tidbyt/community/pull/1451/files?diff=unified&w=0#diff-8a21d6e075c01eae333ed8a0d3a6b428635719c2860a9c9f98e78ef1f8b6ebb2L830-R832), [link](https://github.com/tidbyt/community/pull/1451/files?diff=unified&w=0#diff-d17d0972ac57d9622fae18294fc50d9cfe8c0d047ae67ce50c716b71afc7add7L143-R147), [link](https://github.com/tidbyt/community/pull/1451/files?diff=unified&w=0#diff-1f4909095b29bd33819481b32a79b7329a8b0ed820a034ff2d2f578fc270b93dL152-R156))
* Add a comment to indicate the author and date of the new cache method in the `formula_1.star` app ([link](https://github.com/tidbyt/community/pull/1451/files?diff=unified&w=0#diff-ceb1de56f484321b028d7f48fe73870cc1a0e5b2f22657752934810c27f0e333R31-R32))


