### PR TITLE
updownio: Add demo screen when API key or check token are not set

### DIFF
--- a/apps/updownio/updownio.star
+++ b/apps/updownio/updownio.star
@@ -30,8 +30,8 @@ def main(config):
             "metrics": {
                 "timings": {
                     "total": 123,
-                }
-            }
+                },
+            },
         }
         return render_up_screen(mock_data)
 

--- a/apps/updownio/updownio.star
+++ b/apps/updownio/updownio.star
@@ -25,9 +25,15 @@ def main(config):
     check_token = config.str("check_token")
 
     if not api_key or not check_token:
-        return render.Root(
-            child = render.WrappedText("Please set both API Key and Check Token in settings", font = "5x8"),
-        )
+        mock_data = {
+            "alias": "demo.example.com",
+            "metrics": {
+                "timings": {
+                    "total": 123,
+                }
+            }
+        }
+        return render_up_screen(mock_data)
 
     # Some notes about cache_key:
     # 1. We combine api_key and check_token to prevent people from fetching other people's checks.


### PR DESCRIPTION
# Description
Per @matslina's [feedback](https://github.com/tidbyt/community/pull/1429#discussion_r1191701739), adds a demo screen with mock data when either the API key or check token are missing.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 97ccb49</samp>

### Summary
🎨🧪🛠️

<!--
1.  🎨 - This emoji represents the addition of a new feature or enhancement to the app, which is the mock data option. It can also signify creativity or design improvements.
2.  🧪 - This emoji represents the testing or experimentation aspect of the change, which is useful for verifying the app's functionality and finding bugs. It can also signify curiosity or learning.
3.  🛠️ - This emoji represents the debugging or fixing aspect of the change, which is helpful for resolving issues and improving the app's performance. It can also signify maintenance or repair.
-->
Add mock data option for Updown.io app. This allows testing the app with dummy data by setting `mock_data` to `true` in `apps/updownio/updownio.star`.

> _Mock data option_
> _`render_up_screen` with dummy_
> _Winter of testing_

### Walkthrough
* Add a mock data option for testing the app ([link](https://github.com/tidbyt/community/pull/1454/files?diff=unified&w=0#diff-3c08a961a01e7e7a9e4a5a99e42bbf2cd6dafe584c9c07ff887b63e1065c55deL28-R36))


