### PR TITLE
Update: Tennis Rankings

### DIFF
--- a/apps/tennisrankings/tennis_rankings.star
+++ b/apps/tennisrankings/tennis_rankings.star
@@ -3,10 +3,11 @@ Applet: Tennis Rankings
 Summary: Shows ATP/WTA Top 20
 Description: Displays either ATP or WTA Top 20 with options for position change and total points.
 Author: M0ntyP
+
+v1.1
+Updated caching function and changed title bar color for WTA
 """
 
-load("cache.star", "cache")
-load("encoding/base64.star", "base64")
 load("encoding/json.star", "json")
 load("http.star", "http")
 load("humanize.star", "humanize")
@@ -145,11 +146,16 @@ def main(config):
 def get_screen(x, RankingJSON, Selection):
     output = []
 
+    if Selection == "wta":
+        TitleBarColor = "#7915ff"
+    else:
+        TitleBarColor = "#203764"
+
     heading = [
         render.Box(
             width = 64,
             height = 5,
-            color = "#203764",
+            color = TitleBarColor,
             child = render.Row(
                 expanded = True,
                 main_align = "start",
@@ -201,11 +207,16 @@ def get_screen(x, RankingJSON, Selection):
 def get_screenPoints(x, RankingJSON, Selection):
     output = []
 
+    if Selection == "wta":
+        TitleBarColor = "#7915ff"
+    else:
+        TitleBarColor = "#203764"
+
     heading = [
         render.Box(
             width = 64,
             height = 5,
-            color = "#203764",
+            color = TitleBarColor,
             child = render.Row(
                 expanded = True,
                 main_align = "start",
@@ -269,14 +280,20 @@ def get_screenPoints(x, RankingJSON, Selection):
     return output
 
 def get_screenTrend(x, RankingJSON, Selection):
+    print(Selection)
     output = []
+    if Selection == "wta":
+        TitleBarColor = "#7915ff"
+    else:
+        TitleBarColor = "#203764"
+
     TrendColor = "#fff"
 
     heading = [
         render.Box(
             width = 64,
             height = 5,
-            color = "#203764",
+            color = TitleBarColor,
             child = render.Row(
                 expanded = True,
                 main_align = "start",
@@ -348,18 +365,10 @@ def get_screenTrend(x, RankingJSON, Selection):
     return output
 
 def get_cachable_data(url, timeout):
-    key = base64.encode(url)
+    res = http.get(url = url, ttl_seconds = timeout)
 
-    data = cache.get(key)
-    if data != None:
-        #print("CACHED")
-        return base64.decode(data)
-
-    res = http.get(url = url)
     if res.status_code != 200:
         fail("request to %s failed with status code: %d - %s" % (url, res.status_code, res.body()))
-
-    cache.set(key, base64.encode(res.body()), ttl_seconds = timeout)
 
     return res.body()
 

--- a/apps/tennisrankings/tennis_rankings.star
+++ b/apps/tennisrankings/tennis_rankings.star
@@ -280,7 +280,7 @@ def get_screenPoints(x, RankingJSON, Selection):
     return output
 
 def get_screenTrend(x, RankingJSON, Selection):
-    print(Selection)
+    #print(Selection)
     output = []
     if Selection == "wta":
         TitleBarColor = "#7915ff"


### PR DESCRIPTION
# Description
Updated caching function and changed title bar color for WTA

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1e46b60</samp>

### Summary
🎨🚀💬

<!--
1.  🎨 for updating the title bar colors to match the ATP and WTA logos.
2.  🚀 for using the built-in caching feature of the http.get function, which can improve the app's performance and reduce network requests.
3.  💬 for adding comments and print statements for documentation and debugging purposes.
-->
The `tennis_rankings` app now shows different colors for men's and women's tennis rankings, and uses caching to improve performance and reduce network requests. The code also has more comments and print statements for clarity and troubleshooting.

> _`tennis_rankings` app of doom_
> _Switching colors for ATP and WTA_
> _Caching the data with `http.get`_
> _Comments and prints to guide the way_

### Walkthrough
*  Added version number and comment, and removed unused imports of cache and base64 modules in `tennis_rankings.star` ([link](https://github.com/tidbyt/community/pull/1456/files?diff=unified&w=0#diff-9a6a1ce720b24d7d54f2a20292d720ce1145432a2c8bd261c8f564368dd7dda1L6-R10))
*  Added conditional statement to assign different title bar colors for WTA and ATP options, and used new variable TitleBarColor to set the color of render.Box elements in heading and output lists in `tennis_rankings.star` ([link](https://github.com/tidbyt/community/pull/1456/files?diff=unified&w=0#diff-9a6a1ce720b24d7d54f2a20292d720ce1145432a2c8bd261c8f564368dd7dda1L148-R158), [link](https://github.com/tidbyt/community/pull/1456/files?diff=unified&w=0#diff-9a6a1ce720b24d7d54f2a20292d720ce1145432a2c8bd261c8f564368dd7dda1L204-R219), [link](https://github.com/tidbyt/community/pull/1456/files?diff=unified&w=0#diff-9a6a1ce720b24d7d54f2a20292d720ce1145432a2c8bd261c8f564368dd7dda1L279-R296))
*  Simplified get_cachable_data function by using ttl_seconds parameter of http.get function and removing base64 encoding and decoding in `tennis_rankings.star` ([link](https://github.com/tidbyt/community/pull/1456/files?diff=unified&w=0#diff-9a6a1ce720b24d7d54f2a20292d720ce1145432a2c8bd261c8f564368dd7dda1L351-R372))
*  Added print statement to debug Selection parameter in get_screenTrend function in `tennis_rankings.star` ([link](https://github.com/tidbyt/community/pull/1456/files?diff=unified&w=0#diff-9a6a1ce720b24d7d54f2a20292d720ce1145432a2c8bd261c8f564368dd7dda1L272-R289))


