### PR TITLE
Formula1 : update race name and fix alignment for WCC

### DIFF
--- a/apps/formula1/formula_1.star
+++ b/apps/formula1/formula_1.star
@@ -12,7 +12,7 @@ load("render.star", "render")
 load("schema.star", "schema")
 load("time.star", "time")
 
-VERSION = 23132
+VERSION = 23133
 
 # ############################
 # Mods - jvivona - 2023-02-04
@@ -30,6 +30,9 @@ VERSION = 23132
 # - added proper case names for constructors
 # jvivona - 2023-05-12
 # - new cache method
+# jvivona - 2023-05-13
+# - change scoll to show race name + locality
+# - fix WCC standings alignment issue
 # ############################
 
 DEFAULTS = {

--- a/apps/formula1/formula_1.star
+++ b/apps/formula1/formula_1.star
@@ -133,15 +133,15 @@ def main(config):
         date_and_time3 = time.parse_time(date_and_time, "2006-01-02T15:04:05Z", "UTC").in_location(timezone)
 
         # handle date & time display options here
-        date_str = date_and_time3.format("Jan 02" if config.bool("date_us", DEFAULTS["date_us"]) else "02 Jan").upper()  #current format of your current date str
-        time_str = date_and_time3.format("15:04" if config.bool("time_24", DEFAULTS["time_24"]) else "3:04pm")  #outputs military time but can change 15 to 3 to not do that. The Only thing missing from your current string though is the time zone, but if they're doing local time that's pretty irrelevant
+        date_str = date_and_time3.format("Jan 02" if config.bool("date_us", DEFAULTS["date_us"]) else "02 Jan")  #current format of your current date str
+        time_str = date_and_time3.format("15:04" if config.bool("time_24", DEFAULTS["time_24"]) else "3:04pm")[:-1]  #outputs military time but can change 15 to 3 to not do that. The Only thing missing from your current string though is the time zone, but if they're doing local time that's pretty irrelevant
 
         return render.Root(
             child = render.Column(
                 children = [
                     render.Marquee(
                         width = 64,
-                        child = render.Text("Next Race: " + next_race["Circuit"]["Location"]["country"]),
+                        child = render.Text(" " + next_race["raceName"] + " - " + next_race["Circuit"]["Location"]["locality"] + " " + next_race["Circuit"]["Location"]["country"]),
                         offset_start = 5,
                         offset_end = 5,
                     ),
@@ -183,12 +183,12 @@ def main(config):
                             render.Stack(
                                 children = [
                                     render.Image(src = F1_CONSTRUCTOR.get(Constructor1, "Red Bull")),
-                                    render.Text("1"),
+                                    render.Text("1", font = "5x8"),
                                 ],
                             ),
                             render.Marquee(
                                 width = 50,
-                                child = render.Text(Points1 + " pts - " + text_justify_trunc(12, CONSTRUCTOR_NAMES[Constructor1], "left")),
+                                child = render.Text(Points1 + " pts - " + text_justify_trunc(12, CONSTRUCTOR_NAMES[Constructor1], "left"), font = "5x8"),
                                 offset_start = 64,
                                 offset_end = 64,
                             ),
@@ -199,12 +199,12 @@ def main(config):
                             render.Stack(
                                 children = [
                                     render.Image(src = F1_CONSTRUCTOR.get(Constructor2, "Red Bull")),
-                                    render.Text("2"),
+                                    render.Text("2", font = "5x8"),
                                 ],
                             ),
                             render.Marquee(
                                 width = 50,
-                                child = render.Text(Points2 + " pts - " + text_justify_trunc(12, CONSTRUCTOR_NAMES[Constructor2], "left")),
+                                child = render.Text(Points2 + " pts - " + text_justify_trunc(12, CONSTRUCTOR_NAMES[Constructor2], "left"), font = "5x8"),
                                 offset_start = 64,
                                 offset_end = 64,
                             ),
@@ -220,7 +220,7 @@ def main(config):
                             ),
                             render.Marquee(
                                 width = 50,
-                                child = render.Text(Points3 + " pts - " + text_justify_trunc(12, CONSTRUCTOR_NAMES[Constructor3], "left")),
+                                child = render.Text(Points3 + " pts - " + text_justify_trunc(12, CONSTRUCTOR_NAMES[Constructor3], "left"), font = "5x8"),
                                 offset_start = 64,
                                 offset_end = 64,
                             ),


### PR DESCRIPTION
# Description
change top scroll to show race name + locality instead of just country
fix alignment issue on WCC standings

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2291a19</samp>

### Summary
🏁📐🆙

<!--
1.  🏁 This emoji represents the racing theme of the app and the addition of more details about the next race.
2.  📐 This emoji represents the alignment and font size adjustments of the WCC standings to improve the layout and readability of the app.
3.  🆙 This emoji represents the update of the app version and the comment header to reflect the changes made.
-->
Updated `formula1` app to show more race information and improve layout. Fixed font size, alignment, and scroll text for better readability.

> _`VERSION` updated_
> _More race details on display_
> _Autumn leaves falling_

### Walkthrough
*  Incremented app version to reflect new features and fixes ([link](https://github.com/tidbyt/community/pull/1457/files?diff=unified&w=0#diff-ceb1de56f484321b028d7f48fe73870cc1a0e5b2f22657752934810c27f0e333L15-R15))
*  Added comment to document changes by author and date ([link](https://github.com/tidbyt/community/pull/1457/files?diff=unified&w=0#diff-ceb1de56f484321b028d7f48fe73870cc1a0e5b2f22657752934810c27f0e333R33-R35))
*  Modified scroll text to show race name and locality for next race ([link](https://github.com/tidbyt/community/pull/1457/files?diff=unified&w=0#diff-ceb1de56f484321b028d7f48fe73870cc1a0e5b2f22657752934810c27f0e333L144-R147))
*  Removed last character of time string to save space and avoid overlap with date string ([link](https://github.com/tidbyt/community/pull/1457/files?diff=unified&w=0#diff-ceb1de56f484321b028d7f48fe73870cc1a0e5b2f22657752934810c27f0e333L136-R140))
*  Added font argument and set to "5x8" for render.Text functions to fix alignment issue of WCC standings ([link](https://github.com/tidbyt/community/pull/1457/files?diff=unified&w=0#diff-ceb1de56f484321b028d7f48fe73870cc1a0e5b2f22657752934810c27f0e333L186-R194), [link](https://github.com/tidbyt/community/pull/1457/files?diff=unified&w=0#diff-ceb1de56f484321b028d7f48fe73870cc1a0e5b2f22657752934810c27f0e333L202-R210), [link](https://github.com/tidbyt/community/pull/1457/files?diff=unified&w=0#diff-ceb1de56f484321b028d7f48fe73870cc1a0e5b2f22657752934810c27f0e333L223-R226))


