### PR TITLE
formula1 - fix trunc of am/pm

### DIFF
--- a/apps/formula1/formula_1.star
+++ b/apps/formula1/formula_1.star
@@ -12,7 +12,7 @@ load("render.star", "render")
 load("schema.star", "schema")
 load("time.star", "time")
 
-VERSION = 23133
+VERSION = 23134
 
 # ############################
 # Mods - jvivona - 2023-02-04
@@ -33,6 +33,8 @@ VERSION = 23133
 # jvivona - 2023-05-13
 # - change scoll to show race name + locality
 # - fix WCC standings alignment issue
+# jvivona - 2023-05-14
+# - fix trunc of am/pm - to not trunc when we're in 24 hour format
 # ############################
 
 DEFAULTS = {
@@ -137,7 +139,7 @@ def main(config):
 
         # handle date & time display options here
         date_str = date_and_time3.format("Jan 02" if config.bool("date_us", DEFAULTS["date_us"]) else "02 Jan")  #current format of your current date str
-        time_str = date_and_time3.format("15:04" if config.bool("time_24", DEFAULTS["time_24"]) else "3:04pm")[:-1]  #outputs military time but can change 15 to 3 to not do that. The Only thing missing from your current string though is the time zone, but if they're doing local time that's pretty irrelevant
+        time_str = date_and_time3.format("15:04" if config.bool("time_24", DEFAULTS["time_24"]) else "3:04pm").replace("m", "")  #outputs military time but can change 15 to 3 to not do that. The Only thing missing from your current string though is the time zone, but if they're doing local time that's pretty irrelevant
 
         return render.Root(
             child = render.Column(


### PR DESCRIPTION
which i just broke yesterday

# Description
fix trunc of time to just am/pm instead of including 24 hour time

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c376d75</samp>

### Summary
🐛🔢💬

<!--
1.  🐛 Bug: This emoji is commonly used to indicate a bug fix or a problem that has been resolved. It can also convey a sense of frustration or annoyance with a bug. In this case, it represents the bug with the time display option that was fixed by the pull request.
2.  🔢 Numbers: This emoji is often used to represent numbers, digits, math, statistics, or data. It can also imply counting, ranking, or measuring something. In this case, it represents the increase in the version number of the formula1 app, which is a way of tracking the changes and improvements made to the app over time.
3.  💬 Speech Balloon: This emoji is typically used to represent speech, communication, conversation, or chat. It can also imply commenting, explaining, or giving feedback. In this case, it represents the comment that was added to the code to explain the bug fix and how it works.
-->
This pull request improves the formula1 app by fixing a time display bug and updating the version number. The bug fix is documented in `formula_1.star`.

> _Formula1 app_
> _`time display` bug is fixed_
> _Version number grows_

### Walkthrough
*  Fix truncation of am/pm in time display option for formula1 app ([link](https://github.com/tidbyt/community/pull/1461/files?diff=unified&w=0#diff-ceb1de56f484321b028d7f48fe73870cc1a0e5b2f22657752934810c27f0e333R36-R37), [link](https://github.com/tidbyt/community/pull/1461/files?diff=unified&w=0#diff-ceb1de56f484321b028d7f48fe73870cc1a0e5b2f22657752934810c27f0e333L140-R142))
*  Bump up version number of formula1 app ([link](https://github.com/tidbyt/community/pull/1461/files?diff=unified&w=0#diff-ceb1de56f484321b028d7f48fe73870cc1a0e5b2f22657752934810c27f0e333L15-R15))


