### PR TITLE
noaa-apps : convert to http-cache where able

### DIFF
--- a/apps/noaabuoy/noaa_buoy.star
+++ b/apps/noaabuoy/noaa_buoy.star
@@ -68,7 +68,7 @@ def fetch_data(buoy_id, last_data):
     data = dict()
     url = "https://www.ndbc.noaa.gov/data/latest_obs/%s.rss" % buoy_id.lower()
     debug_print("url: " + url)
-    resp = http.get(url)
+    resp = http.get(url, ttl_seconds = 600) # 10 minutes http cache time
     debug_print(resp)
     if resp.status_code != 200:
         if len(last_data) != 0:  # try to return the last cached data if it exists to account for spurious api failures
@@ -173,15 +173,15 @@ def main(config):
             if "stale" in data and data["stale"] > 2:
                 debug_print("expring stale cache")
 
-                # TODO: Determine if this cache call can be converted to the new HTTP cache.
+                # Custom cacheing determines if we have very stale data. Can't use http cache
                 cache.set(cache_key, json.encode(data), ttl_seconds = 1)  # 1 sec expire almost immediately
             else:
                 debug_print("Setting cache with : " + str(data))
 
-                # TODO: Determine if this cache call can be converted to the new HTTP cache.
+                # Custom cacheing determines if we have very stale data. Can't use http cache
                 cache.set(cache_key, json.encode(data), ttl_seconds = 1800)  # 30 minutes, should never actually expire because always getting re set
 
-                # TODO: Determine if this cache call can be converted to the new HTTP cache.
+                # Custom cacheing determines if we have very stale data. Can't use http cache
                 cache.set(cache_key + "_usecache", '{"usecache":"true"}', ttl_seconds = 600)  # 10 minutes
 
     if buoy_name == "" and "name" in data:

--- a/apps/noaatides/noaa_tides.star
+++ b/apps/noaatides/noaa_tides.star
@@ -123,7 +123,7 @@ def get_tides_hilo(station_id):
     url = NOAA_API_URL_HILO % (station_id)
     if not debug:
         debug_print("HILO Url : " + url)
-        resp = http.get(url)
+        resp = http.get(url,ttl_seconds = 14400) # cache for 4 hours (tides don't change much)
         if resp.status_code != 200:
             tides = None
         else:
@@ -139,7 +139,8 @@ def get_tides_graph(station_id):
     url = NOAA_API_URL_GRAPH % (station_id)
     if not debug:
         debug_print("Graph Url : " + url)
-        resp = http.get(url)
+        resp = http.get(url, ttl_seconds = 14400) # cache for 4 hours (tides don't change much)
+        print(resp.headers.get("Tidbyt-Cache-Status"))
         if resp.status_code != 200:
             tides = None
         else:
@@ -180,7 +181,10 @@ def main(config):
         if "value" in local_selection:
             station_id = json.decode(local_selection)["value"]
             if station_name == None or station_name == "":
-                station_name = json.decode(local_selection)["display"]
+                if "display" in local_selection:
+                    station_name = json.decode(local_selection)["display"]
+                else:
+                    station_name = station_id
         else:
             station_id = local_selection  # san fran
 
@@ -189,30 +193,30 @@ def main(config):
     ################################ CACHINE CODE
     tides_hilo = {}
 
-    #load HILO cache
-    cache_key_hilo = "noaa_tides_%s" % (station_id)
-    cache_str_hilo = cache.get(cache_key_hilo)  #  not actually a json object yet, just a string
+    # #load HILO cache
+    # cache_key_hilo = "noaa_tides_%s" % (station_id)
+    # cache_str_hilo = cache.get(cache_key_hilo)  #  not actually a json object yet, just a string
 
-    #load GRAPH cache
-    cache_key_graph = "noaa_tides_graph_%s" % (station_id)
-    cache_str_graph = cache.get(cache_key_graph)
+    # #load GRAPH cache
+    # cache_key_graph = "noaa_tides_graph_%s" % (station_id)
+    # cache_str_graph = cache.get(cache_key_graph)
 
     tides_graph = {}
 
-    if cache_str_hilo != None:
-        debug_print("loading cached data")
-        tides_hilo = json.decode(cache_str_hilo)
-        tides_graph = json.decode(cache_str_graph)
-    if len(tides_hilo) == 0:
-        debug_print("pulling fresh tide data")
-        tides_hilo = get_tides_hilo(station_id)
-        tides_graph = get_tides_graph(station_id)
-        if tides_hilo != None:
-            # TODO: Determine if this cache call can be converted to the new HTTP cache.
-            cache.set(cache_key_hilo, json.encode(tides_hilo), ttl_seconds = 14400)  # 4 hours
+    # # if cache_str_hilo != None:
+    # #     debug_print("loading cached data")
+    # #     tides_hilo = json.decode(cache_str_hilo)
+    # #     tides_graph = json.decode(cache_str_graph)
+    # if len(tides_hilo) == 0:
+    #     debug_print("pulling fresh tide data")
+    tides_hilo = get_tides_hilo(station_id)
+    tides_graph = get_tides_graph(station_id)
+        # if tides_hilo != None:
+        #     # TODO: Determine if this cache call can be converted to the new HTTP cache.
+        #     cache.set(cache_key_hilo, json.encode(tides_hilo), ttl_seconds = 14400)  # 4 hours
 
-            # TODO: Determine if this cache call can be converted to the new HTTP cache.
-            cache.set(cache_key_graph, json.encode(tides_graph), ttl_seconds = 14400)  # 4 hours
+        #     # TODO: Determine if this cache call can be converted to the new HTTP cache.
+        #     cache.set(cache_key_graph, json.encode(tides_graph), ttl_seconds = 14400)  # 4 hours
 
     debug_print("Tides HILO : " + str(tides_hilo))
     debug_print("Tides GRAPH: " + str(tides_graph))


### PR DESCRIPTION
# Description
NOAA tides migraded to http cache.
NOAA buoy uses stale cache logic to always display data even if some fields are missing in http response so cannot rely solely on http cache.

# Copilot
<!-- please don't change the line below -->
copilot:all
