### PR TITLE
Use new cache

### DIFF
--- a/apps/borisbikes/boris_bikes.star
+++ b/apps/borisbikes/boris_bikes.star
@@ -5,7 +5,6 @@ Description: Availability for a Santander bicycle dock in London.
 Author: dinosaursrarr
 """
 
-load("cache.star", "cache")
 load("encoding/base64.star", "base64")
 load("encoding/json.star", "json")
 load("http.star", "http")
@@ -26,32 +25,25 @@ DEFAULT_DOCK_ID = "BikePoints_614"
 ENCRYPTED_APP_KEY = "AV6+xWcEJKHv8HrhH6FLyaWzsz0i+mcRr8QYac5oRBnj3Cruqdg/l/CuruDiOf4ILRyQPe5/7yoV3Wu8kdXr6WC4rK4FH/1FDuJksEGpdW9NKQj9m/mO3JH/s8B4ygGnPwstFgB/OWHTJh/92hu1hcpGVLhj4QHTY7Eai7HMqKg94x4Sk9I="
 LIST_DOCKS_URL = "https://api.tfl.gov.uk/BikePoint"
 DOCK_URL = "https://api.tfl.gov.uk/BikePoint/%s"
-NO_DATA_IN_CACHE = ""
+USER_AGENT = "Tidbyt boris_bikes"
 
 def app_key():
     return secret.decrypt(ENCRYPTED_APP_KEY) or ""  # Fall back to freebie quota
 
 def fetch_docks():
-    cached = cache.get(LIST_DOCKS_URL)
-    if cached == NO_DATA_IN_CACHE:
-        return None
-    if cached:
-        return json.decode(cached)
     resp = http.get(
         LIST_DOCKS_URL,
         params = {
             "app_key": app_key(),
         },
+        headers = {
+            "User-Agent": USER_AGENT,
+        },
+        ttl_seconds = 86400,  # Bike docks don't move often
     )
     if resp.status_code != 200:
         print("TFL BikePoint query failed with status ", resp.status_code)
-
-        # TODO: Determine if this cache call can be converted to the new HTTP cache.
-        cache.set(LIST_DOCKS_URL, NO_DATA_IN_CACHE, ttl_seconds = 30)
         return None
-
-    # TODO: Determine if this cache call can be converted to the new HTTP cache.
-    cache.set(LIST_DOCKS_URL, resp.body(), ttl_seconds = 86400)  # Bike docks don't move often
     return resp.json()
 
 # API gives errors when searching for locations outside the United Kingdom.
@@ -92,26 +84,19 @@ def list_docks(location):
     return [option[0] for option in options]
 
 def fetch_dock(dock_id):
-    cached = cache.get(dock_id)
-    if cached == NO_DATA_IN_CACHE:
-        return None
-    if cached:
-        return json.decode(cached)
     resp = http.get(
         DOCK_URL % dock_id,
         params = {
             "app_key": app_key(),
         },
+        headers = {
+            "User-Agent": USER_AGENT,
+        },
+        ttl_seconds = 30,
     )
     if resp.status_code != 200:
         print("TFL BikePoint request failed with status ", resp.status_code)
-
-        # TODO: Determine if this cache call can be converted to the new HTTP cache.
-        cache.set(dock_id, NO_DATA_IN_CACHE, ttl_seconds = 30)
         return None
-
-    # TODO: Determine if this cache call can be converted to the new HTTP cache.
-    cache.set(dock_id, resp.body(), ttl_seconds = 30)
     return resp.json()
 
 def tidy_name(name):

--- a/apps/busytube/busy_tube.star
+++ b/apps/busytube/busy_tube.star
@@ -5,7 +5,6 @@ Description: Tells you how busy a given TfL-operated station in London currently
 Author: dinosaursrarr
 """
 
-load("cache.star", "cache")
 load("encoding/json.star", "json")
 load("http.star", "http")
 load("humanize.star", "humanize")
@@ -28,7 +27,7 @@ STATION_URL = "https://api.tfl.gov.uk/StopPoint"
 CROWDING_LIVE_URL = "https://api.tfl.gov.uk/Crowding/%s/Live"
 CROWDING_TYPICAL_URL = "https://api.tfl.gov.uk/Crowding/%s/%s"
 ENCRYPTED_APP_KEY = "AV6+xWcEidogMm49QBNMdHN1M2Ysyt35b6k5o9A1/jHKh4sM5Czv5BffoQw0QBvCR7jr/pFvd4eHZqjuLWYkEX4MTpBTAjTFeTGS3ynqTeumZB7CCghUoULPLDscavZpf9X9m/OzQXsPlNS86qKGcLaJ4B/AaVZ8CLvccNTtKgoJYWq8zYI="
-NO_DATA_IN_CACHE = ""
+USER_AGENT = "Tidbyt busy_tube"
 
 CONTAINER_WIDTH = 62
 CONTAINER_HEIGHT = 30
@@ -47,13 +46,6 @@ def app_key():
 def fetch_stations(loc):
     rounded_lat = math.round(1000.0 * float(loc["lat"])) / 1000.0  # truncate to 3dp, which means
     rounded_lng = math.round(1000.0 * float(loc["lng"])) / 1000.0  # to the nearest ~110 metres.
-    cache_key = "{},{}".format(rounded_lat, rounded_lng)
-
-    cached = cache.get(cache_key)
-    if cached == NO_DATA_IN_CACHE:
-        return None
-    if cached:
-        return json.decode(cached)
     resp = http.get(
         STATION_URL,
         params = {
@@ -66,22 +58,17 @@ def fetch_stations(loc):
             "modes": "tube",
             "categories": "none",
         },
+        headers = {
+            "User-Agent": USER_AGENT,
+        },
+        ttl_seconds = 86400,  # Tube stations don't move often
     )
     if resp.status_code != 200:
         print("TFL station search failed with status ", resp.status_code)
-
-        # TODO: Determine if this cache call can be converted to the new HTTP cache.
-        cache.set(cache_key, NO_DATA_IN_CACHE, ttl_seconds = 30)
         return None
     if not resp.json().get("stopPoints"):
         print("TFL station search does not contain stops")
-
-        # TODO: Determine if this cache call can be converted to the new HTTP cache.
-        cache.set(cache_key, NO_DATA_IN_CACHE, ttl_seconds = 30)
         return None
-
-    # TODO: Determine if this cache call can be converted to the new HTTP cache.
-    cache.set(cache_key, resp.body(), ttl_seconds = 86400)  # Tube stations don't move often
     return resp.json()
 
 # API gives errors when searching for locations outside the United Kingdom.
@@ -130,32 +117,22 @@ def list_stations(location):
 # Fetch data about how crowded the station currently is
 def fetch_live_crowdedness(naptan_id):
     live_url = CROWDING_LIVE_URL % naptan_id
-    cached = cache.get(live_url)
-    if cached == NO_DATA_IN_CACHE:
-        return None
-    if cached:
-        return json.decode(cached)
     resp = http.get(
         live_url,
         params = {
             "app_key": app_key(),
         },
+        headers = {
+            "User-Agent": USER_AGENT,
+        },
+        ttl_seconds = 300,  # Data is updated every 5 mins
     )
     if resp.status_code != 200:
         print("TFL live crowding query failed with status ", resp.status_code)
-
-        # TODO: Determine if this cache call can be converted to the new HTTP cache.
-        cache.set(live_url, NO_DATA_IN_CACHE, ttl_seconds = 30)
         return None
     if not resp.json().get("dataAvailable"):
         print("TFL live crowdedness data not available")
-
-        # TODO: Determine if this cache call can be converted to the new HTTP cache.
-        cache.set(live_url, NO_DATA_IN_CACHE, ttl_seconds = 30)
         return None
-
-    # TODO: Determine if this cache call can be converted to the new HTTP cache.
-    cache.set(live_url, resp.body(), ttl_seconds = 300)  # Data is updated every 5 mins
     return resp.json()
 
 # Extract data about currrent crowdedness from API response
@@ -187,14 +164,15 @@ def weekday_name(date):
 # Fetch data about how crowded the station typically is on a given day
 def fetch_typical_crowdedness(naptan_id, now):
     typical_url = CROWDING_TYPICAL_URL % (naptan_id, weekday_name(now))
-    cached = cache.get(typical_url)
-    if cached:
-        return json.decode(cached)
     resp = http.get(
         typical_url,
         params = {
             "app_key": app_key(),
         },
+        headers = {
+            "User-Agent": USER_AGENT,
+        },
+        ttl_seconds = 604800,  # Data only needed once a week
     )
     if resp.status_code != 200:
         print("TFL live crowding query failed with status ", resp.status_code)
@@ -202,9 +180,6 @@ def fetch_typical_crowdedness(naptan_id, now):
     if not resp.json().get("isFound"):
         print("TFL live crowdedness data not available")
         return None
-
-    # TODO: Determine if this cache call can be converted to the new HTTP cache.
-    cache.set(typical_url, resp.body(), ttl_seconds = 604800)  # Data only needed once a week
     return resp.json()
 
 # Convert a time period from the API into a float we can use to plot.

--- a/apps/londonbusstop/london_bus_stop.star
+++ b/apps/londonbusstop/london_bus_stop.star
@@ -5,7 +5,6 @@ Description: Shows upcoming arrivals at a specific bus stop in London.
 Author: dinosaursrarr
 """
 
-load("cache.star", "cache")
 load("encoding/json.star", "json")
 load("http.star", "http")
 load("math.star", "math")
@@ -16,10 +15,10 @@ load("secret.star", "secret")
 DEFAULT_STOP_ID = "490020255S"
 STOP_URL = "https://api.tfl.gov.uk/StopPoint"
 ARRIVALS_URL = "https://api.tfl.gov.uk/StopPoint/%s/Arrivals"
+USER_AGENT = "Tidbyt london_bus_stop"
 
 # Allows 500 queries per minute
 ENCRYPTED_API_KEY = "AV6+xWcELQeKmsYDiEPA6VUWk2IZKw+uc9dkaM5cXT/xirUKWgWKfsRAQz2pOxq0eKTNhb/aShsRjavxA84Ay12p6NaZDnDOgVeVxoMCCOnWxJsxmURHogJHpVQpuqBTNttfvafOj0PC1zUXkEpcN7EYhveycs6qxmouIwpDzY5I93wpTy4="
-NO_DATA_IN_CACHE = ""
 
 RED = "#DA291C"  # Pantone 485 C - same as the buses
 ORANGE = "#FFA500"  # Like the countdown timers at bus stops
@@ -53,13 +52,6 @@ def extract_stop(stop):
 def fetch_stops(loc):
     truncated_lat = math.round(1000.0 * float(loc["lat"])) / 1000.0  # Truncate to 3dp for better caching
     truncated_lng = math.round(1000.0 * float(loc["lng"])) / 1000.0  # Means to the nearest ~110 metres.
-    cache_key = "{},{}".format(truncated_lat, truncated_lng)
-
-    cached = cache.get(cache_key)
-    if cached == NO_DATA_IN_CACHE:
-        return None
-    if cached:
-        return json.decode(cached)
     resp = http.get(
         STOP_URL,
         params = {
@@ -72,22 +64,17 @@ def fetch_stops(loc):
             "returnLines": "false",
             "categories": "Direction",
         },
+        headers = {
+            "User-Agent": USER_AGENT,
+        },
+        ttl_seconds = 86400,  # Bus stops don't move often
     )
     if resp.status_code != 200:
         print("TFL StopPoint search failed with status ", resp.status_code)
-
-        # TODO: Determine if this cache call can be converted to the new HTTP cache.
-        cache.set(cache_key, NO_DATA_IN_CACHE, ttl_seconds = 30)
         return None
     if not resp.json().get("stopPoints"):
         print("TFL StopPoint search does not contain stops")
-
-        # TODO: Determine if this cache call can be converted to the new HTTP cache.
-        cache.set(cache_key, NO_DATA_IN_CACHE, ttl_seconds = 30)
         return None
-
-    # TODO: Determine if this cache call can be converted to the new HTTP cache.
-    cache.set(cache_key, resp.body(), ttl_seconds = 86400)  # Bus stops don't move often
     return resp.json()
 
 # API gives errors when searching for locations outside the United Kingdom.
@@ -115,26 +102,19 @@ def get_stops(location):
 
 # Perform the actual fetch for a stop, but use cache if available.
 def fetch_stop(stop_id):
-    cached = cache.get(stop_id)
-    if cached == NO_DATA_IN_CACHE:
-        return None
-    if cached:
-        return json.decode(cached)
     resp = http.get(
         url = STOP_URL + "/" + stop_id,
         params = {
             "app_key": app_key(),
         },
+        headers = {
+            "User-Agent": USER_AGENT,
+        },
+        ttl_seconds = 30,
     )
     if resp.status_code != 200:
         print("TFL StopPoint request failed with status ", resp.status_code)
-
-        # TODO: Determine if this cache call can be converted to the new HTTP cache.
-        cache.set(stop_id, NO_DATA_IN_CACHE, ttl_seconds = 30)
         return None
-
-    # TODO: Determine if this cache call can be converted to the new HTTP cache.
-    cache.set(stop_id, resp.body(), ttl_seconds = 30)
     return resp.json()
 
 # Look up a particular stop by its Naptan ID. There can be a hierarchy of
@@ -173,6 +153,9 @@ def get_arrivals(stop_id):
         params = {
             "serviceTypes": "bus,night",
             "app_key": app_key(),
+        },
+        headers = {
+            "User-Agent": USER_AGENT,
         },
     )
     if resp.status_code != 200:

--- a/apps/nationalrail/national_rail.star
+++ b/apps/nationalrail/national_rail.star
@@ -5,7 +5,6 @@ Description: Realtime departure board information from National Rail Enquiries.
 Author: dinosaursrarr
 """
 
-load("cache.star", "cache")
 load("encoding/json.star", "json")
 load("http.star", "http")
 load("math.star", "math")
@@ -49,7 +48,6 @@ DEPARTURES_REQUEST = """
 </soap:Envelope>
 """
 
-EMPTY_DATA_IN_CACHE = ""
 NO_DESTINATION = "-"
 ORIGIN_STATION = "origin_station"
 DESTINATION_STATION = "destination_station"
@@ -2674,27 +2672,16 @@ def fetch_departures(station, via):
     if not app_key:
         return None
     request = DEPARTURES_REQUEST % (app_key, station, filter)
-
-    cached = cache.get(request)
-    if cached == EMPTY_DATA_IN_CACHE:
-        return None
-    if cached:
-        return cached
-
     resp = http.post(
         url = DARWIN_SOAP_URL,
         body = request,
         headers = {
             "Content-Type": "application/soap+xml; charset=utf-8",
         },
+        ttl_seconds = 60,
     )
     if resp.status_code != 200:
-        # TODO: Determine if this cache call can be converted to the new HTTP cache.
-        cache.set(request, EMPTY_DATA_IN_CACHE, ttl_seconds = 30)
         return None
-
-    # TODO: Determine if this cache call can be converted to the new HTTP cache.
-    cache.set(request, resp.body(), ttl_seconds = 60)
     return resp.body()
 
 def render_error(error):
@@ -2861,7 +2848,7 @@ def main(config):
     if destination_station:
         destination_station_value = json.decode(destination_station)["value"]
         if destination_station_value != NO_DESTINATION:
-            filter_crs = json.decode(destination_station_value)
+            filter_crs = json.decode(destination_station_value)["crs"]
 
     display_mode = config.get(DISPLAY_MODE) or DISPLAY_DETAILED
     if display_mode == DISPLAY_DETAILED:
@@ -2871,7 +2858,7 @@ def main(config):
     else:
         fail("Invalid display mode %s" % display_mode)
 
-    resp = fetch_departures(origin_station["crs"], filter_crs["crs"])
+    resp = fetch_departures(origin_station["crs"], filter_crs)
     if not resp:
         return render_error("Train times not available")
     departures = xpath.loads(resp)

--- a/apps/tube/tube.star
+++ b/apps/tube/tube.star
@@ -5,7 +5,6 @@ Description: Upcoming arrivals for a particular Tube, Elizabeth Line, DLR or Ove
 Author: dinosaursrarr
 """
 
-load("cache.star", "cache")
 load("encoding/json.star", "json")
 load("http.star", "http")
 load("math.star", "math")
@@ -17,7 +16,7 @@ load("secret.star", "secret")
 ENCRYPTED_APP_KEY = "AV6+xWcEgG4Ru4ZCA4ggWDRK+4zP4YCk4pCZrLiuXoCVSc677Sipk1Wnrag92v1k4qfa9n8e9FuCdsoLbov5osfGWOWUCYDkR3xh/uEsXOLVJvAr8iUXf6RSac2PXnDZ//z+hhgBzVldDDI/9CD8K8MJa0u75SG9EhZYidD9OXh0NggRHeE="
 STATION_URL = "https://api.tfl.gov.uk/StopPoint"
 ARRIVALS_URL = "https://api.tfl.gov.uk/StopPoint/%s/Arrivals"
-NO_DATA_IN_CACHE = ""
+USER_AGENT = "Tidbyt tube"
 
 HOLBORN_ID = "940GZZLUHBN"
 
@@ -112,13 +111,6 @@ def app_key():
 def fetch_stations(loc):
     truncated_lat = math.round(1000.0 * float(loc["lat"])) / 1000.0  # Truncate to 3dp for better caching
     truncated_lng = math.round(1000.0 * float(loc["lng"])) / 1000.0  # Means to the nearest ~110 metres.
-    cache_key = "{},{}".format(truncated_lat, truncated_lng)
-
-    cached = cache.get(cache_key)
-    if cached == NO_DATA_IN_CACHE:
-        return None
-    if cached:
-        return json.decode(cached)
     resp = http.get(
         STATION_URL,
         params = {
@@ -131,22 +123,17 @@ def fetch_stations(loc):
             "modes": ",".join(MODES),
             "categories": "none",
         },
+        headers = {
+            "User-Agent": USER_AGENT,
+        },
+        ttl_seconds = 86400,  # Tube stations don't move often
     )
     if resp.status_code != 200:
         print("TFL station search failed with status ", resp.status_code)
-
-        # TODO: Determine if this cache call can be converted to the new HTTP cache.
-        cache.set(cache_key, NO_DATA_IN_CACHE, ttl_seconds = 30)
         return None
     if not resp.json().get("stopPoints"):
         print("TFL station search does not contain stops")
-
-        # TODO: Determine if this cache call can be converted to the new HTTP cache.
-        cache.set(cache_key, NO_DATA_IN_CACHE, ttl_seconds = 30)
         return None
-
-    # TODO: Determine if this cache call can be converted to the new HTTP cache.
-    cache.set(cache_key, resp.body(), ttl_seconds = 86400)  # Tube stations don't move often
     return resp.json()
 
 # API gives errors when searching for locations outside the United Kingdom.
@@ -278,26 +265,19 @@ def get_stations(location):
 
 # Lookup upcoming arrivals for our given station, or use cache if available.
 def fetch_arrivals(stop_id):
-    cached = cache.get(stop_id)
-    if cached == NO_DATA_IN_CACHE:
-        return None
-    if cached:
-        return json.decode(cached)
     resp = http.get(
         ARRIVALS_URL % stop_id,
         params = {
             "app_key": app_key(),
         },
+        headers = {
+            "User-Agent": USER_AGENT,
+        },
+        ttl_seconds = 30,
     )
     if resp.status_code != 200:
         print("TFL StopPoint request failed with status ", resp.status_code)
-
-        # TODO: Determine if this cache call can be converted to the new HTTP cache.
-        cache.set(stop_id, NO_DATA_IN_CACHE, ttl_seconds = 30)
         return None
-
-    # TODO: Determine if this cache call can be converted to the new HTTP cache.
-    cache.set(stop_id, resp.body(), ttl_seconds = 30)
     return resp.json()
 
 # TFL response gives the times until a train arrives in seconds. Everyone is used
@@ -396,18 +376,16 @@ def render_arrivals_frame(arrivals):
 
 def render_arrivals(arrivals):
     if len(arrivals) == 0:
-        return [
-            render.Box(
-                width = 64,
-                child = render.WrappedText(
-                    content = "No arrivals data",
-                    width = 62,
-                    align = "center",
-                    color = ORANGE,
-                    font = FONT,
-                ),
+        return render.Box(
+            width = 64,
+            child = render.WrappedText(
+                content = "No arrivals data",
+                width = 62,
+                align = "center",
+                color = ORANGE,
+                font = FONT,
             ),
-        ]
+        )
 
     frames = []
     for i in range(0, len(arrivals), 3):

--- a/apps/tubestatus/tube_status.star
+++ b/apps/tubestatus/tube_status.star
@@ -5,8 +5,6 @@ Description: Shows the current status of each line on London Underground and oth
 Author: dinosaursrarr
 """
 
-load("cache.star", "cache")
-load("encoding/json.star", "json")
 load("http.star", "http")
 load("render.star", "render")
 load("schema.star", "schema")
@@ -15,13 +13,13 @@ load("secret.star", "secret")
 # Allows 500 queries per minute
 ENCRYPTED_APP_KEY = "AV6+xWcE2sENYC+/SYTqo/7oaIT8Q+BjV27Q/Bm9b1C19OEsiEuWKQQ3KKx6ymZQk2DOkiaPMjvoYmBlYZl/yr6AqusGweRYyA/gZ26zZBYX6krBCckHACEZQIS0mtAkwZmiLoGxhH2XpUkBBQdmBBwjODAqrcthPYPCm7u597BdzWyhljQ="
 STATUS_URL = "https://api.tfl.gov.uk/Line/Mode/%s/Status"
+USER_AGENT = "Tidbyt tube_status"
 
 WHITE = "#FFF"
 BLACK = "#000"
 
 DISPLAY_SCROLL = "DISPLAY_SCROLL"
 DISPLAY_SEQUENTIAL = "DISPLAY_SEQUENTIAL"
-NO_DATA_IN_CACHE = ""
 
 LINES = {
     "bakerloo": {
@@ -145,28 +143,20 @@ SEVERITIES = {
 # Cache response for all users. It's always the same info with the same inputs so
 # no need to fetch repeatedly.
 def fetch_response():
-    cache_key = "api_response"  # it's always the same input
-    cached = cache.get(cache_key)
-    if cached == NO_DATA_IN_CACHE:
-        return None
-    if cached:
-        return json.decode(cached)
     app_key = secret.decrypt(ENCRYPTED_APP_KEY) or ""  # fall back to anonymous quota
     resp = http.get(
         url = STATUS_URL % ",".join(["tube", "elizabeth-line", "overground", "dlr", "tram"]),
         params = {
             "app_key": app_key,
         },
+        headers = {
+            "User-Agent": USER_AGENT,
+        },
+        ttl_seconds = 60,
     )
     if resp.status_code != 200:
         print("TFL status request failed with status code ", resp.status_code)
-
-        # TODO: Determine if this cache call can be converted to the new HTTP cache.
-        cache.set(cache_key, NO_DATA_IN_CACHE, ttl_seconds = 30)
         return None
-
-    # TODO: Determine if this cache call can be converted to the new HTTP cache.
-    cache.set(cache_key, resp.body(), ttl_seconds = 60)
     return resp.json()
 
 def fetch_lines():


### PR DESCRIPTION
# Description
Use new http caching in UK transport apps

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 760a0e1</samp>

### Summary
🚇🚀🛠️

<!--
1.  🚇 - This emoji represents the tube, which is the main mode of transport that these apps are related to. It also conveys the idea of speed and efficiency, which are improved by the cache feature and the bug fixes.
2.  🚀 - This emoji represents the performance boost and the innovation that the cache feature brings to the apps. It also suggests that the apps are more reliable and responsive, and that they use the latest technology available.
3.  🛠️ - This emoji represents the bug fixes and the improvements that the pull requests make to the apps. It also suggests that the apps are well-maintained and follow the best practices of the API.
-->
This pull request updates several apps that use the TFL API to take advantage of the new cache feature of the Tidbyt platform, which reduces the number of HTTP requests and improves the performance and reliability of the apps. It also adds custom user agent headers to the requests to follow the API best practices and identify the apps. Additionally, it fixes some bugs and simplifies some code in the apps. The affected apps are `borisbikes`, `busytube`, `londonbusstop`, `nationalrail`, `tube`, and `tubestatus`.

> _We're the Tidbyt crew and we code with skill and pride_
> _We use the cache feature to make our apps run fast and wide_
> _We add the user agent header to the TFL API_
> _And we fix the bugs and errors as we sail the digital sea_

### Walkthrough
*  Remove cache.star imports and cache-related code from all apps, as they are replaced by the built-in cache feature of the HTTP requests ([link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-f9fc456a33f231293e8156465057357674bcf22b42f1467013bfbabeccd7c404L8), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-f9fc456a33f231293e8156465057357674bcf22b42f1467013bfbabeccd7c404L35-L39), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-f9fc456a33f231293e8156465057357674bcf22b42f1467013bfbabeccd7c404L45-R46), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-f9fc456a33f231293e8156465057357674bcf22b42f1467013bfbabeccd7c404L95-L99), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-f9fc456a33f231293e8156465057357674bcf22b42f1467013bfbabeccd7c404L105-R99), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-e0dd25075abf8379027bbefe92e57cd102322da5c3ac3272bc472649d3b0e1c0L8), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-e0dd25075abf8379027bbefe92e57cd102322da5c3ac3272bc472649d3b0e1c0L50-L56), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-e0dd25075abf8379027bbefe92e57cd102322da5c3ac3272bc472649d3b0e1c0L69-R71), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-e0dd25075abf8379027bbefe92e57cd102322da5c3ac3272bc472649d3b0e1c0L133-L137), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-e0dd25075abf8379027bbefe92e57cd102322da5c3ac3272bc472649d3b0e1c0L143-R135), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-e0dd25075abf8379027bbefe92e57cd102322da5c3ac3272bc472649d3b0e1c0L190-L192), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-e0dd25075abf8379027bbefe92e57cd102322da5c3ac3272bc472649d3b0e1c0L205-L207), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-8fa9873b835719afbe2e9e7d0f5d5e1c9b8d435678e15355305fde9531440cfbL8), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-8fa9873b835719afbe2e9e7d0f5d5e1c9b8d435678e15355305fde9531440cfbL56-L62), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-8fa9873b835719afbe2e9e7d0f5d5e1c9b8d435678e15355305fde9531440cfbL75-R77), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-8fa9873b835719afbe2e9e7d0f5d5e1c9b8d435678e15355305fde9531440cfbL118-L122), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-8fa9873b835719afbe2e9e7d0f5d5e1c9b8d435678e15355305fde9531440cfbL128-R117), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-1125330c4be8cf22afcc0e4dac90c04abad865e0dae49fc90d01cfb85cdf8d33L8), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-1125330c4be8cf22afcc0e4dac90c04abad865e0dae49fc90d01cfb85cdf8d33L52), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-1125330c4be8cf22afcc0e4dac90c04abad865e0dae49fc90d01cfb85cdf8d33L2677-L2683), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-1125330c4be8cf22afcc0e4dac90c04abad865e0dae49fc90d01cfb85cdf8d33L2690-R2684), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-616cea18df3be4ab1dd7f03b286ecde190a885e2f25d7c771a675162e5e4bb7aL8), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-616cea18df3be4ab1dd7f03b286ecde190a885e2f25d7c771a675162e5e4bb7aL115-L121), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-616cea18df3be4ab1dd7f03b286ecde190a885e2f25d7c771a675162e5e4bb7aL134-R136), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-616cea18df3be4ab1dd7f03b286ecde190a885e2f25d7c771a675162e5e4bb7aL281-L285), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-616cea18df3be4ab1dd7f03b286ecde190a885e2f25d7c771a675162e5e4bb7aL291-R280), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-c66ad87161d84472990861287d73fa17f036db561b03803a261786ed0fcf20d7L8-L9), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-c66ad87161d84472990861287d73fa17f036db561b03803a261786ed0fcf20d7L24), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-c66ad87161d84472990861287d73fa17f036db561b03803a261786ed0fcf20d7L148-L153), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-c66ad87161d84472990861287d73fa17f036db561b03803a261786ed0fcf20d7L160-R159))
* Add custom user agent headers to all HTTP requests to the TFL API, following their best practices ([link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-f9fc456a33f231293e8156465057357674bcf22b42f1467013bfbabeccd7c404L29-R28), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-f9fc456a33f231293e8156465057357674bcf22b42f1467013bfbabeccd7c404L45-R46), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-f9fc456a33f231293e8156465057357674bcf22b42f1467013bfbabeccd7c404L105-R99), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-e0dd25075abf8379027bbefe92e57cd102322da5c3ac3272bc472649d3b0e1c0L31-R30), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-e0dd25075abf8379027bbefe92e57cd102322da5c3ac3272bc472649d3b0e1c0L69-R71), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-e0dd25075abf8379027bbefe92e57cd102322da5c3ac3272bc472649d3b0e1c0L143-R135), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-e0dd25075abf8379027bbefe92e57cd102322da5c3ac3272bc472649d3b0e1c0R172-R175), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-8fa9873b835719afbe2e9e7d0f5d5e1c9b8d435678e15355305fde9531440cfbL19-R21), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-8fa9873b835719afbe2e9e7d0f5d5e1c9b8d435678e15355305fde9531440cfbL75-R77), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-8fa9873b835719afbe2e9e7d0f5d5e1c9b8d435678e15355305fde9531440cfbL128-R117), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-8fa9873b835719afbe2e9e7d0f5d5e1c9b8d435678e15355305fde9531440cfbR157-R159), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-616cea18df3be4ab1dd7f03b286ecde190a885e2f25d7c771a675162e5e4bb7aL20-R19), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-616cea18df3be4ab1dd7f03b286ecde190a885e2f25d7c771a675162e5e4bb7aL134-R136), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-616cea18df3be4ab1dd7f03b286ecde190a885e2f25d7c771a675162e5e4bb7aL291-R280), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-c66ad87161d84472990861287d73fa17f036db561b03803a261786ed0fcf20d7R16), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-c66ad87161d84472990861287d73fa17f036db561b03803a261786ed0fcf20d7L160-R159))
* Fix bugs in `national_rail.star` that caused incorrect parsing and filtering of the destination station CRS code from the config ([link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-1125330c4be8cf22afcc0e4dac90c04abad865e0dae49fc90d01cfb85cdf8d33L2864-R2851), [link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-1125330c4be8cf22afcc0e4dac90c04abad865e0dae49fc90d01cfb85cdf8d33L2874-R2861))
* Fix bug in `tube.star` that caused incorrect return type of the render_arrivals function when no arrivals data was available ([link](https://github.com/tidbyt/community/pull/1472/files?diff=unified&w=0#diff-616cea18df3be4ab1dd7f03b286ecde190a885e2f25d7c771a675162e5e4bb7aL399-R388))


