### PR TITLE
Update: ATP & WTA Tennis apps

### DIFF
--- a/apps/atptennis/atp_tennis.star
+++ b/apps/atptennis/atp_tennis.star
@@ -21,6 +21,9 @@ Sometimes the data feed will still show matches as "In Progress" after they have
 
 v1.3a
 Updated caching function
+
+v1.4
+Current server now indicated in green
 """
 
 load("encoding/json.star", "json")
@@ -48,7 +51,7 @@ def main(config):
     CompletedMatchList = []
     InProgress = 0
 
-    TestID = "338-2023"
+    TestID = "414-2023"
     SelectedTourneyID = config.get("TournamentList", TestID)
     ShowCompleted = config.get("CompletedOn", "true")
     Number_Events = len(ATP_JSON["events"])
@@ -209,9 +212,18 @@ def getLiveScores(SelectedTourneyID, EventIndex, InProgressMatchList, JSON):
             x = InProgressMatchList.pop()
 
             Player1_Name = JSON["events"][EventIndex]["competitions"][x]["competitors"][0]["athlete"]["shortName"]
+            Player1_ID = JSON["events"][EventIndex]["competitions"][x]["competitors"][0]["id"]
             Player2_Name = JSON["events"][EventIndex]["competitions"][x]["competitors"][1]["athlete"]["shortName"]
+            Player2_ID = JSON["events"][EventIndex]["competitions"][x]["competitors"][1]["id"]
+            Server = JSON["events"][EventIndex]["competitions"][x]["situation"]["server"]["$ref"]
+            Server = Server[70:]
+            Server = Server.removesuffix("?lang=en&region=us")
 
-            # print(Player1_Name)
+            if Server == Player1_ID:
+                Player1Color = "#01AF50"
+            elif Server == Player2_ID:
+                Player2Color = "#01AF50"
+
             Number_Sets = len(JSON["events"][EventIndex]["competitions"][x]["competitors"][0]["linescores"])
             Player1_Sets = ""
             Player2_Sets = ""

--- a/apps/wtatennis/wta_tennis.star
+++ b/apps/wtatennis/wta_tennis.star
@@ -21,10 +21,12 @@ Update title bar color to distinguish between WTA & ATP apps
 
 v1.3
 Sometimes the data feed will still show matches as "In Progress" after they have completed. Have added a 24hr limit so that if the start date is > 24 hrs ago then don't list the match
+
+v1.4
+Updated caching function
+Current server now indicated in green
 """
 
-load("cache.star", "cache")
-load("encoding/base64.star", "base64")
 load("encoding/json.star", "json")
 load("http.star", "http")
 load("humanize.star", "humanize")
@@ -206,8 +208,17 @@ def getLiveScores(SelectedTourneyID, EventIndex, InProgressMatchList, JSON):
             x = InProgressMatchList.pop()
 
             Player1_Name = JSON["events"][EventIndex]["competitions"][x]["competitors"][0]["athlete"]["shortName"]
+            Player1_ID = JSON["events"][EventIndex]["competitions"][x]["competitors"][0]["id"]
             Player2_Name = JSON["events"][EventIndex]["competitions"][x]["competitors"][1]["athlete"]["shortName"]
+            Player2_ID = JSON["events"][EventIndex]["competitions"][x]["competitors"][1]["id"]
+            Server = JSON["events"][EventIndex]["competitions"][x]["situation"]["server"]["$ref"]
+            Server = Server[70:]
+            Server = Server.removesuffix("?lang=en&region=us")
 
+            if Server == Player1_ID:
+                Player1Color = "#01AF50"
+            elif Server == Player2_ID:
+                Player2Color = "#01AF50"
             Number_Sets = len(JSON["events"][EventIndex]["competitions"][x]["competitors"][0]["linescores"])
             Player1_Sets = ""
             Player2_Sets = ""
@@ -669,18 +680,9 @@ RotationOptions = [
 ]
 
 def get_cachable_data(url, timeout):
-    key = base64.encode(url)
-    data = cache.get(key)
-    if data != None:
-        # print("Using cached data")
-        return base64.decode(data)
+    res = http.get(url = url, ttl_seconds = timeout)
 
-    res = http.get(url = url)
-
-    #print("Getting new data")
     if res.status_code != 200:
         fail("request to %s failed with status code: %d - %s" % (url, res.status_code, res.body()))
 
-    # TODO: Determine if this cache call can be converted to the new HTTP cache.
-    cache.set(key, base64.encode(res.body()), ttl_seconds = timeout)
     return res.body()


### PR DESCRIPTION
# Description
The current server is now shown in green. This should give a better indication of how the match is going, eg. if someone is up/down a break, serving for the set or match 

Also, updated the cache function for the WTA Tennis app

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 45ec5e5</samp>

### Summary
🎾🟢🚀

<!--
1.  🎾 - This emoji represents the tennis theme of both apps and the main feature of highlighting the current server.
2.  🟢 - This emoji represents the color green that is used to highlight the current server in both apps.
3.  🚀 - This emoji represents the performance and readability improvements that are made in the WTA tennis app by simplifying the caching function and removing unused imports.
-->
This pull request adds a feature to both the `atp_tennis` and `wta_tennis` apps that makes it easier to see who is serving by coloring their name green. It also improves the code quality and performance of both apps by making some minor adjustments and optimizations.

> _Sing, O Muse, of the skillful programmers who devised_
> _A splendid feature for the tennis-loving fans, to show_
> _The name of the swift-footed server in verdant hue, and revised_
> _The code of the app, making it faster and clearer to flow._

### Walkthrough
*  Add feature to show current server in green for both ATP and WTA tennis apps ([link](https://github.com/tidbyt/community/pull/1473/files?diff=unified&w=0#diff-2fe7726a8148e3fb23a64991e8b2661bd9c098395de1a2f1ea0092f21db623bcR24-R26), [link](https://github.com/tidbyt/community/pull/1473/files?diff=unified&w=0#diff-2fe7726a8148e3fb23a64991e8b2661bd9c098395de1a2f1ea0092f21db623bcL212-R226), [link](https://github.com/tidbyt/community/pull/1473/files?diff=unified&w=0#diff-bacac371ef4450963bfae6cc2618e0ce8278c5d02f808e88e0cff7243efed67dL24-R29), [link](https://github.com/tidbyt/community/pull/1473/files?diff=unified&w=0#diff-bacac371ef4450963bfae6cc2618e0ce8278c5d02f808e88e0cff7243efed67dL209-R221))
*  Change TestID variable to use a different tournament ID for testing the feature ([link](https://github.com/tidbyt/community/pull/1473/files?diff=unified&w=0#diff-2fe7726a8148e3fb23a64991e8b2661bd9c098395de1a2f1ea0092f21db623bcL51-R54))
*  Simplify caching function by using ttl_seconds parameter of http.get and remove unnecessary imports and encoding/decoding ([link](https://github.com/tidbyt/community/pull/1473/files?diff=unified&w=0#diff-bacac371ef4450963bfae6cc2618e0ce8278c5d02f808e88e0cff7243efed67dL672-R687))


