### PR TITLE
SEPTA Transit: migrate to HTTP module caching

### DIFF
--- a/apps/septatransit/septatransit.star
+++ b/apps/septatransit/septatransit.star
@@ -21,16 +21,8 @@ DEFAULT_STOP = "10264"
 DEFAULT_BANNER = ""
 
 def call_routes_api():
-    cache_string = cache.get("routes_api_response")
-    routes = None
-    if cache_string != None:
-        routes = json.decode(cache_string)
-    if routes == None:
-        r = http.get(API_ROUTES)
-        routes = r.json()
-
-        # TODO: Determine if this cache call can be converted to the new HTTP cache.
-        cache.set("routes_api_response", json.encode(routes), ttl_seconds = 3600)
+    r = http.get(API_ROUTES, ttl_seconds = 604800)
+    routes = r.json()
     sorted_routes = sort_routes(routes)
     return sorted_routes
 
@@ -96,19 +88,9 @@ def get_route_text_color(route):
     return "#fff"
 
 def get_stops(route):
-    cache_string = cache.get(route + "_" + "stops_api_response")
-    stops = None
-    if cache_string != None:
-        stops = json.decode(cache_string)
-    if stops == None:
-        r = http.get(API_STOPS, params = {"req1": route})
-        stops = r.json()
-
-        # TODO: Determine if this cache call can be converted to the new HTTP cache.
-        cache.set(route + "_" + "stops_api_response", json.encode(stops), ttl_seconds = 3600)
-
+    r = http.get(API_STOPS, params = {"req1": route}, ttl_seconds = 604800)
+    stops = r.json()
     list_of_stops = []
-
     for i in stops:
         list_of_stops.append(
             schema.Option(
@@ -116,7 +98,6 @@ def get_stops(route):
                 value = i["stopid"],
             ),
         )
-
     return list_of_stops
 
 def pad_direction_desc(data):
@@ -145,10 +126,7 @@ def call_schedule_api(route, stopid):
         expiry = int((parsed_time - time.now()).seconds)
         if expiry < 0:  #this is because septa's API returns tomorrow's times with today's date if the last departure for the day has already happened
             expiry = 30
-
-        # TODO: Determine if this cache call can be converted to the new HTTP cache.
         cache.set(route + "_" + stopid + "_" + "schedule_api_response", json.encode(schedule), ttl_seconds = expiry)
-
     return schedule
 
 def get_schedule(route, stopid):


### PR DESCRIPTION
# Description
This migrates call_routes_api() and get_stops(route) to HTTP module caching with a 1 week TTL.

The call_schedule_api(route, stopid) function still uses the cache module because the expiration time depends on the returned results.

A new option to show relative departure times (eg: "3m") instead of absolute times was also added.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1c84ead</samp>

### Summary
🚀🌐♻️

<!--
1.  🚀 for the new feature of showing relative or absolute departure times.
2.  🌐 for the improvement of using the HTTP cache feature for the API calls.
3.  ♻️ for the simplification and refactoring of the code.
-->
Simplify and enhance septatransit app. Use HTTP cache for API calls and add option to show relative or absolute times.

> _Sing, O Muse, of the skillful coder who refined_
> _The septatransit app, a boon for travelers in the city,_
> _And added a new feature, wondrous to behold,_
> _A toggle switch to show departure times in different modes._

### Walkthrough
*  Simplify API calls by using HTTP cache feature instead of cache module ([link](https://github.com/tidbyt/community/pull/1474/files?diff=unified&w=0#diff-b1fdab8189161d4f11593fce619cf6d6ff03f6798efb8a651cbe1aba9632d6f9L24-R25), [link](https://github.com/tidbyt/community/pull/1474/files?diff=unified&w=0#diff-b1fdab8189161d4f11593fce619cf6d6ff03f6798efb8a651cbe1aba9632d6f9L99-R93))
*  Add new feature to show departure times as relative or absolute ([link](https://github.com/tidbyt/community/pull/1474/files?diff=unified&w=0#diff-b1fdab8189161d4f11593fce619cf6d6ff03f6798efb8a651cbe1aba9632d6f9L148-R123), [link](https://github.com/tidbyt/community/pull/1474/files?diff=unified&w=0#diff-b1fdab8189161d4f11593fce619cf6d6ff03f6798efb8a651cbe1aba9632d6f9L167-R140), [link](https://github.com/tidbyt/community/pull/1474/files?diff=unified&w=0#diff-b1fdab8189161d4f11593fce619cf6d6ff03f6798efb8a651cbe1aba9632d6f9L225-R198), [link](https://github.com/tidbyt/community/pull/1474/files?diff=unified&w=0#diff-b1fdab8189161d4f11593fce619cf6d6ff03f6798efb8a651cbe1aba9632d6f9R291-R297))
*  Remove unnecessary `pad_direction_desc` function and use offsets to align direction descriptions ([link](https://github.com/tidbyt/community/pull/1474/files?diff=unified&w=0#diff-b1fdab8189161d4f11593fce619cf6d6ff03f6798efb8a651cbe1aba9632d6f9L119-R102), [link](https://github.com/tidbyt/community/pull/1474/files?diff=unified&w=0#diff-b1fdab8189161d4f11593fce619cf6d6ff03f6798efb8a651cbe1aba9632d6f9L193-R164))
*  Use `time` module to parse and calculate relative departure times ([link](https://github.com/tidbyt/community/pull/1474/files?diff=unified&w=0#diff-b1fdab8189161d4f11593fce619cf6d6ff03f6798efb8a651cbe1aba9632d6f9L167-R140))

