### PR TITLE
craftnft_app : add ttl_seconds for http but still need cache.set

### DIFF
--- a/apps/craftnft/craftnft.star
+++ b/apps/craftnft/craftnft.star
@@ -102,7 +102,7 @@ def fetch_random_nft(address):
         if cur_url == "":  # we haven't check this token page for an image url yet so lets check and buildup the cache
             collection, token_id = key_list[num].split(":")
             print(TOKEN_URL.format(collection, token_id))
-            token_page_body = http.get(TOKEN_URL.format(collection, token_id)).body()
+            token_page_body = http.get(TOKEN_URL.format(collection, token_id), ttl_seconds = 60 * 60).body()  # 1 hour http cache
             token_json_obj = json.decode(token_page_body)
             if "cloudinary" in token_json_obj and token_json_obj["cloudinary"][-4:] in [".jpg", ".png", "peg", ".gif"]:
                 #print("setting " + key_list[num] + " to " + token_json_obj["cloudinary"] )
@@ -121,7 +121,8 @@ def fetch_random_nft(address):
             break
 
     # re-store the cache with the updated info.
-    # TODO: Determine if this cache call can be converted to the new HTTP cache.
+    # we are storing a custom dictionary that is updated each time the script is run so http cache
+    # will not work here.
     cache.set(address + "_image_dict", json.encode(image_dict_orig), ttl_seconds = 86400)  # 1 day
     if cur_url:
         #print("picked: " + cur_url)
@@ -136,7 +137,7 @@ def fetch_image_dict(address):
     image_dict_json_str = cache.get(address + "_image_dict")
 
     # fetch current image list
-    resp = http.get(USER_URL.format(address))
+    resp = http.get(USER_URL.format(address), ttl_seconds = 60 * 60)  # 1 hour http cache
     if resp.status_code != 200 and image_dict_json_str == None:  # if we hav not cache and http.get fails return None
         return None
 


### PR DESCRIPTION
# Description
Added ttl_seconds for http.get requests but must still use cache module to store custom built up data structure that holds data retrieved from multiple http requests made across multiple script runs.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 276d670</samp>

### Summary
🚀🌐🕒

<!--
1.  🚀 - This emoji can be used to indicate a performance improvement or a speed boost for the app, as well as a sense of excitement or enthusiasm for the new feature.
2.  🌐 - This emoji can be used to represent the HTTP requests or the web-related aspect of the app, as well as the global or networked nature of the app.
3.  🕒 - This emoji can be used to represent the time-related aspect of the app, such as the caching behavior or the `ttl_seconds` parameter, as well as the efficiency or optimization of the app.
-->
Improved caching and performance of the `craftnft` app by using the `ttl_seconds` parameter for HTTP requests.

> _Sing, O Muse, of the crafty `craftnft` app, that skillfully_
> _Reduced the burden of many HTTP requests, by using wisely_
> _The new `ttl_seconds` parameter, a gift from the gods, that sets_
> _The time to live for cached responses, and thus enhances its speed._

### Walkthrough
*  Improve HTTP caching by using ttl_seconds parameter for http.get requests ([link](https://github.com/tidbyt/community/pull/1483/files?diff=unified&w=0#diff-c72bd607076c590a63af074ed24507b18b6df75c07ad5b2224114c3c474f56c0L105-R105), [link](https://github.com/tidbyt/community/pull/1483/files?diff=unified&w=0#diff-c72bd607076c590a63af074ed24507b18b6df75c07ad5b2224114c3c474f56c0L139-R140))
*  Clarify comment about cache.set function and its purpose ([link](https://github.com/tidbyt/community/pull/1483/files?diff=unified&w=0#diff-c72bd607076c590a63af074ed24507b18b6df75c07ad5b2224114c3c474f56c0L124-R125))


