### PR TITLE
Fix: Adelaide Metro

### DIFF
--- a/apps/adelaidemetro/adelaide_metro.star
+++ b/apps/adelaidemetro/adelaide_metro.star
@@ -20,6 +20,9 @@ Trains into the city will display as CITY rather than the route name (only in ne
 Trams will also show the destination rather than route name (only in next arrival mode)
 Updated Tram Stop List
 Updated caching function
+
+v2.0a
+Bug fix for Adelaide Showground station, not showing correct headsign on City bound services
 """
 
 load("encoding/json.star", "json")
@@ -343,8 +346,9 @@ def GetTimes_Time(StopName, Services, z, NEXTSCHED_JSON, INFO_JSON):
                     break
 
             # if its a train route & its to the city, then change the route name but only if its not the Adelaide station
+            # Added condition for Adelaide Showground (18104) as well
             StopCode = INFO_JSON["stop_data"]["stop_code"]
-            ToCity = StopCode.startswith("16")
+            ToCity = StopCode.startswith("16") or StopCode == "18104"
             if StopCode != "16490":
                 if RouteType == 2 and ToCity:
                     TheRoute = "CITY"


### PR DESCRIPTION
# Description
Fixed bug for when Adelaide Showground station is selected. It was not showing correct destination headsign on City bound services

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e255980</samp>

### Summary
🚆🛠️🔢

<!--
1.  🚆 - This emoji represents trains and can be used to indicate that the changes are related to the train headsign display.
2.  🛠️ - This emoji represents tools and can be used to indicate that the changes are fixing a bug or improving the functionality of the app.
3.  🔢 - This emoji represents numbers and can be used to indicate that the changes are updating the version number of the app.
-->
Updated Adelaide Metro app to version 1.1 and fixed a headsign bug. Changed `is_to_city` condition in `adelaide_metro.star`.

> _The city bound train of doom_
> _No more headsigns to confuse_
> _`is_to_city` knows the truth_
> _Adelaide Metro app renewed_

### Walkthrough
* Fix bug where headsign for city bound services from Adelaide Showground was not showing correctly ([link](https://github.com/tidbyt/community/pull/1484/files?diff=unified&w=0#diff-459d339907c7789deca38209515953894ac4b6c896c7d3271fc1a74462a09c5bR23-R25), [link](https://github.com/tidbyt/community/pull/1484/files?diff=unified&w=0#diff-459d339907c7789deca38209515953894ac4b6c896c7d3271fc1a74462a09c5bL346-R351))
* Update `adelaide_metro.star` to version 1.0.1 with comment header ([link](https://github.com/tidbyt/community/pull/1484/files?diff=unified&w=0#diff-459d339907c7789deca38209515953894ac4b6c896c7d3271fc1a74462a09c5bR23-R25))


