### PR TITLE
strava: Bump ttl to once every 36 hours.

### DIFF
--- a/apps/strava/strava.star
+++ b/apps/strava/strava.star
@@ -34,7 +34,7 @@ PREVIEW_DATA = {
     "elevation_gain": 125800,
 }
 
-CACHE_TTL = 60 * 60 * 24  # updates once daily
+CACHE_TTL = 60 * 60 * 36  # updates once every 36 hours
 
 RUN_ICON = base64.decode("""
 iVBORw0KGgoAAAANSUhEUgAAAAoAAAAGCAYAAAD68A/GAAAAAXNSR0IArs4c6QAAAGpJREFUGFdj


### PR DESCRIPTION
# Description
This commit increases the TTL to once every 36 hours to extend the life of our current rate limits.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 62ff271</samp>

### Summary
:clock1::zap::bug:

<!--
1.  :clock1: - This emoji represents the increase in the cache time limit, which is related to time and duration.
2.  :zap: - This emoji represents the reduction in the API calls, which is related to speed and performance.
3.  :bug: - This emoji represents the fix of the error caused by the rate limit, which is related to bugs and issues.
-->
Increased the cache duration for the `strava` app to prevent API errors. This change affects the file `apps/strava/strava.star`.

> _`CACHE_TTL` grows_
> _Less calls to Strava API_
> _Winter saves quota_

### Walkthrough
* Increase cache time to avoid hitting Strava API rate limit ([link](https://github.com/tidbyt/community/pull/1485/files?diff=unified&w=0#diff-7cc751532edf305a47e0bcc935eb429a2913f05523ddd5beec97283d56bb4ad1L37-R37))


