### PR TITLE
solar_manager_ch add autarky screen

### DIFF
--- a/apps/solarmanagerch/solar_manager_ch.star
+++ b/apps/solarmanagerch/solar_manager_ch.star
@@ -12,6 +12,7 @@ load("http.star", "http")
 load("humanize.star", "humanize")
 load("render.star", "render")
 load("schema.star", "schema")
+load("time.star", "time")
 
 DEBUG = False
 #DEBUG = True # set to True to skip api calls and use dummy data
@@ -75,6 +76,10 @@ BATTERY_CHARGE_TEST_10x10 = base64.decode("""
 R0lGODdhCgAKAOYAAAAAAMIyNDMzZjQ8TDg+Tp4+P7c/QcBCRB9DXx5EYCNFX5hHRyFKYzxLTJ9LS0BMTDRNTTVOXTpOXDZQXjpQXjpUYx5XXFxaWStcXT5cWkNcWzxeYEpeWgBfXhtfXyxgY0liYVpjW2BkWhdlZURlXEVlYTNmMzNmZmZmM2ZmZk5oXFNoXERpXHppU3VqVnltWphvQJFwSZlwQVNzQpl2Tk99P09+QFJ+P75+MEV/VrR/PVKAP3aAVICAAL+AMT+CUcGCLFuDUnmDT0CEUXqEUL2EQr+FP0aHWmCIVnuIWVKNP2KNW0KSVUiTVIyTUmGUVZGXTWOZWWaZZpCZWJWZS0OaWkSaUUaaT0maVpSaVUycWZqeS0ygWZqgVnKoAGu1AIO+Mo/DjY/KNmbMM5nMM5HPN6PRg6jSnI7TAKTTfrbe25vmH8/r6aDsJP///wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAAG8ALAAAAAAKAAoAAAdHgG+CZ2xqYYKIZW1mZmtgiG9iaGlmaI+IQUs1NkEzkBIVERMTA5AaJRkZJA2mIBqvrIgZIx0dHrGCFwcBAQYQkBcOBQULsYEAIfkECQAAbwAsAgAAAAYACgAABz2Ab2dsamFvZW1mZmtgYmhpZmhgQUs1NkEzEhURExMDGiUZGSQNGiAaqA0ZIx0dHg0XBwEBBhAXDgUFCw2BACH5BAkAAG8ALAIAAAAGAAoAAAc9gG9nbGphb2VtZmZrYGJoaWZoYEFLNTZBMxIVERMTAxolGRkkDRogGqgNGSMdHR4NFwcBAQYQFw4FBQsNgQAh+QQJAABvACwCAAAABgAKAAAHPYBvZ2xqYW9lbWZma2BiaGlmaGBBSzU2QTMSFRETEwMaJRkZJA0aIBqoDRkjHR0eDRcHAQEGEBcOBQULDYEAIfkECQAAbwAsAgAAAAYACgAABzyAb2dsamFvZW1mZmtgYmhpZmhgQUs1NkEzFBUUnAMaHxYWGA0cLy0tLg0iRkBAOhAhRTg+ryE0MDIxDYEAIfkECQAAbwAsAgAAAAYACgAABzyAb2dsamFvZW1mZmtgYmhpZmhgQUs1NkEzFBUUnAMaHxYWGA0cLy0tLg0iRkBAOhAhRTg+ryE0MDIxDYEAIfkECQAAbwAsAgAAAAYACgAABzyAb2dsamFvZW1mZmtgYmhpZmhgQUs1NkEzFBUUnAMaHxYWGA0cLy0tLg0iRkBAOhAhRTg+ryE0MDIxDYEAIfkECQAAbwAsAgAAAAYACgAABzyAb2dsamFvZW1mZmtgYmhpZmhgQUs1NkEzFBUUnAMaHxYWGA0cLy0tLg0iRkBAOhAhRTg+ryE0MDIxDYEAIfkECQAAbwAsAgAAAAYACgAABzqAb2dsamFvZW1mZmtgYmhpZmhgQUs3O0gzEQwICQoDK1NQUE4NK1lUVKSmUKmlXVtbWQ0qSUJEPA2BACH5BAkAAG8ALAIAAAAGAAoAAAc6gG9nbGphb2VtZmZrYGJoaWZoYEFLNztIMxEMCAkKAytTUFBODStZVFSkplCppV1bW1kNKklCRDwNgQAh+QQJAABvACwCAAAABgAKAAAHOoBvZ2xqYW9lbWZma2BiaGlmaGBBSzc7SDMRDAgJCgMrU1BQTg0rWVRUpKZQqaVdW1tZDSpJQkQ8DYEAIfkECQAAbwAsAgAAAAYACgAABzqAb2dsamFvZW1mZmtgYmhpZmhgQUs3O0gzEQwICQoDK1NQUE4NK1lUVKSmUKmlXVtbWQ0qSUJEPA2BACH5BAkAAG8ALAIAAAAGAAoAAAc2gG9nbGphb2VtZmZrYGJoimhgQVFKSk8zG1VWVkwELFpXVk0Nn5ujJFihoyxcoVikRz9DOQ+BACH5BAkAAG8ALAIAAAAGAAoAAAc2gG9nbGphb2VtZmZrYGJoimhgQVFKSk8zG1VWVkwELFpXVk0Nn5ujJFihoyxcoVikRz9DOQ+BACH5BAkAAG8ALAIAAAAGAAoAAAc2gG9nbGphb2VtZmZrYGJoimhgQVFKSk8zG1VWVkwELFpXVk0Nn5ujJFihoyxcoVikRz9DOQ+BACH5BAkAAG8ALAIAAAAGAAoAAAc2gG9nbGphb2VtZmZrYGJoimhgQVFKSk8zG1VWVkwELFpXVk0Nn5ujJFihoyxcoVikRz9DOQ+BACH5BAkAAG8ALAIAAAAGAAoAAAc2gG9nbGphb2VtZmZrYGJoimhgQVFKSk8zG1VWVkwELFpXVk0Nn5ujJFihoyxcoVikRz9DOQ+BACH5BAkAAG8ALAIAAAAGAAoAAAc2gG9nbGphb2VtZmZrYGJoimhgQVFKSk8zG1VWVkwELFpXVk0Nn5ujJFihoyxcoVikRz9DOQ+BACH5BAkAAG8ALAIAAAAGAAoAAAc2gG9nbGphb2VtZmZrYGJoimhgQVFKSk8zG1VWVkwELFpXVk0Nn5ujJFihoyxcoVikRz9DOQ+BACH5BAkAAG8ALAIAAAAGAAoAAAc2gG9nbGphb2VtZmZrYGJoimhgQVFKSk8zG1VWVkwELFpXVk0Nn5ujJFihoyxcoVikRz9DOQ+BACH5BAkAAG8ALAIAAAAGAAoAAAc2gG9nbGphb2VtZmZrYGJoimhgQVFKSk8zG1VWVkwELFpXVk0Nn5ujJFihoyxcoVikRz9DOQ+BACH5BAkAAG8ALAIAAAAGAAoAAAc2gG9nbGphb2VtZmZrYGJoimhgQVFKSk8zG1VWVkwELFpXVk0Nn5ujJFihoyxcoVikRz9DOQ+BACH5BAkAAG8ALAIAAAAGAAoAAAc2gG9nbGphb2VtZmZrYGJoimhgQVFKSk8zG1VWVkwELFpXVk0Nn5ujJFihoyxcoVikRz9DOQ+BACH5BAkAAG8ALAIAAAAGAAoAAAc2gG9nbGphb2VtZmZrYGJoimhgQVFKSk8zG1VWVkwELFpXVk0Nn5ujJFihoyxcoVikRz9DOQ+BADs=
 """)
 
+AUTARKY_16x16 = base64.decode("""
+iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAAbwAAAG8B8aLcQwAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAAKGSURBVDiNfZJtaM1hGMZ/9/P/73TOzFvIZuMYJ8uStywjhSQhSxvLywdbJNl88V1a2VfJbKVEjVJn+TRqQlvxQfJW7GSRaENsM+Ts5f/y3L44pzPk+Xjd1+/qeu5uUVVy377+usWhyA6E9Sjrbg5OLylw7FDU2FS+obmv/MK9XL8BaKLJANT219cFIrcRiYvV6xHrrUrMoHi6GzQbw1j/hNu1oLfhhiAmEyC7Ph7Nj4bePUVfAittGFbdiF/9NKlWh8RI4Zftb0yMjMsdC5Hh5S1FilrjTHgRhUpBKsTRmr/gTqnUCX6wjIN9S1pefVl+fr4Bb37v8Q4AkzeaHhWkWyGt1tk+Ce6Rhfqd+yJ41NCekWdGdeuQl1dVlmrcIn8uMRe20GPeEWcaZ6jWU7njeKrxlrXEzP9gII6Lzw+a/7TkYbvGrSk3NR/qKydN7sucLAwQkIchTVJ66ZTSjC0WiyR/hma2MaodtYMNBdkAIQC6gKGsZjF4JPCxGelF6bnPJVHvmBGVZ+F4enXWvEFHzCY9ZqAI4e3vvh4FrKVa3+eWfb207ZJB9LERJn8DCJWdKIvUxSdKJbv1+b/WJXv7DyeU8K64UpEsvDz4WxbbwzNgivnGPnbrkwywMNV47bvvVIkQzHODBSZZcumNomc10NZsbA9rgajx2ZgLA+RH7IVQxR3xnZlWZJaoKoLInoG6TmBUXGlIXrwyDMBptbnwktTRlV/82IOYCQfGrFM8NzZemj0kQaRm4NAJQU6CtlnloROd8rTvqzcnHUYOj1mz7VvgrJgb8dvflrce2UyT283p4K9LrB04koDgACprVHTVrcEZhVNd+zHm2EdRR9telbV25/p/AZhtE/ThSw0TAAAAAElFTkSuQmCC
+""")
+
 # need 5 items because 100% is index 4
 battery_level_icons = [BATTERY_CHARGE_STATUS_0_25_10x10, BATTERY_CHARGE_STATUS_25_50_10x10, BATTERY_CHARGE_STATUS_50_75_10x10, BATTERY_CHARGE_STATUS_75_100_10x10, BATTERY_CHARGE_STATUS_75_100_10x10]
 battery_level_mains = [BATTERY_0_TO_25_MAIN_SCREEN, BATTERY_25_TO_50_MAIN_SCREEN, BATTERY_50_TO_75_MAIN_SCREEN, BATTERY_75_TO_100_MAIN_SCREEN, BATTERY_75_TO_100_MAIN_SCREEN]
@@ -126,6 +131,7 @@ iVBORw0KGgoAAAANSUhEUgAAAAcAAAAQCAYAAADagWXwAAAACXBIWXMAAAsTAAALEwEAmpwYAAAKn2lU
 
 URL_CUR = "https://cloud.solar-manager.ch/v1/stream/gateway/{}"
 URL_SUM = "https://cloud.solar-manager.ch/v1/consumption/gateway/{}?period=day"
+URL_AUT = "https://cloud.solar-manager.ch/v1/statistics/gateways/{}?accuracy=low&from={}&to={}"
 
 # 5 minutes cache time
 CACHE_TTL = 300
@@ -139,6 +145,10 @@ DUMMY_DATA = {
     "consumption": 1000.96,
     "production": 3000.11,
     "has_battery": True,
+    "autarky_day": 100,
+    "autarky_24h": 75,
+    "autarky_month": 50,
+    "autarky_year": 25,
 }
 
 def w2kwstr(w, dec = None):  # rounds off decimal, removes completey if over 100kw
@@ -158,9 +168,50 @@ def render_fail(rep):
     content = json.decode(rep.body())
     return render.Root(render.Box(render.WrappedText(content["error"] + " " + str(rep.status_code) + " : " + content["message"], color = RED)))
 
+def get_autarky_percent(site_id, api_key, tz, interval):
+    now = time.now().in_location(tz)
+
+    now_string = humanize.time_format("yyyy-MM-ddTHH:00", now)
+    start_string = now_string  # init
+    print(now_string)
+    if interval == "day":  # from the start of today to now, just set time to 00:00
+        start_string = humanize.time_format("yyyy-MM-ddT00:00", now)
+        now_string = humanize.time_format("2006-01-02T15:04:05", now)
+    elif interval == "24h":  # the last 24hr from now, use a now-duration
+        duration = time.parse_duration("24h")
+        start_time = now - duration
+        start_string = humanize.time_format("yyyy-MM-ddTHH:00", start_time)
+    elif interval == "month":  # from the start of the month to now, just set day to 01 and time to 00:00
+        month = now.month
+        if now.month < 10:  # pad a zero if less then 10
+            month = "0" + str(month)
+        start_string = "{}-{}-01T00:00".format(now.year, month)
+    elif interval == "year":  # from the start of the year to now, set month/day to 01/01 and time to 00:00
+        start_string = "{}-01-01T00:00".format(now.year)
+    url = URL_AUT.format(site_id, start_string, now_string)
+    print(url)
+    rep = http.get(
+        url,
+        headers = {
+            "Accept": "application/json",
+            "Authorization": "Basic " + api_key,
+        },
+        ttl_seconds = 60 * 60,  # 1 hour cache
+    )
+
+    if rep.status_code != 200:
+        print(rep.body())
+        return 0
+    print(rep.headers.get("Tidbyt-Cache-Status"))
+    autarky = rep.json().get("autarchyDegree", 0)
+    return int(autarky)
+
+#######################################
+
 def main(config):
     api_key = config.str("api_key")
     site_id = config.str("site_id")
+    tz = config.get("$tz", "Europe/Zurich")
     has_battery = False  #  assume no battery until we have data
 
     # verify api key doesn't have non key characters in there eg. "Basic"
@@ -170,9 +221,10 @@ def main(config):
         print("corrected api_key : " + api_key)
 
     if not DEBUG and api_key and site_id:
-        url = URL_CUR.format(site_id)
         data = cache.get(site_id)
+
         if not data:
+            url = URL_CUR.format(site_id)
             data = dict()
             rep = http.get(
                 url,
@@ -212,7 +264,12 @@ def main(config):
             data["consumption"] = sum_data["data"][0]["consumption"]
             data["production"] = sum_data["data"][0]["production"]
 
-            # TODO: Determine if this cache call can be converted to the new HTTP cache.
+            data["autarky_day"] = get_autarky_percent(site_id, api_key, tz, "day")
+            data["autarky_24h"] = get_autarky_percent(site_id, api_key, tz, "24h")
+            data["autarky_month"] = get_autarky_percent(site_id, api_key, tz, "month")
+            data["autarky_year"] = get_autarky_percent(site_id, api_key, tz, "year")
+
+            # We store custom data and data from multiple http calls so http cache won't suffice here.
             cache.set(site_id, json.encode(data), ttl_seconds = CACHE_TTL)
         else:
             print("using cache")
@@ -521,6 +578,70 @@ def main(config):
         ),
     )
 
+    # AUTARKY FRAME
+    autarky_frame = render.Stack(
+        children = [
+            render.Box(
+                height = 32,
+                width = 64,
+                child = render.Image(src = AUTARKY_16x16),
+            ),
+            render.Column(
+                # column for the top
+                main_align = "start",
+                expanded = True,
+                children = [
+                    # top row
+                    render.Row(
+                        expanded = True,
+                        main_align = "space_between",
+                        children = [
+                            render.Row([render.Text("24hr:", font = "tom-thumb", color = GRAY)]),
+                            render.Row([render.Text("Month:", font = "tom-thumb", color = GRAY)]),
+                        ],
+                    ),
+
+                    # second row
+                    render.Row(
+                        expanded = True,
+                        main_align = "space_between",
+                        cross_align = "end",
+                        children = [
+                            render.Row([render.Text(" {}%".format(data["autarky_24h"]), color = GREEN)]),
+                            render.Row([render.Text("{}%".format(data["autarky_month"]), color = GREEN)]),
+                        ],
+                    ),
+                ],
+            ),
+            render.Column(
+                main_align = "end",
+                expanded = True,
+                children = [
+                    # third row
+                    render.Row(
+                        expanded = True,
+                        main_align = "space_between",
+                        children = [
+                            render.Row([render.Text("Today:", font = "tom-thumb", color = GRAY)]),
+                            render.Row([render.Text("Year:", font = "tom-thumb", color = GRAY)]),
+                        ],
+                    ),
+
+                    # fourth row
+                    render.Row(
+                        expanded = True,
+                        main_align = "space_between",
+                        cross_align = "end",
+                        children = [
+                            render.Row([render.Text(" {}%".format(data["autarky_day"]), color = GREEN)]),
+                            render.Row([render.Text("{}%".format(data["autarky_year"]), color = GREEN)]),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+
     if config.bool("show_logo", False):
         frames.append(logo_frame)
     if config.bool("show_main", True):
@@ -533,6 +654,8 @@ def main(config):
         frames.append(verbrauch_frame)
     if config.bool("show_summary", False):
         frames.append(summary_frame)
+    if config.bool("show_autarky", False):
+        frames.append(autarky_frame)
 
     if len(frames) == 1:
         return render.Root(frames[0])
@@ -606,6 +729,13 @@ def get_schema():
                 id = "show_logo",
                 name = "Show Logo Frame",
                 desc = "Solar Manager Logo",
+                icon = "compress",
+                default = False,
+            ),
+            schema.Toggle(
+                id = "show_autarky",
+                name = "Show Autarky Frame",
+                desc = "Display the 4 Autarky values for day,week,month,year",
                 icon = "compress",
                 default = False,
             ),


### PR DESCRIPTION
# Description
Pull autarky data and display on optional screen

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b0219a0</samp>

### Summary
🌞📊⏱️

<!--
1.  🌞 - This emoji represents the solar manager app and its domain of solar energy and self-sufficiency. It can be used to indicate any feature or improvement related to the app's core functionality or user experience.
2.  📊 - This emoji represents the new feature of showing the autarky percentage, which is a statistical measure of how much of the user's energy demand is met by their own solar system. It can be used to indicate any feature or improvement related to data visualization, analysis, or reporting.
3.  ⏱️ - This emoji represents the different time intervals that the user can choose from to view the autarky percentage, such as hour, day, week, month, or year. It can be used to indicate any feature or improvement related to time management, scheduling, or flexibility.
-->
This pull request adds a new feature to the `solar_manager_ch` app that displays the autarky percentage of the user's solar system. Autarky percentage is the ratio of self-consumed solar energy to total energy demand. The feature allows the user to choose from different time intervals, such as hour, day, week, month, or year, and uses the `time` and `humanize` modules to format the output.

> _Oh we are the solar sailors, and we love to see the sun_
> _We use the `autarky` feature to measure how we've done_
> _We pull the `time` and `humanize` modules from the store_
> _And we render a component with the `config` option and more_

### Walkthrough
*  Add a new feature to display the autarky percentages for different time intervals from the solar manager API ([link](https://github.com/tidbyt/community/pull/1487/files?diff=unified&w=0#diff-c051df266f180eb1cf7fa7e4c0a4cabb28d7cfeb7b35a76af13f36d8f7109d61R15), [link](https://github.com/tidbyt/community/pull/1487/files?diff=unified&w=0#diff-c051df266f180eb1cf7fa7e4c0a4cabb28d7cfeb7b35a76af13f36d8f7109d61R79-R82), [link](https://github.com/tidbyt/community/pull/1487/files?diff=unified&w=0#diff-c051df266f180eb1cf7fa7e4c0a4cabb28d7cfeb7b35a76af13f36d8f7109d61R134), [link](https://github.com/tidbyt/community/pull/1487/files?diff=unified&w=0#diff-c051df266f180eb1cf7fa7e4c0a4cabb28d7cfeb7b35a76af13f36d8f7109d61R148-R151), [link](https://github.com/tidbyt/community/pull/1487/files?diff=unified&w=0#diff-c051df266f180eb1cf7fa7e4c0a4cabb28d7cfeb7b35a76af13f36d8f7109d61L161-R214), [link](https://github.com/tidbyt/community/pull/1487/files?diff=unified&w=0#diff-c051df266f180eb1cf7fa7e4c0a4cabb28d7cfeb7b35a76af13f36d8f7109d61R581-R644), [link](https://github.com/tidbyt/community/pull/1487/files?diff=unified&w=0#diff-c051df266f180eb1cf7fa7e4c0a4cabb28d7cfeb7b35a76af13f36d8f7109d61R657-R658), [link](https://github.com/tidbyt/community/pull/1487/files?diff=unified&w=0#diff-c051df266f180eb1cf7fa7e4c0a4cabb28d7cfeb7b35a76af13f36d8f7109d61R735-R741))
*  Move the URL definition for the current data inside the cache check to avoid unnecessary computation ([link](https://github.com/tidbyt/community/pull/1487/files?diff=unified&w=0#diff-c051df266f180eb1cf7fa7e4c0a4cabb28d7cfeb7b35a76af13f36d8f7109d61L173-R227))
*  Add a comment explaining the need for the custom cache ([link](https://github.com/tidbyt/community/pull/1487/files?diff=unified&w=0#diff-c051df266f180eb1cf7fa7e4c0a4cabb28d7cfeb7b35a76af13f36d8f7109d61L215-R272))


