### PR TITLE
Fix encryption key

### DIFF
--- a/apps/relay_fm_live/relay_fm_live.star
+++ b/apps/relay_fm_live/relay_fm_live.star
@@ -77,7 +77,7 @@ def get_next_recording(api_key, live, timezone):
     )
 
 def main(config):
-    api_key = secret.decrypt("AV6+xWcE1+vVlYsC8ctRY3w3gUNEEkB3OUcob0kBvK0+1KGcve4gnEaq0WTcR9PmCrpsetzOOhdl7VkU/vW4Gek88eNzgOdvlD1pYWGo3eIAod5BmPq+DDP0YC0HRNYD9Zcjb2As2tXeXUiXcsERnKqMHQdMMlJoDO9pWGrsD0q4tKZHOhzG2Be0jJmC") or config.get("dev_api_key")
+    api_key = secret.decrypt("AV6+xWcEoKjG8mFe0dFr2eQI1xB5D/XCOCSfZjtFDGVbkundM4GZvhRqSFK1yhMOF9WMZBRstFbpJPAfQIk6fVHTwSz00thU0a+VPQb6fuofS+VFq1g/G9zsU4B78n9T3oQ7KerEBimdJzQmZHBX8Cnf5khhBnv4uktupaoF5ElvnkGDx0OO17t4eYI0") or config.get("dev_api_key")
     timezone = config.get("timezone") or "America/New_York"
     img = render.Image(src = relay_logo)
     live = check_live()


### PR DESCRIPTION
# Description
Replaces the encryption key with one encoded with the correct packageName

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 41f37b6</samp>

### Summary
🔒🐛📻

<!--
1.  🔒 - This emoji represents encryption or security, and can be used to indicate that the `api_key` variable was updated with a new encrypted value.
2.  🐛 - This emoji represents a bug or an error, and can be used to indicate that the change was made to fix a bug that prevented the app from working properly.
3.  📻 - This emoji represents a radio or a podcast, and can be used to indicate that the app is related to the Relay FM API and the live show schedule.
-->
Updated the `api_key` variable in `relay_fm_live.star` to use a new encrypted value. This fixed a bug that prevented the app from fetching the live show schedule from the Relay FM API.

> _`api_key` changed_
> _To fix the live show bug_
> _Fall leaves no errors_

### Walkthrough
*  Update the `api_key` variable to use a new encrypted value ([link](https://github.com/tidbyt/community/pull/1489/files?diff=unified&w=0#diff-44b21248cc7081a01595decbbfa3ddd55da61a8868aede4ecdf8316aa99c9ef5L80-R80)). This fixes a bug that prevented fetching the live show schedule from the Relay FM API. Keep the `dev_api_key` config option as a fallback for local testing. The rest of the code in the `main` function is unchanged. This is the only change in the file `apps/relay_fm_live/relay_fm_live.star`.


