### PR TITLE
Addition of the steam_plus (Steam Plus) app

### DIFF
--- a/apps/steam_plus/manifest.yaml
+++ b/apps/steam_plus/manifest.yaml
@@ -1,0 +1,8 @@
+---
+id: steam-plus
+name: Steam Plus
+summary: Show Steam user status
+desc: Shows Steam user avatar, name, status, and currently playing.
+author: Mike Toscano
+fileName: steam_plus.star
+packageName: steamplus

--- a/apps/steam_plus/steam_plus.star
+++ b/apps/steam_plus/steam_plus.star
@@ -1,0 +1,158 @@
+"""
+Applet: Steam Plus
+Summary: Show Steam user status
+Description: Shows Steam user avatar, name, status, and currently playing.
+Author: Mike Toscano
+"""
+
+load("cache.star", "cache")
+load("encoding/json.star", "json")
+load("http.star", "http")
+load("render.star", "render")
+load("schema.star", "schema")
+load("secret.star", "secret")
+
+STEAM_LOGO_PATH = "https://images-wixmp-ed30a86b8c4ca887773594c2.wixmp.com/f/7a48ed11-13b2-44e3-a982-8d763d500a3e/db6u02a-edde930a-c504-4284-a0ce-bc88e4ba15b2.png?token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1cm46YXBwOjdlMGQxODg5ODIyNjQzNzNhNWYwZDQxNWVhMGQyNmUwIiwiaXNzIjoidXJuOmFwcDo3ZTBkMTg4OTgyMjY0MzczYTVmMGQ0MTVlYTBkMjZlMCIsIm9iaiI6W1t7InBhdGgiOiJcL2ZcLzdhNDhlZDExLTEzYjItNDRlMy1hOTgyLThkNzYzZDUwMGEzZVwvZGI2dTAyYS1lZGRlOTMwYS1jNTA0LTQyODQtYTBjZS1iYzg4ZTRiYTE1YjIucG5nIn1dXSwiYXVkIjpbInVybjpzZXJ2aWNlOmZpbGUuZG93bmxvYWQiXX0.bH5kQSIO2Fp1YhXcwTgqQCG-n0HADfWmtPIdqxaF_ZI"
+STATUS = ["Offline", "Online", "Busy", "Away"]
+STATUS_COLOR = ["#59707B", "#0a0", "#F67407", "#FFD100"]
+
+def main(config):
+    api_key = secret.decrypt("AV6+xWcEwaY3vnJsrpZ955musUx4antJ6gbwX3x2owwWA3+5Op9iKbtJOOwUi5IEtAyFUoBZ2m/9udqMTty57El86cAySE44VGeMQY7/7gkzdTxISb1jxZy+bI+TM0sOdoYgA/Fs1kVAnT/JFrG0RESwBcHDaP09o77VlvVv0ujLqnz6x20=") or "7F08C7D00DFAA3C9E3EEB3503F9712EA"
+
+    STEAM_API_ENDPOINT = "http://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/?key=" + api_key + "&steamids="
+    STEAM_GAMES_ENDPOINT = "http://api.steampowered.com/IPlayerService/GetOwnedGames/v0001/?key=" + api_key + "&steamid="
+
+    resp_cached = cache.get("players")
+
+    players = {}
+    if resp_cached == None:
+        resp = http.get(STEAM_API_ENDPOINT + config.str("id", ""))
+
+        if resp.status_code != 200:
+            fail("Cannot load the specified user")
+
+        players = resp.json()["response"]["players"]
+        cache.set("players", json.encode(players), ttl_seconds = 180)
+    else:
+        players = json.decode(resp_cached)
+
+    username = "Cannot find the specified user"
+    avatar = http.get(STEAM_LOGO_PATH).body()
+    currently_playing_logo = http.get(STEAM_LOGO_PATH).body()
+    currently_playing = ""
+    status = ""
+    persona_state = 0
+
+    user = {}
+    if len(players) > 0:
+        user = players[0]
+
+        username = user["personaname"]
+
+        # currently_playing_label = "Now playing:" if "gameextrainfo" in user else ""
+        currently_playing = user["gameextrainfo"] if "gameextrainfo" in user else "Just Chilling"
+        avatar = http.get(user["avatarfull"]).body()
+        status = STATUS[int(user["personastate"])]
+        currently_playing_game_id = user["gameid"] if "gameid" in user else ""
+        currently_playing_logo = http.get(STEAM_LOGO_PATH).body()
+        persona_state = int(user["personastate"])
+
+        games_cached = cache.get("games")
+
+        user_games = {}
+        if games_cached == None:
+            user_games_resp = http.get(STEAM_GAMES_ENDPOINT + config.str("id", "") + "&include_appinfo=true&format=json")
+
+            if user_games_resp.status_code == 200:
+                user_games = user_games_resp.json()["response"]["games"]
+                cache.set("games", json.encode(user_games), ttl_seconds = 180)
+        else:
+            user_games = json.decode(games_cached)
+
+        for game in user_games:
+            if len(currently_playing_game_id) > 0 and int(game["appid"]) == int(currently_playing_game_id):
+                currently_playing_logo = http.get("https://media.steampowered.com/steamcommunity/public/images/apps/" + currently_playing_game_id + "/" + game["img_icon_url"] + ".jpg").body()
+                break
+
+    return render.Root(
+        delay = 90,
+        child = render.Box(
+            height = 32,
+            child = render.Column(
+                children = [
+                    render.Row(
+                        expanded = True,  # Use as much horizontal space as possible
+                        main_align = "space_evenly",  # Controls horizontal alignment
+                        cross_align = "center",  # Controls vertical alignment
+                        children = [
+                            render.Image(
+                                src = avatar,
+                                width = 16,
+                                height = 16,
+                            ),
+                            render.Column(
+                                children = [
+                                    render.Marquee(
+                                        width = 48,
+                                        height = 8,
+                                        child = render.Text(content = username, font = "tb-8"),
+                                        offset_start = 0,
+                                        offset_end = 0,
+                                    ),
+                                    render.Text(content = status, font = "tb-8", color = STATUS_COLOR[persona_state], height = 8),
+                                ],
+                            ),
+                        ],
+                    ),
+                    # render.Row(
+                    #     expanded=True, # Use as much horizontal space as possible
+                    #     main_align="space_evenly", # Controls horizontal alignment
+                    #     cross_align="center", # Controls vertical alignment
+                    #     children = [
+                    #         # render.Text(content=currently_playing_label, font="tb-8")
+                    #         render.Text(content=" ")
+                    #     ]
+                    # ),
+                    render.Row(
+                        expanded = True,  # Use as much horizontal space as possible
+                        main_align = "space_evenly",  # Controls horizontal alignment
+                        cross_align = "end",  # Controls vertical alignment
+                        children = [
+                            render.Image(
+                                src = currently_playing_logo,
+                                width = 16,
+                                height = 15,
+                            ),
+                            # render.Text(content=currently_playing, font="tb-8", height=16, offset=4),
+                            render.Marquee(
+                                width = 56,
+                                child = render.Text(content = " " + currently_playing, font = "tb-8", height = 16, offset = 4),
+                                offset_start = 0,
+                                offset_end = 0,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ),
+    )
+
+def get_schema():
+    return schema.Schema(
+        version = "1",
+        fields = [
+            schema.Text(
+                id = "id",
+                name = "Steam ID",
+                desc = "17 digit Steam ID",
+                icon = "user",
+            ),
+            # schema.Toggle(
+            #     id = "small",
+            #     name = "Display small text",
+            #     desc = "A toggle to display smaller text.",
+            #     icon = "compress",
+            #     default = False,
+            # ),
+        ],
+    )


### PR DESCRIPTION
Add a steam_plus app, meant to provide more information than the existing steam app. The steam_plus app will also function even when the specified user is offline.

# Description
Adding a new community app. The Steam Plus app provides the following functionality. Note that the gif only shows the app in the unconfigured state. The screenshot shows a better view.
![steam_plus](https://github.com/tidbyt/community/assets/7661715/d59eda1f-01cd-4fce-a8a2-a79f2d22a7e6)
<img width="957" alt="Screenshot 2023-05-20 at 12 34 01 AM" src="https://github.com/tidbyt/community/assets/7661715/8b313134-b241-49bc-80b5-6caf3ba86158">

- Shows the specified user's avatar
- Shows the specified user's name in a marquee
- Shows the specified user's online/offline/away status
- Shows the specified user's "now playing" status and the game icon

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9952e05</samp>

### Summary
🎮🚂🖼️

<!--
1.  🎮 - This emoji represents the gaming theme of the applet, as well as the Steam platform itself.
2.  🚂 - This emoji represents the Steam logo, which is a stylized locomotive, as well as the idea of steam power and speed.
3.  🖼️ - This emoji represents the applet's display of the user's avatar, name, and game on the Tidbyt device, as well as the use of the render module to create the UI elements.
-->
Added a new applet `steam_plus` that displays Steam user and game information on the Tidbyt device. The applet uses the Steam API, the secret and render modules, and a configuration schema that requires the user's Steam ID. The applet code is in `apps/steam_plus/steam_plus.star`.

> _`Steam Plus` applet_
> _Shows user and game status_
> _Winter nights of fun_

### Walkthrough
* Create and display the Steam Plus applet, which shows Steam user status, avatar, name, and currently playing game ([link](https://github.com/tidbyt/community/pull/1494/files?diff=unified&w=0#diff-8d3df16931b284d07f757bdbd2eab7651b510759e23b62879821dba2b4b40601R1-R158))


