### PR TITLE
Update: F1 Results

### DIFF
--- a/apps/f1results/f1_results.star
+++ b/apps/f1results/f1_results.star
@@ -6,6 +6,9 @@ Author: M0ntyP
 
 v1.0a
 Updated caching function
+
+v1.1
+The API is a round behind with the cancellation of Round 6. Monaco should be Round 7 but its appearing as Round 6. Added 1 to the round number for the race preview
 """
 
 load("encoding/json.star", "json")
@@ -96,6 +99,9 @@ def main(config):
             Session = "R"
 
     if Session == "":
+        # API feed is one round behind, so bumping by 1 to match the official F1 round number
+        CurrentRound = str(int(CurrentRound) + 1)
+
         # nothing has happened yet
         return render.Root(
             child = render.Column(


### PR DESCRIPTION
# Description
The API is a round behind with the cancellation of Round 6. Monaco should be Round 7 but its appearing as Round 6. Added 1 to the round number for the race preview screen. Will probably need to remove it later once they adjust it

Thanks to @jvivona for the heads up!

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 55615a3</samp>

### Summary
🐛🏎️🚫

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of this change.
2.  🏎️ - This emoji represents a racing car, which is relevant to the f1_results app and the race preview feature.
3.  🚫 - This emoji represents a cancelled or prohibited action, which is what happened to the race that caused the round number issue.
-->
Fix round number bug in `f1_results` app. The app now accounts for cancelled races and shows the correct round number for the next race.

> _The race was cancelled, the season in despair_
> _But we won't give up, we'll fix the bug in `f1_results`_
> _We'll adjust the round, we'll show the preview right_
> _We'll rock the code review, we'll make the app shine bright_

### Walkthrough
*  Adjust the current round number to match the official F1 round number ([link](https://github.com/tidbyt/community/pull/1502/files?diff=unified&w=0#diff-1ca327b6c6255476fd9edfc191d4f9fc55fbb9bb645e932cfa8e777f8693aa7aR9-R11),[link](https://github.com/tidbyt/community/pull/1502/files?diff=unified&w=0#diff-1ca327b6c6255476fd9edfc191d4f9fc55fbb9bb645e932cfa8e777f8693aa7aR102-R104)) in `f1_results.star`


