### PR TITLE
Bug fix: ATP Tennis & WTA Tennis

### DIFF
--- a/apps/wtatennis/wta_tennis.star
+++ b/apps/wtatennis/wta_tennis.star
@@ -25,6 +25,9 @@ Sometimes the data feed will still show matches as "In Progress" after they have
 v1.4
 Updated caching function
 Current server now indicated in green
+
+v1.4.1
+Fixed bug which appears when player who is serving is not being provided by data feed. Code now checks if that data is present before showing it, or not 
 """
 
 load("encoding/json.star", "json")
@@ -211,14 +214,18 @@ def getLiveScores(SelectedTourneyID, EventIndex, InProgressMatchList, JSON):
             Player1_ID = JSON["events"][EventIndex]["competitions"][x]["competitors"][0]["id"]
             Player2_Name = JSON["events"][EventIndex]["competitions"][x]["competitors"][1]["athlete"]["shortName"]
             Player2_ID = JSON["events"][EventIndex]["competitions"][x]["competitors"][1]["id"]
-            Server = JSON["events"][EventIndex]["competitions"][x]["situation"]["server"]["$ref"]
-            Server = Server[70:]
-            Server = Server.removesuffix("?lang=en&region=us")
 
-            if Server == Player1_ID:
-                Player1Color = "#01AF50"
-            elif Server == Player2_ID:
-                Player2Color = "#01AF50"
+            # 17 fields in a live game if the serving data is being shown
+            if len(JSON["events"][EventIndex]["competitions"][x]) == 17:
+                Server = JSON["events"][EventIndex]["competitions"][x]["situation"]["server"]["$ref"]
+                Server = Server[70:]
+                Server = Server.removesuffix("?lang=en&region=us")
+
+                if Server == Player1_ID:
+                    Player1Color = "#01AF50"
+                elif Server == Player2_ID:
+                    Player2Color = "#01AF50"
+
             Number_Sets = len(JSON["events"][EventIndex]["competitions"][x]["competitors"][0]["linescores"])
             Player1_Sets = ""
             Player2_Sets = ""


### PR DESCRIPTION
# Description
Fixed bug which appears when player who is serving is not being provided by data feed. Code now checks if that data is present before showing it, or not 

I'm hoping this also fixes the issue with the tournament selection dropdown list?

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 98c3bea</samp>

### Summary
🐛📝🚀

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of both pull requests.
2.  📝 - This emoji represents a comment or documentation update, which both pull requests also include to explain the version and the bug fix.
3.  🚀 - This emoji represents a performance improvement or a new feature, which the `atp_tennis` pull request introduces by adding a variable to define the cache expiration time for the data feed. This could potentially improve the app's speed and efficiency.
-->
This pull request fixes a bug in the `atp_tennis` and `wtatennis` apps that could cause display issues when serving data is missing. It also adds comments and a variable to improve code readability and maintainability.

> _Sing, O Muse, of the skillful programmers who fixed the bugs_
> _That plagued the `wtatennis` and `atptennis` apps, and caused much woe_
> _To the eager fans of the swift-footed players and the golden racket_
> _Who wished to see the serving data of their heroes and their foes._

### Walkthrough
*  Add comments to indicate version number and bug fix for missing serving data in `apps/atptennis/atp_tennis.star` and `apps/wtatennis/wta_tennis.star` ([link](https://github.com/tidbyt/community/pull/1505/files?diff=unified&w=0#diff-2fe7726a8148e3fb23a64991e8b2661bd9c098395de1a2f1ea0092f21db623bcR27-R29), [link](https://github.com/tidbyt/community/pull/1505/files?diff=unified&w=0#diff-bacac371ef4450963bfae6cc2618e0ce8278c5d02f808e88e0cff7243efed67dR28-R30))
*  Modify `get_tournament_data` function to check the length of the JSON object for each competition and only assign the `Server` variable and the color codes if the serving data is present in both `apps/atptennis/atp_tennis.star` and `apps/wtatennis/wta_tennis.star` ([link](https://github.com/tidbyt/community/pull/1505/files?diff=unified&w=0#diff-2fe7726a8148e3fb23a64991e8b2661bd9c098395de1a2f1ea0092f21db623bcL218-R232), [link](https://github.com/tidbyt/community/pull/1505/files?diff=unified&w=0#diff-bacac371ef4450963bfae6cc2618e0ce8278c5d02f808e88e0cff7243efed67dL214-R228))
*  Introduce `TOURNEY_CACHE` variable to store the cache expiration time for the data feed and use it as an argument for the `get_cachable_data` function in `apps/atptennis/atp_tennis.star` ([link](https://github.com/tidbyt/community/pull/1505/files?diff=unified&w=0#diff-2fe7726a8148e3fb23a64991e8b2661bd9c098395de1a2f1ea0092f21db623bcL588-R596))


