### PR TITLE
DetailedMETAR: Flight category fixes.

### DIFF
--- a/apps/detailedmetar/detailedmetar.star
+++ b/apps/detailedmetar/detailedmetar.star
@@ -537,10 +537,28 @@ def getFlightCategory(decodedMetar):
     else:
         visibility = int(decodedMetar["visib"])
 
-    if cloudLayers[0]["base"] != None:
+    baseClouds = int(12000)
+    print(baseClouds)
+
+    print(decodedMetar)
+
+    if cloudLayers[2]["cover"] == "BKN":
+        baseClouds = cloudLayers[2]["base"]
+
+    if cloudLayers[2]["cover"] == "OVC":
+        baseClouds = cloudLayers[2]["base"]
+
+    if cloudLayers[1]["cover"] == "BKN":
+        baseClouds = cloudLayers[1]["base"]
+
+    if cloudLayers[1]["cover"] == "OVC":
+        baseClouds = cloudLayers[1]["base"]
+
+    if cloudLayers[0]["cover"] == "BKN":
         baseClouds = cloudLayers[0]["base"]
-    else:
-        baseClouds = int(12000)
+
+    if cloudLayers[0]["cover"] == "OVC":
+        baseClouds = cloudLayers[0]["base"]
 
     #IFR
     if baseClouds > 3000 and visibility >= 5:


### PR DESCRIPTION
# Description
Fixes an issue where the flight category (VFR, MVFR, IFR, LIFR) determination was being made using the base level of the first level of clouds, no matter the cover type. Fixes problem so that base levels are only determined from BKN & OVC layers.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 221f833</samp>

### Summary
:bug::cloud::mag:

<!--
1.  :bug: This emoji represents a bug fix, which is the main purpose of the pull request. It indicates that the code was not working as intended or expected, and that the change resolves the issue.
2.  :cloud: This emoji represents a cloud, which is the main subject of the change. It indicates that the code deals with cloud layers and conditions, and that the change affects how the app displays them.
3.  :mag: This emoji represents a magnifying glass, which is a symbol of investigation or debugging. It indicates that the code adds some print statements for debugging purposes, and that the change helps to inspect or verify the app's logic and output.
-->
Fixed a bug in `detailedmetar` app that caused incorrect IFR conditions. Changed the code to use the lowest broken or overcast cloud layer as the baseClouds variable.

> _`baseClouds` changes_
> _to find the true ceiling_
> _autumn fog lingers_

### Walkthrough
* Improve IFR condition detection by assigning baseClouds to lowest broken or overcast layer instead of first layer ([link](https://github.com/tidbyt/community/pull/1508/files?diff=unified&w=0#diff-1a845b3df75ba68543ee3a1655dbb32040827eff408bbdedc31f78cb48c684a6L540-R562))


