### PR TITLE
DetailedMETAR: Big Fix: No output if cloud layers not within MVFR/IFR/LIFR range

### DIFF
--- a/apps/detailedmetar/detailedmetar.star
+++ b/apps/detailedmetar/detailedmetar.star
@@ -531,6 +531,8 @@ def getFlightCategory(decodedMetar):
     flightCategory = None
     cloudLayers = decodedMetar["clouds"]
     visibility = None
+    cloudLayerCount = len(cloudLayers)
+    cloudLayerArrayObject = cloudLayerCount - 1
 
     if (decodedMetar["visib"] == "10+"):
         visibility = 10
@@ -538,27 +540,46 @@ def getFlightCategory(decodedMetar):
         visibility = int(decodedMetar["visib"])
 
     baseClouds = int(12000)
-    print(baseClouds)
+    print(cloudLayers)
 
-    print(decodedMetar)
+    if(cloudLayerCount == 1):
+        if cloudLayers[0]["cover"] == "BKN":
+            baseClouds = cloudLayers[0]["base"]
 
-    if cloudLayers[2]["cover"] == "BKN":
-        baseClouds = cloudLayers[2]["base"]
+        if cloudLayers[0]["cover"] == "OVC":
+            baseClouds = cloudLayers[0]["base"]
 
-    if cloudLayers[2]["cover"] == "OVC":
-        baseClouds = cloudLayers[2]["base"]
+    if(cloudLayerCount == 2):
+        if cloudLayers[0]["cover"] == "BKN":
+            baseClouds = cloudLayers[0]["base"]
 
-    if cloudLayers[1]["cover"] == "BKN":
-        baseClouds = cloudLayers[1]["base"]
+        if cloudLayers[0]["cover"] == "OVC":
+            baseClouds = cloudLayers[0]["base"]
+            
+        if cloudLayers[1]["cover"] == "BKN":
+            baseClouds = cloudLayers[1]["base"]
 
-    if cloudLayers[1]["cover"] == "OVC":
-        baseClouds = cloudLayers[1]["base"]
+        if cloudLayers[1]["cover"] == "OVC":
+            baseClouds = cloudLayers[1]["base"]
 
-    if cloudLayers[0]["cover"] == "BKN":
-        baseClouds = cloudLayers[0]["base"]
+    if(cloudLayerCount == 3):
+        if cloudLayers[0]["cover"] == "BKN":
+            baseClouds = cloudLayers[0]["base"]
 
-    if cloudLayers[0]["cover"] == "OVC":
-        baseClouds = cloudLayers[0]["base"]
+        if cloudLayers[0]["cover"] == "OVC":
+            baseClouds = cloudLayers[0]["base"]
+
+        if cloudLayers[1]["cover"] == "BKN":
+            baseClouds = cloudLayers[1]["base"]
+
+        if cloudLayers[1]["cover"] == "OVC":
+            baseClouds = cloudLayers[1]["base"]
+
+        if cloudLayers[2]["cover"] == "BKN":
+            baseClouds = cloudLayers[2]["base"]
+
+        if cloudLayers[2]["cover"] == "OVC":
+            baseClouds = cloudLayers[2]["base"]
 
     #IFR
     if baseClouds > 3000 and visibility >= 5:

--- a/apps/detailedmetar/detailedmetar.star
+++ b/apps/detailedmetar/detailedmetar.star
@@ -538,10 +538,46 @@ def getFlightCategory(decodedMetar):
     else:
         visibility = int(decodedMetar["visib"])
 
-    if cloudLayers[0]["base"] != None:
-        baseClouds = cloudLayers[0]["base"]
-    else:
-        baseClouds = int(12000)
+    baseClouds = int(12000)
+
+    if (cloudLayerCount == 1):
+        if cloudLayers[0]["cover"] == "BKN":
+            baseClouds = cloudLayers[0]["base"]
+
+        if cloudLayers[0]["cover"] == "OVC":
+            baseClouds = cloudLayers[0]["base"]
+
+    if (cloudLayerCount == 2):
+        if cloudLayers[0]["cover"] == "BKN":
+            baseClouds = cloudLayers[0]["base"]
+
+        if cloudLayers[0]["cover"] == "OVC":
+            baseClouds = cloudLayers[0]["base"]
+
+        if cloudLayers[1]["cover"] == "BKN":
+            baseClouds = cloudLayers[1]["base"]
+
+        if cloudLayers[1]["cover"] == "OVC":
+            baseClouds = cloudLayers[1]["base"]
+
+    if (cloudLayerCount == 3):
+        if cloudLayers[0]["cover"] == "BKN":
+            baseClouds = cloudLayers[0]["base"]
+
+        if cloudLayers[0]["cover"] == "OVC":
+            baseClouds = cloudLayers[0]["base"]
+
+        if cloudLayers[1]["cover"] == "BKN":
+            baseClouds = cloudLayers[1]["base"]
+
+        if cloudLayers[1]["cover"] == "OVC":
+            baseClouds = cloudLayers[1]["base"]
+
+        if cloudLayers[2]["cover"] == "BKN":
+            baseClouds = cloudLayers[2]["base"]
+
+        if cloudLayers[2]["cover"] == "OVC":
+            baseClouds = cloudLayers[2]["base"]
 
     #IFR
     if baseClouds > 3000 and visibility >= 5:

--- a/apps/detailedmetar/detailedmetar.star
+++ b/apps/detailedmetar/detailedmetar.star
@@ -537,10 +537,28 @@ def getFlightCategory(decodedMetar):
     else:
         visibility = int(decodedMetar["visib"])
 
-    if cloudLayers[0]["base"] != None:
+    baseClouds = int(12000)
+    print(baseClouds)
+
+    print(decodedMetar)
+
+    if cloudLayers[2]["cover"] == "BKN":
+        baseClouds = cloudLayers[2]["base"]
+
+    if cloudLayers[2]["cover"] == "OVC":
+        baseClouds = cloudLayers[2]["base"]
+
+    if cloudLayers[1]["cover"] == "BKN":
+        baseClouds = cloudLayers[1]["base"]
+
+    if cloudLayers[1]["cover"] == "OVC":
+        baseClouds = cloudLayers[1]["base"]
+
+    if cloudLayers[0]["cover"] == "BKN":
         baseClouds = cloudLayers[0]["base"]
-    else:
-        baseClouds = int(12000)
+
+    if cloudLayers[0]["cover"] == "OVC":
+        baseClouds = cloudLayers[0]["base"]
 
     #IFR
     if baseClouds > 3000 and visibility >= 5:

--- a/apps/detailedmetar/detailedmetar.star
+++ b/apps/detailedmetar/detailedmetar.star
@@ -532,7 +532,6 @@ def getFlightCategory(decodedMetar):
     cloudLayers = decodedMetar["clouds"]
     visibility = None
     cloudLayerCount = len(cloudLayers)
-    cloudLayerArrayObject = cloudLayerCount - 1
 
     if (decodedMetar["visib"] == "10+"):
         visibility = 10
@@ -542,27 +541,27 @@ def getFlightCategory(decodedMetar):
     baseClouds = int(12000)
     print(cloudLayers)
 
-    if(cloudLayerCount == 1):
+    if (cloudLayerCount == 1):
         if cloudLayers[0]["cover"] == "BKN":
             baseClouds = cloudLayers[0]["base"]
 
         if cloudLayers[0]["cover"] == "OVC":
             baseClouds = cloudLayers[0]["base"]
 
-    if(cloudLayerCount == 2):
+    if (cloudLayerCount == 2):
         if cloudLayers[0]["cover"] == "BKN":
             baseClouds = cloudLayers[0]["base"]
 
         if cloudLayers[0]["cover"] == "OVC":
             baseClouds = cloudLayers[0]["base"]
-            
+
         if cloudLayers[1]["cover"] == "BKN":
             baseClouds = cloudLayers[1]["base"]
 
         if cloudLayers[1]["cover"] == "OVC":
             baseClouds = cloudLayers[1]["base"]
 
-    if(cloudLayerCount == 3):
+    if (cloudLayerCount == 3):
         if cloudLayers[0]["cover"] == "BKN":
             baseClouds = cloudLayers[0]["base"]
 


### PR DESCRIPTION
# Description
A fix to last week's patch - fixes a failure of cloud layer outputs when cloud layers not within MVFR/IFR/LIFR range

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1f2b390</samp>

### Summary
🌥️🔧🚀

<!--
1.  🌥️ - This emoji represents the cloud height calculation and the different cloud layers that the app can display.
2.  🔧 - This emoji represents the improvement and simplification of the code, as well as the bug fix for the negative cloud height issue.
3.  🚀 - This emoji represents the enhancement of the app's functionality and performance, as well as the user experience.
-->
Improved cloud height calculation in `detailedmetar` app by using a new variable and simpler logic. This change affects the file `apps/detailedmetar/detailedmetar.star`.

> _Sing, O Muse, of the skillful coder who improved_
> _The `detailedmetar` app with a clever change_
> _Introducing `cloudLayerCount`, a variable that smoothed_
> _The logic of cloud height, making it more concise and strange_

### Walkthrough
*  Simplify cloud height logic by adding `cloudLayerCount` variable and using nested if statements ([link](https://github.com/tidbyt/community/pull/1514/files?diff=unified&w=0#diff-1a845b3df75ba68543ee3a1655dbb32040827eff408bbdedc31f78cb48c684a6R534), [link](https://github.com/tidbyt/community/pull/1514/files?diff=unified&w=0#diff-1a845b3df75ba68543ee3a1655dbb32040827eff408bbdedc31f78cb48c684a6L541-R581)) in `apps/detailedmetar/detailedmetar.star`


