### PR TITLE
fix(metar): tweak blue color

### DIFF
--- a/apps/metar/metar.star
+++ b/apps/metar/metar.star
@@ -84,7 +84,7 @@ def color_for_state(result):
     elif category == "IFR":
         return "#FF0000"
     elif category == "MVFR":
-        return "#0000FF"
+        return "#0088FF"
     elif category == "LIFR":
         return "#FF00FF"
     elif category == "ERR" or category == "UNK":


### PR DESCRIPTION
# Description
Smidge tweak on the Marginal VFR blue values for increased legibility

| Before | After | 
| ---- | ---- |
| #0000FF | #0088FF |
| ![CleanShot 2023-05-30 at 22 49 24@2x](https://github.com/tidbyt/community/assets/51947763/6313d92f-54a7-4e1f-89b7-484aae399de9) | ![CleanShot 2023-05-30 at 22 49 37@2x](https://github.com/tidbyt/community/assets/51947763/96b32c89-5c90-43b8-9339-171d021eb9e4) |
| ![IMG_0498](https://github.com/tidbyt/community/assets/51947763/7488838b-00a3-4384-a09f-f6504024defa) | ![IMG_0499](https://github.com/tidbyt/community/assets/51947763/f4da8eb3-8766-4201-ae5e-996c7f42a06b) |

# Copilot
<!-- please don't change the line below -->
copilot:all
