### PR TITLE
Fix (beattime): prevent overflow

### DIFF
--- a/apps/beattime/beat_time.star
+++ b/apps/beattime/beat_time.star
@@ -7,7 +7,7 @@ DEFAULT_SHOW_CENTIBEATS = True
 
 def time_in_beats(now):
     # The time zone to use is Biel Mean Time (BMT) - UTC+1, ignore daylight savings
-    time_in_milliseconds = (math.round(now.nanosecond / 1000000)) + ((now.second + (now.minute * 60 + (now.hour + 1) * 3600)) * 1000)
+    time_in_milliseconds = (math.round(now.nanosecond / 1000000)) + ((now.second + (now.minute * 60 + ((now.hour + 1) % 24) * 3600)) * 1000)
     time_in_beats = math.round(time_in_milliseconds / 86400 * 100000) / 100000
     time_in_beats_integral, time_in_beats_fractional = str("%f" % time_in_beats).split(".")
 


### PR DESCRIPTION
Correct calculation of beats to avoid overflowing past 1000.

# Description
When calculating beats from UTC time, the current code simply adds 1 to the UTC hour, giving it the range [1..24]. This means that during the hour starting at 23:00 UTC, beats are displayed as **@1000.00** through **@1041.66** instead of the correct **@000.00** through **@041.66**.

This fix modifies the subexpression `(now.hour + 1)` to `((now.hour + 1) % 24)` so the hour will be constrained to [0..23], preventing the overflow.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 47fa60f</samp>

### Summary
🐛🕒🌐

<!--
1.  🐛 This emoji represents a bug or an error that was fixed by the change. It is often used to indicate bug fixes or patches in commit messages or pull requests.
2.  🕒 This emoji represents a clock or a time-related feature or change. It is often used to indicate changes related to time zones, scheduling, deadlines, or performance.
3.  🌐 This emoji represents the globe or the world wide web. It is often used to indicate changes related to internationalization, localization, or web development.
-->
Fixed a bug in `beat_time.star` that caused incorrect time in beats calculation for certain time zones. Used modulo operator to wrap around the hour value.

> _`time_in_beats` fixed_
> _modulo for edge cases_
> _winter bug no more_

### Walkthrough
* Fix bug in `time_in_beats` function to handle edge case of hour 23 and UTC+1 ([link](https://github.com/tidbyt/community/pull/1528/files?diff=unified&w=0#diff-2f3690b0be45f3c138fb74bd68bceac6dfcf3bc7f5ca9ab1c74c3e21ff8ad9bdL10-R10))


