### PR TITLE
Update: ATP & WTA Tennis apps

### DIFF
--- a/apps/atptennis/atp_tennis.star
+++ b/apps/atptennis/atp_tennis.star
@@ -31,6 +31,7 @@ Fixed bug which appears when player who is serving is not being provided by data
 v1.5
 Added handling for "scheduled" matches which are actually in progress
 Updated logic that finds player who is serving
+Certain API fields of ESPN data feed showing that the French Open is over? Changed the way an "in progress" tournament is determined using start and end dates
 """
 
 load("encoding/json.star", "json")
@@ -57,6 +58,8 @@ def main(config):
     InProgressMatchList = []
     CompletedMatchList = []
     InProgress = 0
+    diffTournEnd = 0
+    diffTournStart = 0
 
     TestID = "414-2023"
     SelectedTourneyID = config.get("TournamentList", TestID)
@@ -70,9 +73,16 @@ def main(config):
             # Capture the index of the particular event, we'll need this later on
             EventIndex = x
 
-            # if there are 10 items, this means we have matches
-            # if != 10 then call function that says tournament has not started yet
-            if len(ATP_JSON["events"][x]) == 10:
+            # Get start & end date/time of the tournament
+            EndDate = ATP_JSON["events"][x]["endDate"]
+            StartDate = ATP_JSON["events"][x]["date"]
+            EndDate = time.parse_time(EndDate, format = "2006-01-02T15:04Z")
+            StartDate = time.parse_time(StartDate, format = "2006-01-02T15:04Z")
+            diffTournEnd = EndDate - now
+            diffTournStart = StartDate - now
+
+            # check if we are between the start & end date of the tournament
+            if diffTournStart.hours < 0 and diffTournEnd.hours > 0:
                 for y in range(0, len(ATP_JSON["events"][x]["competitions"]), 1):
                     # if the match is "In Progress" and its a singles match, lets add it to the list of in progress matches
                     # And the "In Progress" match started < 24 hrs ago , sometimes the data feed will still show matches as "In Progress" after they have completed
@@ -81,8 +91,8 @@ def main(config):
                         if ATP_JSON["events"][x]["competitions"][y]["competitors"][0]["type"] == "athlete":
                             MatchTime = ATP_JSON["events"][EventIndex]["competitions"][y]["date"]
                             MatchTime = time.parse_time(MatchTime, format = "2006-01-02T15:04Z").in_location(timezone)
-                            diff = MatchTime - now
-                            if diff.hours > -24:
+                            diffMatch = MatchTime - now
+                            if diffMatch.hours > -24:
                                 InProgressMatchList.append(y)
                                 InProgress = InProgress + 1
 
@@ -93,8 +103,8 @@ def main(config):
                             if ATP_JSON["events"][x]["competitions"][y]["competitors"][0]["type"] == "athlete":
                                 MatchTime = ATP_JSON["events"][EventIndex]["competitions"][y]["date"]
                                 MatchTime = time.parse_time(MatchTime, format = "2006-01-02T15:04Z").in_location(timezone)
-                                diff = MatchTime - now
-                                if diff.hours > -24:
+                                diffMatch = MatchTime - now
+                                if diffMatch.hours > -24:
                                     InProgressMatchList.append(y)
                                     InProgress = InProgress + 1
 
@@ -138,7 +148,9 @@ def main(config):
         for x in range(0, Number_Events, 1):
             if SelectedTourneyID == ATP_JSON["events"][x]["id"]:
                 EventIndex = x
-                if len(ATP_JSON["events"][x]) == 10:
+
+                # check if we are between the start & end date of the tournament
+                if diffTournStart.hours < 0 and diffTournEnd.hours > 0:
                     for y in range(0, len(ATP_JSON["events"][x]["competitions"]), 1):
                         # if the match is completed ("post") and its a singles match ("athlete") and the start time of the match was < 24 hrs ago, lets add it to the list of completed matches
                         if ATP_JSON["events"][x]["competitions"][y]["status"]["type"]["state"] == "post":
@@ -620,9 +632,19 @@ def get_schema():
     TournamentOptions = []
     ActualEvents = 0
 
+    #timezone = config.get("$tz")
+    now = time.now()
+
     # Only show "In Progress" tournaments
     for x in range(0, Number_Events, 1):
-        if ATP_JSON["events"][x]["status"]["type"]["state"] == "in":
+        EndDate = ATP_JSON["events"][x]["endDate"]
+        StartDate = ATP_JSON["events"][x]["date"]
+        EndDate = time.parse_time(EndDate, format = "2006-01-02T15:04Z")
+        StartDate = time.parse_time(StartDate, format = "2006-01-02T15:04Z")
+        diffTournEnd = EndDate - now
+        diffTournStart = StartDate - now
+
+        if diffTournStart.hours < 0 and diffTournEnd.hours > 0:
             Event_Name = ATP_JSON["events"][x]["name"]
             Event_ID = ATP_JSON["events"][x]["id"]
             Events.append(Event_Name)

--- a/apps/atptennis/atp_tennis.star
+++ b/apps/atptennis/atp_tennis.star
@@ -27,6 +27,10 @@ Current server now indicated in green
 
 v1.4.1
 Fixed bug which appears when player who is serving is not being provided by data feed. Code now checks if that data is present before showing it, or not 
+
+v1.5
+Added handling for "scheduled" matches which are actually in progress
+Updated logic that finds player who is serving
 """
 
 load("encoding/json.star", "json")
@@ -81,6 +85,19 @@ def main(config):
                             if diff.hours > -24:
                                 InProgressMatchList.append(y)
                                 InProgress = InProgress + 1
+
+                    # Another gotcha with the ESPN data feed, some in progress matches are still listed as "Scheduled"
+                    # So check if there is a score listed and if so, add it to the in progress list
+                    if ATP_JSON["events"][x]["competitions"][y]["status"]["type"]["description"] == "Scheduled":
+                        if "linescores" in ATP_JSON["events"][x]["competitions"][y]["competitors"][0]:
+                            if ATP_JSON["events"][x]["competitions"][y]["competitors"][0]["type"] == "athlete":
+                                MatchTime = ATP_JSON["events"][EventIndex]["competitions"][y]["date"]
+                                MatchTime = time.parse_time(MatchTime, format = "2006-01-02T15:04Z").in_location(timezone)
+                                diff = MatchTime - now
+                                if diff.hours > -24:
+                                    InProgressMatchList.append(y)
+                                    InProgress = InProgress + 1
+
             else:
                 Display1.extend([
                     render.Column(
@@ -219,8 +236,8 @@ def getLiveScores(SelectedTourneyID, EventIndex, InProgressMatchList, JSON):
             Player2_Name = JSON["events"][EventIndex]["competitions"][x]["competitors"][1]["athlete"]["shortName"]
             Player2_ID = JSON["events"][EventIndex]["competitions"][x]["competitors"][1]["id"]
 
-            # 17 fields in a live game if the serving data is being shown
-            if len(JSON["events"][EventIndex]["competitions"][x]) == 17:
+            # See if the server details are been captured and then display them if they are there
+            if "situation" in JSON["events"][EventIndex]["competitions"][x]:
                 Server = JSON["events"][EventIndex]["competitions"][x]["situation"]["server"]["$ref"]
                 Server = Server[70:]
                 Server = Server.removesuffix("?lang=en&region=us")


### PR DESCRIPTION
# Description
Updated logic that finds player who is serving
Added handling for "scheduled" matches which are actually in progress

The tournament status fields of the ESPN data feed were showing that the French Open is over already, eg "completed" = true....which broke my app. So I've changed the way an "in progress" tournament is determined by using the start and end dates instead

And also for some reason ESPN is showing both mens and womens matches in both ATP & WTA feeds now...

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c3f3275</samp>

### Summary
🎾🔄📝

<!--
1.  🎾 - This emoji represents the sport of tennis and the main topic of the apps.
2.  🔄 - This emoji represents the update and improvement of the existing code and functionality of the apps.
3.  📝 - This emoji represents the addition of a comment with the version number and features of the apps.
-->
This pull request improves the tennis apps for both ATP and WTA by using more reliable criteria to display live and upcoming matches. It also adds version and feature comments to the `atp_tennis.star` app. The changes affect the files `apps/atptennis/atp_tennis.star` and `apps/wtatennis/wta_tennis.star`.

> _Sing, O Muse, of the skillful coder who updated the apps_
> _That show the glorious deeds of tennis players, men and women,_
> _Who wield their rackets like the thunderbolts of mighty Zeus_
> _And strive for victory and fame on courts of clay and grass._

### Walkthrough
*  Add comment to indicate version number and main features for both `atp_tennis.star` and `wta_tennis.star` ([link](https://github.com/tidbyt/community/pull/1533/files?diff=unified&w=0#diff-2fe7726a8148e3fb23a64991e8b2661bd9c098395de1a2f1ea0092f21db623bcR30-R34), [link](https://github.com/tidbyt/community/pull/1533/files?diff=unified&w=0#diff-bacac371ef4450963bfae6cc2618e0ce8278c5d02f808e88e0cff7243efed67dR31-R35))
*  Add variables to store time difference between current time and tournament start and end date for both apps ([link](https://github.com/tidbyt/community/pull/1533/files?diff=unified&w=0#diff-2fe7726a8148e3fb23a64991e8b2661bd9c098395de1a2f1ea0092f21db623bcR61-R62), [link](https://github.com/tidbyt/community/pull/1533/files?diff=unified&w=0#diff-bacac371ef4450963bfae6cc2618e0ce8278c5d02f808e88e0cff7243efed67dR62-R63))
*  Replace condition that checks number of items in JSON response with condition that checks time difference for both apps in functions that display matches for a selected tournament ([link](https://github.com/tidbyt/community/pull/1533/files?diff=unified&w=0#diff-2fe7726a8148e3fb23a64991e8b2661bd9c098395de1a2f1ea0092f21db623bcL69-R85), [link](https://github.com/tidbyt/community/pull/1533/files?diff=unified&w=0#diff-2fe7726a8148e3fb23a64991e8b2661bd9c098395de1a2f1ea0092f21db623bcL124-R153), [link](https://github.com/tidbyt/community/pull/1533/files?diff=unified&w=0#diff-bacac371ef4450963bfae6cc2618e0ce8278c5d02f808e88e0cff7243efed67dL71-R86), [link](https://github.com/tidbyt/community/pull/1533/files?diff=unified&w=0#diff-bacac371ef4450963bfae6cc2618e0ce8278c5d02f808e88e0cff7243efed67dL126-R154))
*  Add code to handle matches that are in progress but listed as scheduled in JSON response for both apps ([link](https://github.com/tidbyt/community/pull/1533/files?diff=unified&w=0#diff-2fe7726a8148e3fb23a64991e8b2661bd9c098395de1a2f1ea0092f21db623bcL80-R110), [link](https://github.com/tidbyt/community/pull/1533/files?diff=unified&w=0#diff-bacac371ef4450963bfae6cc2618e0ce8278c5d02f808e88e0cff7243efed67dR99-R111))
*  Modify condition that checks number of fields in JSON response with condition that checks key existence for both apps in functions that display serving data for a live match ([link](https://github.com/tidbyt/community/pull/1533/files?diff=unified&w=0#diff-2fe7726a8148e3fb23a64991e8b2661bd9c098395de1a2f1ea0092f21db623bcL222-R252), [link](https://github.com/tidbyt/community/pull/1533/files?diff=unified&w=0#diff-bacac371ef4450963bfae6cc2618e0ce8278c5d02f808e88e0cff7243efed67dL218-R247))
*  Add code to calculate time difference for each tournament and check if it is in progress for both apps in functions that display list of in progress tournaments ([link](https://github.com/tidbyt/community/pull/1533/files?diff=unified&w=0#diff-2fe7726a8148e3fb23a64991e8b2661bd9c098395de1a2f1ea0092f21db623bcL606-R647), [link](https://github.com/tidbyt/community/pull/1533/files?diff=unified&w=0#diff-bacac371ef4450963bfae6cc2618e0ce8278c5d02f808e88e0cff7243efed67dL596-R635))
*  Remove commented out line of code that prints tournament ID in `wta_tennis.star` ([link](https://github.com/tidbyt/community/pull/1533/files?diff=unified&w=0#diff-bacac371ef4450963bfae6cc2618e0ce8278c5d02f808e88e0cff7243efed67dL63))


