### PR TITLE
solarmanager_ch : add new page to display aux sensor kWh usage

### DIFF
--- a/apps/solarmanagerch/solar_manager_ch.star
+++ b/apps/solarmanagerch/solar_manager_ch.star
@@ -1,7 +1,7 @@
 """
 Applet: Solar Manager Ch
 Summary: Show solarmanager.ch status
-Description: Multiple screen selections will disable animations. If you prefer animated screens, run separate instances of the app and select 1 screen per instance.  For API Key : authorize with your solarmanager username and password on: https://external-web.solar-manager.ch/swagger and copy the long string that follows after '-H authorization: Basic'.  For Site ID : check the back of your solarmanager device for the SMID code..
+Description: Multiple screen selections will disable animations. If you prefer animated screens, run separate instances of the app and select 1 screen per instance.  For API Key : authorize with your solarmanager username and password on: https://external-web.solar-manager.ch/swagger and copy the long string that follows after '-H authorization: Basic'.  For Site ID : check the back of your solarmanager device for the SMID code.  If you have an aux sensor the ID can be found be executing the 'GET/v1/info/senors/(smid)' command on the solarmanager API page at https://external-web.solar-manager.ch/swagger"
 Author: tavdog, marcbaier
 """
 
@@ -80,6 +80,14 @@ AUTARKY_16x16 = base64.decode("""
 iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAAbwAAAG8B8aLcQwAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAAKGSURBVDiNfZJtaM1hGMZ/9/P/73TOzFvIZuMYJ8uStywjhSQhSxvLywdbJNl88V1a2VfJbKVEjVJn+TRqQlvxQfJW7GSRaENsM+Ts5f/y3L44pzPk+Xjd1+/qeu5uUVVy377+usWhyA6E9Sjrbg5OLylw7FDU2FS+obmv/MK9XL8BaKLJANT219cFIrcRiYvV6xHrrUrMoHi6GzQbw1j/hNu1oLfhhiAmEyC7Ph7Nj4bePUVfAittGFbdiF/9NKlWh8RI4Zftb0yMjMsdC5Hh5S1FilrjTHgRhUpBKsTRmr/gTqnUCX6wjIN9S1pefVl+fr4Bb37v8Q4AkzeaHhWkWyGt1tk+Ce6Rhfqd+yJ41NCekWdGdeuQl1dVlmrcIn8uMRe20GPeEWcaZ6jWU7njeKrxlrXEzP9gII6Lzw+a/7TkYbvGrSk3NR/qKydN7sucLAwQkIchTVJ66ZTSjC0WiyR/hma2MaodtYMNBdkAIQC6gKGsZjF4JPCxGelF6bnPJVHvmBGVZ+F4enXWvEFHzCY9ZqAI4e3vvh4FrKVa3+eWfb207ZJB9LERJn8DCJWdKIvUxSdKJbv1+b/WJXv7DyeU8K64UpEsvDz4WxbbwzNgivnGPnbrkwywMNV47bvvVIkQzHODBSZZcumNomc10NZsbA9rgajx2ZgLA+RH7IVQxR3xnZlWZJaoKoLInoG6TmBUXGlIXrwyDMBptbnwktTRlV/82IOYCQfGrFM8NzZemj0kQaRm4NAJQU6CtlnloROd8rTvqzcnHUYOj1mz7VvgrJgb8dvflrce2UyT283p4K9LrB04koDgACprVHTVrcEZhVNd+zHm2EdRR9telbV25/p/AZhtE/ThSw0TAAAAAElFTkSuQmCC
 """)
 
+EV_CHARGING_16x16 = base64.decode("""
+iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAACXBIWXMAAAB2AAAAdgFOeyYIAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAArtJREFUOI11k0to1GcUxX/3+08SMxNFrNpYE9+C8RGliBupJmpiEIKBOMUHFhQXYoVSiKGiJt+oCx0GuhAR6mtVtZlIDBYSkhhEEBcWIRpHRR2Mxlh8YZsZJzaZ73ZjZRzt2V04nHPuS8hCmbW+L5JUApUGZqugCvckLV0vR2vnZWtHMvmSWQTrQxWqehQYVqEFx10DTmG+CjUCBpHvm8ONlz4RqK2320U5iLKzOWJ/AzQrnATr7AYVjoiwOxq2v3wQCNbZFSo0iTHl0cMNt7LbykRtnS0VoVuUb6MR2y3BYJPnpsdixhGKRuwZgAs337QhVH1kL7StnT92zXvDjc7QuMBPiY+pd6pEGYlG7Nmfu/pmeM4UI3yT7azK8iOdT8pGxD3+cdXUs7W77N7eQVntc6IVCC2ASpqZKW9wR0/iYeAz6f2jZOIPuQSOAnGgFaMVPgMzQKIAxn9q2cuhZ9UP/xpDIL+IcTkFALweTpBM9TPT+7u6eNSkXqDLwD2FGp+CoioAJXJj63f5f3iRd8uY++UKKguXAtDx51ViT69Rl3fFu87ircA+T+gYdvLKhxDHMQegXSv7Tw4VfZXSXHqfdPD7wBUA3qaHUC1ke6qGyXlz++Ei58J2ABjwiZMuFY0Ae3IfFbfmxf9ZMmnihAcFCwu2ZQ4g0ZM48fr5i1l5s4sufLSdMmt945PEEAktmvf15TfJ5LH8/MC5A1uqz2QS952+uDGVSq4vyMnZcft+b/k8v/5qrXUCsK4+tBLVaNqY8pbDDT3/d0T7r3csfTeY2Hu//VY4bbTv/CEbNwDN4cZLIvzkOde9rj60iawf+S8tpA/mjvFXTVk+Z7NxUks28X2SY4ADWhG5K6qqUAKsLSwt7ptQMrkUON64uKrhEwGAYLDJc9NiqwVWAdMADyGuSueCAO3WWpfJ/xczZBKg/h8O2gAAAABJRU5ErkJggg==
+""")
+
+CUSTOM_SENSOR_16_16 = base64.decode("""
+iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAACXBIWXMAAAPvAAAD7wHnP/QUAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAohJREFUOI1tUl9I02EUPeeba9Bm/kuzQvPfQpTa1rQCDYR806iQoPAlQoKITKJe1ERKJEIpeqqE6qGXHhxEgVQKFQVK4ZYoUpugZoogKjibP92+24NO1+q83e+ce889l4/YwOeh0fNC+VV+oOhd9O2W31GsqI4ryOSqZe1ja9bIPOJAABgYHU0Lr0pAk5VKowKi+8pcxb62MXc5RF8kkQfATbBbU5qa87wTWwMEbB0ofZtjrprPTjjdYoH5iwlrRUcdjqlYp3a/K10UmwCp1VrO3LT73gMAr73Jz6JJ+yxWM7apxIXChLrXZ92XGuJXjaJtzFVDoCui9bEW+7cRFQlHrocNnbo8b6QGfy/uGIrcexXbsDS458ry1527o3VzvreblA6T4kMAUCCHQawAwFoofL/98I++qHjZm1lKyA1rydxM7FBbJNgJMKc94CxTGYVJ42m5SeMCXkgJ2jqiosWh7BQBX4AYjo9Rbw8YJDyarE4A1H6Thd8fVI0/jQpEwKBv9RnAXAgWgoOZd8QkzxMds5vDRHNEEZUKWhRElmIdQoO7jpDcC2AWxCGQp1YskYlYDaENEbEoAacA5saS292z/TbnTAmJTyBWSJ5LL5z7y0STeaD8VGGL8QGAuzVwMCM+qxa4CF62Oqe98RzIExT0qo3v6TEzoTGWX/DmJBPotzqnn8T3tvmdJymSapNgjwIAIRoBqW0bc9VERcmhsGENmerim2/73flU7KJIQ709YHCLcFYoRQ8pHbZIsLPeHjD+56wUH0PY2VgweHf9mDG45XcUm5R6BGAfCQ8gw6JpCJG/nllSRcvVZrvv5eYp/jkOgPaAs0yT1QQKAFgAmaSg1ybBnvjN/gABgQjIrnX3XQAAAABJRU5ErkJggg==
+""")
+
 # need 5 items because 100% is index 4
 battery_level_icons = [BATTERY_CHARGE_STATUS_0_25_10x10, BATTERY_CHARGE_STATUS_25_50_10x10, BATTERY_CHARGE_STATUS_50_75_10x10, BATTERY_CHARGE_STATUS_75_100_10x10, BATTERY_CHARGE_STATUS_75_100_10x10]
 battery_level_mains = [BATTERY_0_TO_25_MAIN_SCREEN, BATTERY_25_TO_50_MAIN_SCREEN, BATTERY_50_TO_75_MAIN_SCREEN, BATTERY_75_TO_100_MAIN_SCREEN, BATTERY_75_TO_100_MAIN_SCREEN]
@@ -132,6 +140,7 @@ iVBORw0KGgoAAAANSUhEUgAAAAcAAAAQCAYAAADagWXwAAAACXBIWXMAAAsTAAALEwEAmpwYAAAKn2lU
 URL_CUR = "https://cloud.solar-manager.ch/v1/stream/gateway/{}"
 URL_SUM = "https://cloud.solar-manager.ch/v1/consumption/gateway/{}?period=day"
 URL_AUT = "https://cloud.solar-manager.ch/v1/statistics/gateways/{}?accuracy=low&from={}&to={}"
+URL_AUX = "https://cloud.solar-manager.ch/v1/consumption/sensor/{}?period={}"
 
 # 5 minutes cache time
 CACHE_TTL = 300
@@ -149,6 +158,9 @@ DUMMY_DATA = {
     "autarky_24h": 75,
     "autarky_month": 50,
     "autarky_year": 25,
+    "aux_sensor_day": 10000,
+    "aux_sensor_week": 70000,
+    "aux_sensor_month": 140000,
 }
 
 def w2kwstr(w, dec = None):  # rounds off decimal, removes completey if over 100kw
@@ -168,12 +180,28 @@ def render_fail(rep):
     content = json.decode(rep.body())
     return render.Root(render.Box(render.WrappedText(content["error"] + " " + str(rep.status_code) + " : " + content["message"], color = RED)))
 
+def get_aux_sensor_data(sensor_id, api_key, period):
+    # 'https://cloud.solar-manager.ch/v1/consumption/sensor/62a7324c7ffb2aabdaf96b8d?period=day'
+    # user 1 hour for http cache TTL
+    print(URL_AUX.format(sensor_id, period))
+    res = http.get(
+        URL_AUX.format(sensor_id, period),
+        headers = {
+            "Accept": "application/json",
+            "Authorization": "Basic " + api_key,
+        },
+        ttl_seconds = 60 * 60,
+    )  # 1 hour http cache ttl
+    if res.status_code != 200:
+        print(res.body())
+        return 0
+    print(res.headers.get("Tidbyt-Cache-Status"))
+    return res.json().get("totalConsumption")
+
 def get_autarky_percent(site_id, api_key, tz, interval):
     now = time.now().in_location(tz)
-
+    start_string = ""
     now_string = humanize.time_format("yyyy-MM-ddTHH:00", now)
-    start_string = now_string  # init
-    print(now_string)
     if interval == "day":  # from the start of today to now, just set time to 00:00
         start_string = humanize.time_format("yyyy-MM-ddT00:00", now)
         now_string = humanize.time_format("2006-01-02T15:04:05", now)
@@ -269,6 +297,15 @@ def main(config):
             data["autarky_month"] = get_autarky_percent(site_id, api_key, tz, "month")
             data["autarky_year"] = get_autarky_percent(site_id, api_key, tz, "year")
 
+            data["aux_sensor_day"] = 0
+            data["aux_sensor_week"] = 0
+            data["aux_sensor_month"] = 0
+
+            if config.get("aux_sensor_id", "") != "":
+                data["aux_sensor_day"] = get_aux_sensor_data(config.get("aux_sensor_id"), api_key, "day")
+                data["aux_sensor_week"] = get_aux_sensor_data(config.get("aux_sensor_id"), api_key, "week")
+                data["aux_sensor_month"] = get_aux_sensor_data(config.get("aux_sensor_id"), api_key, "month")
+
             # We store custom data and data from multiple http calls so http cache won't suffice here.
             cache.set(site_id, json.encode(data), ttl_seconds = CACHE_TTL)
         else:
@@ -278,6 +315,7 @@ def main(config):
                 has_battery = True
 
     else:
+        print("using dummy data")
         data = DUMMY_DATA
     print(data)
     frames = []
@@ -642,6 +680,103 @@ def main(config):
         ],
     )
 
+    # AUX SENSOR FRAME
+    aux_icon = CUSTOM_SENSOR_16_16
+    if config.get("aux_icon") == "EV":
+        aux_icon = EV_CHARGING_16x16
+    sensor_frame = render.Stack(
+        children = [
+            render.Column(
+                main_align = "space_evenly",  # this controls position of children, start = top
+                expanded = True,
+                cross_align = "center",
+                children = [
+                    render.Text(config.get("aux_sensor_label", "Aux Load"), font = "tom-thumb"),
+                    render.Row(
+                        expanded = True,
+                        main_align = "space_between",
+                        children = [
+                            render.Column(
+                                expanded = True,
+                                main_align = "center",
+                                #cross_align = "center",
+                                children = [
+                                    render.Image(src = aux_icon),
+                                ],
+                            ),
+                            render.Column(
+                                expanded = True,
+                                main_align = "space_around",
+                                cross_align = "start",
+                                children = [
+                                    render.Text(
+                                        content = "D",
+                                        font = "5x8",
+                                        color = GRAY,
+                                    ),
+                                    render.Text(
+                                        content = "W",
+                                        font = "5x8",
+                                        color = GRAY,
+                                    ),
+                                    render.Text(
+                                        content = "M",
+                                        font = "5x8",
+                                        color = GRAY,
+                                    ),
+                                ],
+                            ),
+                            render.Column(
+                                expanded = True,
+                                main_align = "space_around",
+                                cross_align = "end",
+                                children = [
+                                    render.Text(
+                                        content = w2kwstr(data["aux_sensor_day"], dec = 0),
+                                        font = "5x8",
+                                        color = GREEN,
+                                    ),
+                                    render.Text(
+                                        content = w2kwstr(data["aux_sensor_week"], dec = 0),
+                                        font = "5x8",
+                                        color = GREEN,
+                                    ),
+                                    render.Text(
+                                        content = w2kwstr(data["aux_sensor_month"], dec = 0),
+                                        font = "5x8",
+                                        color = GREEN,
+                                    ),
+                                ],
+                            ),
+                            render.Column(
+                                expanded = True,
+                                main_align = "space_around",
+                                cross_align = "start",
+                                children = [
+                                    render.Text(
+                                        content = " kWh",
+                                        font = "5x8",
+                                        color = GRAY,
+                                    ),
+                                    render.Text(
+                                        content = " kWh",
+                                        font = "5x8",
+                                        color = GRAY,
+                                    ),
+                                    render.Text(
+                                        content = " kWh",
+                                        font = "5x8",
+                                        color = GRAY,
+                                    ),
+                                ],
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+
     if config.bool("show_logo", False):
         frames.append(logo_frame)
     if config.bool("show_main", True):
@@ -656,6 +791,8 @@ def main(config):
         frames.append(summary_frame)
     if config.bool("show_autarky", False):
         frames.append(autarky_frame)
+    if config.get("aux_sensor_id", "") != "":
+        frames.append(sensor_frame)
 
     if len(frames) == 1:
         return render.Root(frames[0])
@@ -738,6 +875,37 @@ def get_schema():
                 desc = "Display the 4 Autarky values for day,week,month,year",
                 icon = "compress",
                 default = False,
+            ),
+            schema.Text(
+                id = "aux_sensor_id",
+                name = "Aux Sensor ID",
+                desc = "Aux Senso ID",
+                icon = "hashtag",
+                default = "",
+            ),
+            schema.Text(
+                id = "aux_sensor_label",
+                name = "Aux Sensor Label",
+                desc = "Aux Senso Label",
+                icon = "hashtag",
+                default = "",
+            ),
+            schema.Dropdown(
+                id = "aux_icon",
+                name = "Aux Icon",
+                desc = "Icon Selection",
+                icon = "hashtag",
+                default = "EV",
+                options = [
+                    schema.Option(
+                        display = "EV",
+                        value = "EV",
+                    ),
+                    schema.Option(
+                        display = "Generic",
+                        value = "Generic",
+                    ),
+                ],
             ),
             schema.Dropdown(
                 id = "frame_delay",


### PR DESCRIPTION
# Description
Added a page to display an auxiliary sensor (eg. car charger) showing the total kWh usage for day, week, month.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9eddcf6</samp>

### Summary
🌞🔌⚙️

<!--
1.  🌞 - This emoji represents the solar manager applet and its main functionality of showing solar data.
2.  🔌 - This emoji represents the auxiliary sensor feature and the possibility of connecting different devices to the applet, such as an EV charger or a smart plug.
3.  ⚙️ - This emoji represents the applet settings and the configuration options for the aux sensor ID, label, and icon.
-->
This pull request adds a new feature to the `solar_manager_ch` applet that enables displaying data from an auxiliary sensor. The user can choose the sensor ID, label, and icon in the settings. The applet uses a new API endpoint and a new render component to show the sensor data.

> _Oh, we're the crew of the solar manager_
> _We monitor the sun and the power_
> _We've added a feature to show the aux sensor_
> _So we can see the charger or the flower_

### Walkthrough
*  Update applet description with instructions on finding aux sensor ID ([link](https://github.com/tidbyt/community/pull/1547/files?diff=unified&w=0#diff-c051df266f180eb1cf7fa7e4c0a4cabb28d7cfeb7b35a76af13f36d8f7109d61L4-R4))
*  Add new icons for EV charging and generic sensor as base64 strings ([link](https://github.com/tidbyt/community/pull/1547/files?diff=unified&w=0#diff-c051df266f180eb1cf7fa7e4c0a4cabb28d7cfeb7b35a76af13f36d8f7109d61R83-R90))
*  Define URL template for aux sensor API endpoint ([link](https://github.com/tidbyt/community/pull/1547/files?diff=unified&w=0#diff-c051df266f180eb1cf7fa7e4c0a4cabb28d7cfeb7b35a76af13f36d8f7109d61R143))
*  Add keys for aux sensor consumption values to data dictionary ([link](https://github.com/tidbyt/community/pull/1547/files?diff=unified&w=0#diff-c051df266f180eb1cf7fa7e4c0a4cabb28d7cfeb7b35a76af13f36d8f7109d61R161-R163))
*  Define function to get aux sensor data from API and assign to data dictionary ([link](https://github.com/tidbyt/community/pull/1547/files?diff=unified&w=0#diff-c051df266f180eb1cf7fa7e4c0a4cabb28d7cfeb7b35a76af13f36d8f7109d61L171-R204), [link](https://github.com/tidbyt/community/pull/1547/files?diff=unified&w=0#diff-c051df266f180eb1cf7fa7e4c0a4cabb28d7cfeb7b35a76af13f36d8f7109d61R300-R308))
*  Define render component to display aux sensor data in grid layout ([link](https://github.com/tidbyt/community/pull/1547/files?diff=unified&w=0#diff-c051df266f180eb1cf7fa7e4c0a4cabb28d7cfeb7b35a76af13f36d8f7109d61R683-R779))
*  Append sensor frame to list of frames if aux sensor ID is given ([link](https://github.com/tidbyt/community/pull/1547/files?diff=unified&w=0#diff-c051df266f180eb1cf7fa7e4c0a4cabb28d7cfeb7b35a76af13f36d8f7109d61R794-R795))
*  Add schema components for aux sensor ID, label, and icon choice ([link](https://github.com/tidbyt/community/pull/1547/files?diff=unified&w=0#diff-c051df266f180eb1cf7fa7e4c0a4cabb28d7cfeb7b35a76af13f36d8f7109d61L742-R910))
*  Print cache status of HTTP requests and dummy data usage ([link](https://github.com/tidbyt/community/pull/1547/files?diff=unified&w=0#diff-c051df266f180eb1cf7fa7e4c0a4cabb28d7cfeb7b35a76af13f36d8f7109d61L171-R204), [link](https://github.com/tidbyt/community/pull/1547/files?diff=unified&w=0#diff-c051df266f180eb1cf7fa7e4c0a4cabb28d7cfeb7b35a76af13f36d8f7109d61R318))


