### PR TITLE
Merge i18n support from dutchfuzzyclock into fuzzyclock

### DIFF
--- a/apps/fuzzyclock/fuzzy_clock.star
+++ b/apps/fuzzyclock/fuzzy_clock.star
@@ -17,26 +17,114 @@ DEFAULT_LOCATION = {
 }
 DEFAULT_TIMEZONE = "US/Eastern"
 
-words = {
-    1: "ONE",
-    2: "TWO",
-    3: "THREE",
-    4: "FOUR",
-    5: "FIVE",
-    6: "SIX",
-    7: "SEVEN",
-    8: "EIGHT",
-    9: "NINE",
-    10: "TEN",
-    11: "ELEVEN",
-    12: "TWELVE",
-    15: "QUARTER",
-    20: "TWENTY",
-    25: "TWENTY-FIVE",
-    30: "HALF",
+numbersPerLang = {
+    "nl-NL": {
+        1: "ÉÉN",
+        2: "TWEE",
+        3: "DRIE",
+        4: "VIER",
+        5: "VIJF",
+        6: "ZES",
+        7: "ZEVEN",
+        8: "ACHT",
+        9: "NEGEN",
+        10: "TIEN",
+        11: "ELF",
+        12: "TWAALF",
+        15: "KWART",
+    },
+    "de-DE": {
+        1: "EINS",
+        2: "ZWEI",
+        3: "DREI",
+        4: "VIER",
+        5: "FÜNF",
+        6: "SECHS",
+        7: "SIEBEN",
+        8: "ACHT",
+        9: "NEIN",
+        10: "ZEHN",
+        11: "ELF",
+        12: "ZWÖLF",
+        15: "VIERTEL",
+        20: "ZWANZIG",
+    },
+    "en-US": {
+        1: "ONE",
+        2: "TWO",
+        3: "THREE",
+        4: "FOUR",
+        5: "FIVE",
+        6: "SIX",
+        7: "SEVEN",
+        8: "EIGHT",
+        9: "NINE",
+        10: "TEN",
+        11: "ELEVEN",
+        12: "TWELVE",
+        15: "QUARTER",
+        20: "TWENTY",
+        25: "TWENTY-FIVE",
+        30: "HALF",
+    },
+}
+numbersPerLang["en-GB"] = numbersPerLang["en-US"]
+numbersPerLang["nl-BE"] = numbersPerLang["nl-NL"]
+numbersPerLang["de-CH"] = numbersPerLang["de-DE"]
+
+wordsPerLang = {
+    "nl-NL": {
+        "hour": "UUR",
+        "half": "HALF",
+        "to": "VOOR",
+        "past": "OVER",
+    },
+    "nl-BE": {
+        "hour": "UUR",
+        "half": "HALF",
+        "to": "VOOR",
+        "past": "NA",
+    },
+    "de-DE": {
+        "hour": "UHR",
+        "half": "HALB",
+        "to": "VOR",
+        "past": "NACH",
+    },
+    "de-CH": {
+        "hour": "UHR",
+        "half": "HALB",
+        "to": "VOR",
+        "past": "AB",
+    },
+    "en-US": {
+        "hour": "O'CLOCK",
+        "half": "HALF",
+        "to": "TILL",
+        "past": "PAST",
+    },
+    "en-GB": {
+        "hour": "O'CLOCK",
+        "half": "HALF",
+        "to": "TO",
+        "past": "PAST",
+    },
 }
 
-def round(minutes):
+# At which point a dialect switches from one hour to the next
+# Example: 6:20
+# en-US: TWENTY PAST SIX
+# nl-NL: TEN TO HALF SEVEN
+roundUpFrom = {
+    "de-DE": 15,
+    "de-CH": 15,
+    "en-GB": 30,
+    "en-US": 30,
+    "nl-NL": 15,
+    "nl-BE": 15,
+}
+
+def round(minutes, up_threshold):
     """Returns:
         minutes: rounded to the nearest 5.
         up: if we rounded up or down.
@@ -44,22 +132,23 @@ def round(minutes):
     rounded = (minutes + 2) % 60 // 5 * 5
     up = False
 
-    if rounded > 30:
-        rounded = 60 - rounded
+    if rounded > up_threshold:
         up = True
     elif minutes > 30 and rounded == 0:
         up = True
 
     return rounded, up
 
-def fuzzy_time(config, hours, minutes):
-    glue = "PAST"
-    rounded, up = round(minutes)
+def fuzzy_time(hours, minutes, language):
+    numbers = numbersPerLang[language]
+    words = wordsPerLang[language]
+
+    glue = words["past"]
+    rounded, up = round(minutes, roundUpFrom[language])
 
     if up:
         hours += 1
-
-        glue = "TILL" if config.get("dialect") == "american" else "TO"
+        glue = words["to"]
 
     # Handle 24 hour time.
     if hours > 12:
@@ -69,10 +158,24 @@ def fuzzy_time(config, hours, minutes):
     if hours == 0:
         hours = 12
 
+    # Handle the whole hours
     if rounded == 0:
-        return [words[hours], "O’CLOCK"]
+        return [numbers[hours], words["hour"]]
 
-    return [words[rounded], glue, words[hours]]
+    if up:
+        if roundUpFrom[language] < 30:
+            if rounded < 30:
+                return [numbers[30 - rounded], words["to"] + " " + words["half"], numbers[hours]]
+
+            if rounded == 30:
+                return [words["half"], numbers[hours]]
+
+            if rounded < 45:
+                return [numbers[rounded - 30], words["past"] + " " + words["half"], numbers[hours]]
+
+        rounded = 60 - rounded
+
+    return [numbers[rounded], glue, numbers[hours]]
 
 def main(config):
     location = config.get("location")
@@ -80,7 +183,17 @@ def main(config):
     timezone = loc.get("timezone", DEFAULT_TIMEZONE)
     now = time.now().in_location(timezone)
 
-    fuzzed = fuzzy_time(config, now.hour, now.minute)
+    hours = now.hour
+    minutes = now.minute
+    language = config.get("dialect") or "en-US"
+
+    # backwards compatibility
+    if language == "american":
+        language = "en-US"
+    elif language == "british":
+        language = "en-GB"
+
+    fuzzed = fuzzy_time(hours, minutes, language)
 
     # Add some left padding for ~style~.
     texts = [render.Text(" " * i + s) for i, s in enumerate(fuzzed)]
@@ -98,11 +211,27 @@ def get_schema():
     dialectOptions = [
         schema.Option(
             display = "American English",
-            value = "american",
+            value = "en-US",
         ),
         schema.Option(
             display = "British English",
-            value = "british",
+            value = "en-GB",
+        ),
+        schema.Option(
+            display = "Deutsch",
+            value = "de-DE",
+        ),
+        schema.Option(
+            display = "Deutsch (Schweiz)",
+            value = "de-CH",
+        ),
+        schema.Option(
+            display = "Dutch",
+            value = "nl-NL",
+        ),
+        schema.Option(
+            display = "Dutch (Belgium)",
+            value = "nl-BE",
         ),
     ]
 
@@ -117,9 +246,9 @@ def get_schema():
             ),
             schema.Dropdown(
                 id = "dialect",
-                name = "Dialect",
+                name = "Language",
                 icon = "language",
-                desc = "British or American English",
+                desc = "Language in which to display time",
                 default = dialectOptions[0].value,
                 options = dialectOptions,
             ),


### PR DESCRIPTION
Add support for the de-CH, de-DE, nl-BE, nl-NL locales.

# Description

As a follow-up to https://github.com/tidbyt/community/pull/1535, this PR creates feature parity between `fuzzyclock` and `dutchfuzzyclock` with the goal to deprecate `dutchfuzzyclock`.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9861c51</samp>

### Summary
🌐🗣️🔧

<!--
1.  🌐 - This emoji represents the global or international aspect of supporting multiple languages and dialects, and could be used to indicate that the app is more accessible and inclusive for different users and regions.
2.  🗣️ - This emoji represents the speech or communication aspect of displaying fuzzy time in different languages and dialects, and could be used to indicate that the app is more expressive and adaptable to different preferences and contexts.
3.  🔧 - This emoji represents the tool or adjustment aspect of refactoring the `fuzzy_time` function and renaming and expanding the `language` key, and could be used to indicate that the app is more modular and flexible in its code and functionality.
-->
Updated the `fuzzy_clock` app to support multiple languages and dialects. Refactored the `fuzzy_time` function to use language-specific dictionaries and parameters. Renamed and expanded the `language` key in the app settings.

> _Time is slipping away, no matter what you say_
> _`fuzzy_time` will show you how the hours decay_
> _In any tongue or dialect, you can hear the clock tick_
> _`language` is the key to your doom or your bliss_

### Walkthrough
*  Added support for multiple languages and dialects for displaying fuzzy time ([link](https://github.com/tidbyt/community/pull/1549/files?diff=unified&w=0#diff-8fb3dcfaadcf41d62c73625b4184543811a3a96d7cef336fb39226487e3d0d40L20-R127), [link](https://github.com/tidbyt/community/pull/1549/files?diff=unified&w=0#diff-8fb3dcfaadcf41d62c73625b4184543811a3a96d7cef336fb39226487e3d0d40L47-R135), [link](https://github.com/tidbyt/community/pull/1549/files?diff=unified&w=0#diff-8fb3dcfaadcf41d62c73625b4184543811a3a96d7cef336fb39226487e3d0d40L55-R152), [link](https://github.com/tidbyt/community/pull/1549/files?diff=unified&w=0#diff-8fb3dcfaadcf41d62c73625b4184543811a3a96d7cef336fb39226487e3d0d40L72-R179), [link](https://github.com/tidbyt/community/pull/1549/files?diff=unified&w=0#diff-8fb3dcfaadcf41d62c73625b4184543811a3a96d7cef336fb39226487e3d0d40L100-R234))
*  Modified `fuzzy_time` function to handle whole hours, half hours, and minutes before and after half hours differently for different languages ([link](https://github.com/tidbyt/community/pull/1549/files?diff=unified&w=0#diff-8fb3dcfaadcf41d62c73625b4184543811a3a96d7cef336fb39226487e3d0d40L72-R179))
*  Modified `round` function to take an additional parameter `up_threshold` that determines when the minutes are rounded up to the next hour for different languages ([link](https://github.com/tidbyt/community/pull/1549/files?diff=unified&w=0#diff-8fb3dcfaadcf41d62c73625b4184543811a3a96d7cef336fb39226487e3d0d40L47-R135))
*  Modified `main` function to get the `hours`, `minutes`, and `language` from the `config` and the `now` variables and pass them to the `fuzzy_time` function ([link](https://github.com/tidbyt/community/pull/1549/files?diff=unified&w=0#diff-8fb3dcfaadcf41d62c73625b4184543811a3a96d7cef336fb39226487e3d0d40L83-R197))
*  Modified `dialect` key to `language` and updated the `schema.Dropdown` object to reflect the new options and name in `fuzzy_clock.star` ([link](https://github.com/tidbyt/community/pull/1549/files?diff=unified&w=0#diff-8fb3dcfaadcf41d62c73625b4184543811a3a96d7cef336fb39226487e3d0d40L120-R251))


