### PR TITLE
solarmanager_ch : fix aux sensor cache issue

### DIFF
--- a/apps/solarmanagerch/solar_manager_ch.star
+++ b/apps/solarmanagerch/solar_manager_ch.star
@@ -159,8 +159,8 @@ DUMMY_DATA = {
     "autarky_month": 50,
     "autarky_year": 25,
     "aux_sensor_day": 10000,
-    "aux_sensor_week": 70000,
-    "aux_sensor_month": 140000,
+    "aux_sensor_week": 10000,
+    "aux_sensor_month": 10000,
 }
 
 def w2kwstr(w, dec = None):  # rounds off decimal, removes completey if over 100kw
@@ -297,9 +297,9 @@ def main(config):
             data["autarky_month"] = get_autarky_percent(site_id, api_key, tz, "month")
             data["autarky_year"] = get_autarky_percent(site_id, api_key, tz, "year")
 
-            data["aux_sensor_day"] = 0
-            data["aux_sensor_week"] = 0
-            data["aux_sensor_month"] = 0
+            data["aux_sensor_day"] = None
+            data["aux_sensor_week"] = None
+            data["aux_sensor_month"] = None
 
             if config.get("aux_sensor_id", "") != "":
                 data["aux_sensor_day"] = get_aux_sensor_data(config.get("aux_sensor_id"), api_key, "day")
@@ -313,6 +313,11 @@ def main(config):
             data = json.decode(data)  # data from cache is json so need to decode.
             if "has_battery" in data and data["has_battery"] == True:
                 has_battery = True
+            if config.get("aux_sensor_id", "") != "" and data.get("aux_sensor_day", "") == "":
+                print("fetching aux_sensor data outside of cache")
+                data["aux_sensor_day"] = get_aux_sensor_data(config.get("aux_sensor_id"), api_key, "day")
+                data["aux_sensor_week"] = get_aux_sensor_data(config.get("aux_sensor_id"), api_key, "week")
+                data["aux_sensor_month"] = get_aux_sensor_data(config.get("aux_sensor_id"), api_key, "month")
 
     else:
         print("using dummy data")


### PR DESCRIPTION
# Description
Cache confusion when multiple instances were using the same cache but settings were different.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4eae9a2</samp>

### Summary
🌡️🐛🚀

<!--
1.  🌡️ - This emoji represents the auxiliary sensor data, such as temperature, humidity, and pressure, that the app displays on the tidbyt device.
2.  🐛 - This emoji represents the bug fixes that the app implements, such as avoiding zero or unrealistic values and fetching the data from the API when needed.
3.  🚀 - This emoji represents the improvement and enhancement that the app delivers, such as a more reliable and accurate display of the sensor data.
-->
This pull request enhances the `solar_manager_ch` app by fixing some issues with auxiliary sensor data display and fetching. It prevents showing invalid or misleading data on the tidbyt device and improves the app's performance and reliability.

> _Oh we are the `solar_manager_ch` crew_
> _And we fetch the sensor data when it's due_
> _We don't want to see no zeros or lies_
> _On our tidbyt device in the skies_

### Walkthrough
*  Adjust the default and initial values for the auxiliary sensor data to avoid displaying unrealistic or misleading numbers on the tidbyt device ([link](https://github.com/tidbyt/community/pull/1553/files?diff=unified&w=0#diff-c051df266f180eb1cf7fa7e4c0a4cabb28d7cfeb7b35a76af13f36d8f7109d61L162-R163), [link](https://github.com/tidbyt/community/pull/1553/files?diff=unified&w=0#diff-c051df266f180eb1cf7fa7e4c0a4cabb28d7cfeb7b35a76af13f36d8f7109d61L300-R302))
*  Add a conditional block to fetch the auxiliary sensor data from the API if it is empty, to ensure that the data is updated when needed ([link](https://github.com/tidbyt/community/pull/1553/files?diff=unified&w=0#diff-c051df266f180eb1cf7fa7e4c0a4cabb28d7cfeb7b35a76af13f36d8f7109d61R316-R320))


