### PR TITLE
solarmanager_ch : add aux sensor instructions to manifest

### DIFF
--- a/apps/solarmanagerch/manifest.yaml
+++ b/apps/solarmanagerch/manifest.yaml
@@ -2,7 +2,7 @@
 id: solar-manager-ch
 name: Solar Manager CH
 summary: Show solarmanager.ch stats
-desc: 'Multiple screen selections will disable animations. If you prefer animated screens, run separate instances of the app and select 1 screen per instance.  For API Key : authorize with your solarmanager username and password on: https://external-web.solar-manager.ch/swagger and copy the long string that follows after ''-H authorization: Basic''.  For Site ID : check the back of your solarmanager device for the SMID code.'
+desc: 'Multiple screen selections will disable animations. If you prefer animated screens, run separate instances of the app and select 1 screen per instance.  For API Key : authorize with your solarmanager username and password on: https://external-web.solar-manager.ch/swagger and copy the long string that follows after ''-H authorization: Basic''.  For Site ID : check the back of your solarmanager device for the SMID code.  If you have an aux sensor the ID can be found be executing the GET/v1/info/senors/(smid) command on the solarmanager API page at https://external-web.solar-manager.ch/swagger .'
 author: tavdog
 fileName: solar_manager_ch.star
 packageName: solarmanagerch


### PR DESCRIPTION
# Description
forgot to add extra instructions to the manifest so they will show up in the app so added them.
# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e7a582b</samp>

### Summary
📝🔎🌡️

<!--
1.  📝 - This emoji can be used to indicate that the app description was edited or updated with more details.
2.  🔎 - This emoji can be used to suggest that the app helps the user find or search for the aux sensor ID if they have one.
3.  🌡️ - This emoji can be used to represent the temperature data that the app displays from the aux sensor.
-->
Updated the `desc` field of the `solarmanagerch` app manifest to provide instructions for finding the aux sensor ID. This improves the user experience and documentation of the app.

> _`desc` field updated_
> _How to find aux sensor ID_
> _Helpful for winter_

### Walkthrough
* Updated the app description to include instructions for finding the aux sensor ID ([link](https://github.com/tidbyt/community/pull/1558/files?diff=unified&w=0#diff-a48dfc507cc0821f3c0943a0b5ed543a56616bce98cd3c81489fe25231ce534fL5-R5))


