### PR TITLE
Bug fix: Test Cricket

### DIFF
--- a/apps/testcricket/test_cricket.star
+++ b/apps/testcricket/test_cricket.star
@@ -24,8 +24,11 @@ Fixed bug regarding API URL which now requires Series ID also
 v1.3a
 Updated caching function
 
-v1.4
+v1.4 - Published 9/6/23
 Future fixtures are now shown for selected team rather than immediate fixtures
+
+v1.4.1
+Fixed bug for "need to win" amount in 4th innings
 """
 
 load("encoding/json.star", "json")
@@ -124,7 +127,7 @@ def main(config):
 
             # if 4th innings of the match, show what they need to win
             if Innings == 3:
-                Lead_or_Trail = Lead_or_Trail + 1
+                Lead_or_Trail = Lead_or_Trail - 1
 
             Lead_or_Trail = math.fabs(Lead_or_Trail)
             Lead_or_Trail = humanize.ftoa(Lead_or_Trail)


### PR DESCRIPTION
# Description
The "need to win" calculation was wrong, now fixed!

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e8277c4</samp>

### Summary
🐛📺🆙

<!--
1.  🐛 - This emoji is commonly used to indicate a bug fix or a problem that has been resolved. It can also suggest a sense of relief or satisfaction after fixing a bug.
2.  📺 - This emoji can represent the display, screen, or output of an app or a device. It can also suggest a visual improvement, enhancement, or change. It can be used to indicate the display of the 4th innings score in this case.
3.  🆙 - This emoji can signify an update, upgrade, or increase in something. It can also suggest a sense of progress, advancement, or improvement. It can be used to indicate the app version and date update in this case.
-->
Fixed a display bug and updated version info in the `test_cricket` app. The app shows the latest scores of test cricket matches on the Tidbyt device.

> _`test_cricket` app_
> _bug in fourth innings fixed_
> _version updated - spring_

### Walkthrough
* Fix logic for calculating "need to win" amount in 4th innings ([link](https://github.com/tidbyt/community/pull/1564/files?diff=unified&w=0#diff-bdfdb775effb3cb43889928dd455c5a25b68afb7fcdb3cf3b8f8f56f0170a2bdL127-R130))
* Update version number and date of app ([link](https://github.com/tidbyt/community/pull/1564/files?diff=unified&w=0#diff-bdfdb775effb3cb43889928dd455c5a25b68afb7fcdb3cf3b8f8f56f0170a2bdL27-R31))


