### PR TITLE
(dutch)fuzzyclock: fix typo in German translation

### DIFF
--- a/apps/dutchfuzzyclock/dutch_fuzzy_clock.star
+++ b/apps/dutchfuzzyclock/dutch_fuzzy_clock.star
@@ -43,7 +43,7 @@ numbersPerLang = {
         6: "SECHS",
         7: "SIEBEN",
         8: "ACHT",
-        9: "NEIN",
+        9: "NEUN",
         10: "ZEHN",
         11: "ELF",
         12: "ZWÖLF",

--- a/apps/fuzzyclock/fuzzy_clock.star
+++ b/apps/fuzzyclock/fuzzy_clock.star
@@ -42,7 +42,7 @@ numbersPerLang = {
         6: "SECHS",
         7: "SIEBEN",
         8: "ACHT",
-        9: "NEIN",
+        9: "NEUN",
         10: "ZEHN",
         11: "ELF",
         12: "ZWÖLF",


### PR DESCRIPTION
# Description
Fixing a typo from #1549

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cb5f5a9</samp>

### Summary
🇩🇪🕒🐛

<!--
1.  🇩🇪 - This emoji represents the German language and culture, and indicates that the changes are related to the German word for nine.
2.  🕒 - This emoji represents a clock or time, and indicates that the changes are related to the fuzzy clock apps that display the time in a human-readable way.
3.  🐛 - This emoji represents a bug or an error, and indicates that the changes are fixing a typo or a mistake in the code.
-->
This pull request fixes a typo in the German word for nine (`NEUN`) in the fuzzy clock apps. It updates both the original `apps/fuzzyclock/fuzzy_clock.star` file and its Dutch variant `apps/dutchfuzzyclock/dutch_fuzzy_clock.star`.

> _`NEUN` not `NEIN`_
> _German fuzzy clock typo_
> _Fixed in two files_

### Walkthrough
*  Fix typo in German word for nine in fuzzy clock apps ([link](https://github.com/tidbyt/community/pull/1572/files?diff=unified&w=0#diff-e57a2b8c81874208fc6516529d189a94cd5d259014dec356657fcce8cb11e909L46-R46), [link](https://github.com/tidbyt/community/pull/1572/files?diff=unified&w=0#diff-8fb3dcfaadcf41d62c73625b4184543811a3a96d7cef336fb39226487e3d0d40L45-R45))


