### PR TITLE
[FuzzyClock] Bring back curly quotes

### DIFF
--- a/apps/fuzzyclock/fuzzy_clock.star
+++ b/apps/fuzzyclock/fuzzy_clock.star
@@ -98,13 +98,13 @@ wordsPerLang = {
         "past": "AB",
     },
     "en-US": {
-        "hour": "O'CLOCK",
+        "hour": "O’CLOCK",
         "half": "HALF",
         "to": "TILL",
         "past": "PAST",
     },
     "en-GB": {
-        "hour": "O'CLOCK",
+        "hour": "O’CLOCK",
         "half": "HALF",
         "to": "TO",
         "past": "PAST",


### PR DESCRIPTION
# Description
Bring back the curly quotes in "o’clock".

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 33aa6c5</samp>

### Summary
:pencil2::globe_with_meridians::white_check_mark:

<!--
1.  :pencil2: - This emoji means "pencil" and can be used to indicate that something was edited or corrected, such as the apostrophes in this case.
2.  :globe_with_meridians: - This emoji means "globe with meridians" and can be used to indicate that something relates to languages, translations, or internationalization, such as the English languages in this case.
3.  :white_check_mark: - This emoji means "white check mark" and can be used to indicate that something was completed, verified, or approved, such as the improved consistency and compatibility in this case.
-->
Fixed apostrophe issues in `fuzzy_clock.star` app. Made the app display time phrases correctly in English.

> _The clock of doom is ticking, no escape from fate_
> _But we can change the symbols, make them resonate_
> _We wield the power of apostrophes, to unify and clarify_
> _We are the masters of `fuzzy_clock.star`, we defy the tyranny of time_

### Walkthrough
* Replace apostrophes with curly quotes in "O'CLOCK" strings for "en-US" and "en-GB" languages ([link](https://github.com/tidbyt/community/pull/1581/files?diff=unified&w=0#diff-8fb3dcfaadcf41d62c73625b4184543811a3a96d7cef336fb39226487e3d0d40L101-R101), [link](https://github.com/tidbyt/community/pull/1581/files?diff=unified&w=0#diff-8fb3dcfaadcf41d62c73625b4184543811a3a96d7cef336fb39226487e3d0d40L107-R107))


