### PR TITLE
Birdbyt fix: allow app to render when API key isn't passed in

### DIFF
--- a/apps/birdbyt/birdbyt.star
+++ b/apps/birdbyt/birdbyt.star
@@ -182,7 +182,7 @@ def main(config):
       rendered WebP image for Tidbyt display
     """
     random.seed(time.now().unix // 10)
-    ebird_key = secret.decrypt(EBIRD_API_KEY) or config.get("ebird_api_key")
+    ebird_key = secret.decrypt(EBIRD_API_KEY) or config.get("ebird_api_key", "BIRDERROR-NO-API-KEY")
     params = get_params(config)
     timezone = params.pop("tz")
     response = get_recent_birds(params, ebird_key)


### PR DESCRIPTION
This change allows the app to render even if there's no config or the API key isn't decrypted (e.g. when running locally). It will render with a "bird error" image, but will no longer throw an error due to a None value in the HTTP header.

# Description
Addresses build error in prior merge: https://github.com/tidbyt/community/actions/runs/5283342953/jobs/9559458173

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c426733</samp>

### Summary
🐦🔑🛠️

<!--
1.  🐦 - This emoji represents the eBird API and the app's main functionality of displaying bird sightings and sounds.
2.  🔑 - This emoji represents the API key that is required to access the eBird API and the config value that stores it.
3.  🛠️ - This emoji represents the modification or improvement of the `config.get` method to handle the possible absence of the API key and provide a default value.
-->
Improved error handling for birdbyt app by providing a default value for the eBird API key. Modified `config.get` method in `apps/birdbyt/birdbyt.star`.

> _`config.get` saves_
> _from `KeyError` mishap_
> _BIRDERROR in fall_

### Walkthrough
*  Provide a default value for the eBird API key to prevent errors and inform the user ([link](https://github.com/tidbyt/community/pull/1583/files?diff=unified&w=0#diff-32439ab0595350d4e094ab3f2167cb4db44da23a22ebc046f270068a1c21571aL185-R185))


