### PR TITLE
roomba: don't fail on missing config

### DIFF
--- a/apps/roomba/roomba.star
+++ b/apps/roomba/roomba.star
@@ -126,7 +126,6 @@ def main(config):
 
     if not serverIP:
         return []
-        fail("Server IP must be configured")
 
     if type(int(serverPort)) != "int":
         fail("Server Port must be an integer")

--- a/apps/roomba/roomba.star
+++ b/apps/roomba/roomba.star
@@ -120,11 +120,12 @@ def main(config):
         color = BLACK,
     )
 
-    serverIP = config.str("serverIP", "localhost")
+    serverIP = config.str("serverIP")
     serverPort = config.str("serverPort", 6565)
     roombaIP = config.str("roombaIP")
 
     if not serverIP:
+        return []
         fail("Server IP must be configured")
 
     if type(int(serverPort)) != "int":


### PR DESCRIPTION
# Description
Replace this with a description of your changes.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5b767d9</samp>

### Summary
🛠️🌐🧹

<!--
1.  🛠️ - This emoji represents the fix or improvement aspect of the change, as it prevents the app from crashing and provides a more graceful fallback.
2.  🌐 - This emoji represents the network or server aspect of the change, as it relates to the app's connection to the server that controls the roomba.
3.  🧹 - This emoji represents the roomba aspect of the change, as it is the main feature of the app and the reason why the user needs to configure the server IP.
-->
Fixed a bug in `roomba.star` that caused the app to crash when the server IP was not configured. The app now returns an empty list in the `config` function to display a blank screen instead of an error message.

> _No server IP_
> _`return []` before `fail`_
> _Blank screen in winter_

### Walkthrough
*  Prevent app from crashing when server IP is not configured by returning an empty list before failing ([link](https://github.com/tidbyt/community/pull/1587/files?diff=unified&w=0#diff-e30ae99e3ce331353e74da47892999add51030b44eb57b6beab2815ac34b9187L123-R128))


