### PR TITLE
Add an option to pull message from url

### DIFF
--- a/apps/verticalmessage/vertical_message.star
+++ b/apps/verticalmessage/vertical_message.star
@@ -9,6 +9,7 @@ Author: rs7q5
 #Created 20220221 RIS
 #Last Modified 20230323 RIS
 
+load("http.star", "http")
 load("render.star", "render")
 load("schema.star", "schema")
 
@@ -22,7 +23,7 @@ def main(config):
     color_opt = config.str("color", "#fff")
 
     #get message
-    msg_txt = config.str("msg", DEFAULT_MSG)
+    msg_txt = get_message(config)
 
     #set linespacing
     linespacing = config.str("linespacing", "0")
@@ -51,6 +52,16 @@ def main(config):
         ),
     )
 
+def get_message(config):
+    url = config.str("url", "")
+    if url != "":
+        rep = http.get(url)
+        if rep.status_code == 200:
+            return rep.body()
+        else:
+            fail("couldn't get remote url, status code: %d", rep.status_code)
+    return config.str("msg", DEFAULT_MSG)
+
 def get_schema():
     scroll_speed = [
         schema.Option(display = "Slow", value = "200"),
@@ -75,6 +86,13 @@ def get_schema():
                 desc = "A mesage to display.",
                 icon = "gear",
                 default = DEFAULT_MSG,
+            ),
+            schema.Text(
+                id = "url",
+                name = "URL",
+                desc = "A url to GET to fetch the message to display (optional).",
+                icon = "gear",
+                default = "",
             ),
             schema.Dropdown(
                 id = "font",


### PR DESCRIPTION
# Description
This makes a minor addition to the vertical message app to have it optionally pull from a remote endpoint instead of a static configuration, which is a simple use case i have. This app seems to have just been a prototype to start with (https://github.com/tidbyt/community/pull/182) so feel free to reject pr if out of scope.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2af6a03</samp>

### Summary
🌐🔧📨

<!--
1.  🌐 - This emoji represents the internet or the web, and can be used to indicate the feature of fetching messages from remote URLs using the `http` module.
2.  🔧 - This emoji represents a wrench or a tool, and can be used to indicate the refactoring of the message retrieval logic into a separate function.
3.  📨 - This emoji represents an envelope or a message, and can be used to indicate the main functionality of the `verticalmessage` app.
-->
Added remote message support and refactored code for `verticalmessage` app. The app can now display messages from web sources as well as local files.

> _`verticalmessage`_
> _Fetches from remote URLs_
> _A new feature - spring_

### Walkthrough
* Import the `http` module to enable fetching messages from remote URLs ([link](https://github.com/tidbyt/community/pull/1594/files?diff=unified&w=0#diff-459cdb2f2ce13d24cce876e14558d7e0846db10883337a33f306c5ca948bdc83R14))
* Define a new function `get_message` to handle the logic of getting the message from either the config or the URL, with error handling and fallback ([link](https://github.com/tidbyt/community/pull/1594/files?diff=unified&w=0#diff-459cdb2f2ce13d24cce876e14558d7e0846db10883337a33f306c5ca948bdc83R55-R65))
* Call `get_message` in the main loop to get the message to display on the tidbyt ([link](https://github.com/tidbyt/community/pull/1594/files?diff=unified&w=0#diff-459cdb2f2ce13d24cce876e14558d7e0846db10883337a33f306c5ca948bdc83L25-R26))
* Add a new schema field `message_url` to the app config to allow the user to specify a URL to get the message from, with a name, a description, an icon, and a default value ([link](https://github.com/tidbyt/community/pull/1594/files?diff=unified&w=0#diff-459cdb2f2ce13d24cce876e14558d7e0846db10883337a33f306c5ca948bdc83R91-R97))


