### PR TITLE
Add WQXR

### DIFF
--- a/apps/wqxr/README.md
+++ b/apps/wqxr/README.md
@@ -1,0 +1,18 @@
+# WQXR
+
+Show what's currently playing on [WQXR](https://wqxr.org), New York's Classical Music Radio
+Station, on your Tidbyt
+
+## Settings
+
+You can change the following settings:
+
+- **Show ensemble**: Show the ensemble, if applicable
+- **Show conductor and soloists**: Show the conductor and/or soloist(s), if applicable
+- **Color: Title**: Choose your own color for the title of the current piece
+- **Color: Composer**: Choose your own color for the composer of the current piece
+- **Color: Ensemble and Conductor/Soloists**: Choose your own color for the ensemble and conductor/soloists
+
+## Development
+
+See more information in the main development repo at [expandrew/tidbyt](https://github.com/expandrew/tidbyt)

--- a/apps/wqxr/manifest.yaml
+++ b/apps/wqxr/manifest.yaml
@@ -1,0 +1,8 @@
+---
+id: wqxr
+name: WQXR
+summary: WQXR What's On
+desc: Shows what's currently playing on WQXR, New York's Classical Music Radio Station.
+author: Andrew Westling
+fileName: wqxr.star
+packageName: wqxr

--- a/apps/wqxr/wqxr.star
+++ b/apps/wqxr/wqxr.star
@@ -1,0 +1,184 @@
+"""
+Applet: WQXR
+Summary: WQXR What's On
+Description: Shows what's currently playing on WQXR, New York's Classical Music Radio Station.
+Author: Andrew Westling
+"""
+
+load("http.star", "http")
+load("render.star", "render")
+load("schema.star", "schema")
+
+WHATS_ON = "https://api.wnyc.org/api/v1/whats_on/wqxr"
+
+COLORS = {
+    "dark_blue": "#12518A",
+    "medium_blue": "#0162AB",
+    "light_blue": "#00AEFF",
+    "white": "#FFFFFF",
+    "light_gray": "#AAAAAA",
+    "medium_gray": "#888888",
+    "dark_gray": "#444444",
+    "red": "#FF0000",
+}
+
+DEFAULT_COLOR_TITLE = COLORS["light_blue"]
+DEFAULT_COLOR_COMPOSER = COLORS["white"]
+DEFAULT_COLOR_ENSEMBLE_AND_PEOPLE = COLORS["medium_gray"]
+
+BLUE_HEADER_BAR = render.Stack(
+    children = [
+        render.Box(width = 64, height = 5, color = COLORS["dark_blue"]),
+        render.Text(content = "WQXR", height = 6, font = "tom-thumb"),
+    ],
+)
+
+ERROR_CONTENT = render.Column(
+    expanded = True,
+    main_align = "space_around",
+    children = [
+        render.Marquee(width = 64, child = render.Text(content = "Can't connect to WQXR :(", color = COLORS["red"])),
+    ],
+)
+
+def main(config):
+    whats_on = http.get(url = WHATS_ON, ttl_seconds = 30)
+
+    if (whats_on.status_code) != 200:
+        return render.Root(
+            child = render.Column(
+                children = [
+                    BLUE_HEADER_BAR,
+                    ERROR_CONTENT,
+                ],
+            ),
+        )
+
+    has_current_show = whats_on.json()["current_show"]
+    has_playlist_item = whats_on.json()["current_playlist_item"]
+    has_catalog_entry = has_playlist_item and whats_on.json()["current_playlist_item"]["catalog_entry"]
+
+    title = ""
+    composer = ""
+    ensemble = ""
+    people = ""
+
+    if has_current_show:
+        title = whats_on.json()["current_show"]["title"]
+
+    if has_catalog_entry:
+        title = has_catalog_entry and whats_on.json()["current_playlist_item"]["catalog_entry"]["title"]
+        composer = has_catalog_entry and whats_on.json()["current_playlist_item"]["catalog_entry"]["composer"]["name"]
+
+        # Ensemble
+        has_ensemble = has_catalog_entry and whats_on.json()["current_playlist_item"]["catalog_entry"]["ensemble"]
+        ensemble = has_ensemble and whats_on.json()["current_playlist_item"]["catalog_entry"]["ensemble"]["name"]
+
+        # Conductor
+        has_conductor = has_catalog_entry and whats_on.json()["current_playlist_item"]["catalog_entry"]["conductor"]
+        conductor = has_conductor and whats_on.json()["current_playlist_item"]["catalog_entry"]["conductor"]["name"]
+
+        # Soloists
+        has_soloists = has_catalog_entry and len(whats_on.json()["current_playlist_item"]["catalog_entry"]["soloists"]) > 0
+        soloists = has_soloists and whats_on.json()["current_playlist_item"]["catalog_entry"]["soloists"]
+
+        people = build_people(conductor, soloists)
+
+    children = []
+    should_show_ensemble = config.bool("show_ensemble")
+    should_show_people = config.bool("show_people")
+
+    if title:
+        children.append(render.Marquee(width = 64, child = render.Text(content = title, font = "tb-8", color = config.str("color_title", DEFAULT_COLOR_TITLE))))
+    if composer:
+        children.append(render.Marquee(width = 64, child = render.Text(content = composer, font = "tom-thumb", color = config.str("color_composer", DEFAULT_COLOR_COMPOSER))))
+    if should_show_ensemble and ensemble:
+        children.append(render.Marquee(width = 64, child = render.Text(content = ensemble, font = "tom-thumb", color = config.str("color_ensemble_and_people", DEFAULT_COLOR_ENSEMBLE_AND_PEOPLE))))
+    if should_show_people and people:
+        children.append(render.Marquee(width = 64, child = render.Text(content = people, font = "tom-thumb", color = config.str("color_ensemble_and_people", DEFAULT_COLOR_ENSEMBLE_AND_PEOPLE))))
+
+    return render.Root(
+        child = render.Column(
+            children = [
+                BLUE_HEADER_BAR,
+                render.Column(
+                    expanded = True,
+                    main_align = "space_evenly",
+                    children = children,
+                ),
+            ],
+        ),
+    )
+
+def build_people(conductor, soloists):
+    output = []
+
+    if conductor:
+        output.append("%s, conductor" % (conductor))
+
+    if soloists:
+        soloist_parts = []
+        for soloist in soloists:
+            soloist_parts.append("%s, %s" % (soloist["musician"]["name"], soloist["instruments"][0]))
+        output.append(", ".join(soloist_parts))
+
+    return ", ".join(output)
+
+def get_schema():
+    return schema.Schema(
+        version = "1",
+        fields = [
+            schema.Toggle(
+                id = "show_ensemble",
+                name = "Show ensemble",
+                desc = "Show the ensemble, if applicable",
+                icon = "peopleGroup",
+                default = False,
+            ),
+            schema.Toggle(
+                id = "show_people",
+                name = "Show conductor and soloists",
+                desc = "Show the conductor and/or soloist(s), if applicable",
+                icon = "wandMagicSparkles",
+                default = True,
+            ),
+            schema.Color(
+                id = "color_title",
+                name = "Color: Title",
+                desc = "Choose your own color for the title of the current piece",
+                icon = "palette",
+                default = DEFAULT_COLOR_TITLE,
+                palette = [
+                    COLORS["white"],
+                    COLORS["light_blue"],
+                    COLORS["medium_blue"],
+                ],
+            ),
+            schema.Color(
+                id = "color_composer",
+                name = "Color: Composer",
+                desc = "Choose your own color for the composer of the current piece",
+                icon = "palette",
+                default = DEFAULT_COLOR_COMPOSER,
+                palette = [
+                    COLORS["white"],
+                    COLORS["light_blue"],
+                    COLORS["medium_blue"],
+                    COLORS["dark_blue"],
+                ],
+            ),
+            schema.Color(
+                id = "color_ensemble_and_people",
+                name = "Color: Ensemble and Conductor/Soloists",
+                desc = "Choose your own color for the ensemble and conductor/soloists",
+                icon = "palette",
+                default = DEFAULT_COLOR_ENSEMBLE_AND_PEOPLE,
+                palette = [
+                    COLORS["white"],
+                    COLORS["light_gray"],
+                    COLORS["medium_gray"],
+                    COLORS["dark_gray"],
+                ],
+            ),
+        ],
+    )


### PR DESCRIPTION
# Description
This will show what's currently playing on [WQXR](https://wqxr.org), New York's Classical Music Radio Station, on your Tidbyt 🎵

![wqxr](https://github.com/tidbyt/community/assets/3157928/cbbbd917-6e97-4e30-aa24-5d0865698540)


# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at bf62d92</samp>

### Summary
🎵📝🌟

<!--
1.  🎵 - This emoji represents the musical theme of the applet, as it shows what's playing on a classical music radio station. It also conveys a sense of enjoyment and entertainment that the applet might provide to the user.
2.  📝 - This emoji represents the documentation and configuration of the applet, as it shows the addition of the manifest.yaml and README.md files that define the metadata and instructions of the applet. It also conveys a sense of clarity and completeness that the applet might offer to the user.
3.  🌟 - This emoji represents the Starlark code of the applet, as it shows the addition of the wqxr.star file that implements the applet's logic and rendering. It also conveys a sense of creativity and functionality that the applet might demonstrate to the user.
-->
This pull request adds a new applet for WQXR, a classical music radio station, to the Tidbyt community repository. It includes a `manifest.yaml` file that defines the applet metadata and configuration, a `README.md` file that explains the applet features and settings, and a `wqxr.star` file that contains the applet code. The applet shows the current music playing on WQXR on the Tidbyt device and allows the user to customize the display.

> _`wqxr.star` code_
> _shows classical music on_
> _Tidbyt in autumn_

### Walkthrough
* Create a new applet for WQXR, New York's Classical Music Radio Station ([link](https://github.com/tidbyt/community/pull/1597/files?diff=unified&w=0#diff-54f2f9f3ad0e470794d9e2ccbde198d94c3e54b36051f5f1b8ff08cbfe4900e8R1-R8), [link](https://github.com/tidbyt/community/pull/1597/files?diff=unified&w=0#diff-9a44b4ff7052ac548e7d14e39c9646f1d43c34bcbcec88827f35f7305cab1cb2R1-R18), [link](https://github.com/tidbyt/community/pull/1597/files?diff=unified&w=0#diff-dc41be26bb0dcf8d80083b9f03c34f50b65ff35cbfd99218abc52031ab7d9a33R1-R184))
  * Add a `manifest.yaml` file to define the applet metadata and configuration ([link](https://github.com/tidbyt/community/pull/1597/files?diff=unified&w=0#diff-54f2f9f3ad0e470794d9e2ccbde198d94c3e54b36051f5f1b8ff08cbfe4900e8R1-R8))
  * Add a `README.md` file to document the applet features and settings ([link](https://github.com/tidbyt/community/pull/1597/files?diff=unified&w=0#diff-9a44b4ff7052ac548e7d14e39c9646f1d43c34bcbcec88827f35f7305cab1cb2R1-R18))
  * Add a `wqxr.star` file to implement the applet logic and rendering ([link](https://github.com/tidbyt/community/pull/1597/files?diff=unified&w=0#diff-dc41be26bb0dcf8d80083b9f03c34f50b65ff35cbfd99218abc52031ab7d9a33R1-R184))
    * Use the `http` module to fetch the data from the WQXR API ([link](https://github.com/tidbyt/community/pull/1597/files?diff=unified&w=0#diff-dc41be26bb0dcf8d80083b9f03c34f50b65ff35cbfd99218abc52031ab7d9a33R1-R184))
    * Use the `render` module to display the current piece, composer, ensemble, and conductor/soloists on the Tidbyt screen ([link](https://github.com/tidbyt/community/pull/1597/files?diff=unified&w=0#diff-dc41be26bb0dcf8d80083b9f03c34f50b65ff35cbfd99218abc52031ab7d9a33R1-R184))
    * Use the `schema` module to provide the user with options to change the colors and visibility of the elements ([link](https://github.com/tidbyt/community/pull/1597/files?diff=unified&w=0#diff-dc41be26bb0dcf8d80083b9f03c34f50b65ff35cbfd99218abc52031ab7d9a33R1-R184))
    * Handle the error case when the API is not reachable ([link](https://github.com/tidbyt/community/pull/1597/files?diff=unified&w=0#diff-dc41be26bb0dcf8d80083b9f03c34f50b65ff35cbfd99218abc52031ab7d9a33R1-R184))


