### PR TITLE
New App: Smooth FM

### DIFF
--- a/apps/smoothfm/manifest.yaml
+++ b/apps/smoothfm/manifest.yaml
@@ -1,0 +1,8 @@
+---
+id: smooth-fm
+name: Smooth FM
+summary: Now playing on Smooth
+desc: Shows the current playing song on Smooth FM for various stations around Australia..
+author: M0ntyP
+fileName: smooth_fm.star
+packageName: smoothfm

--- a/apps/smoothfm/smooth_fm.star
+++ b/apps/smoothfm/smooth_fm.star
@@ -1,0 +1,120 @@
+"""
+Applet: Smooth FM
+Summary: Now playing on Smooth
+Description: Shows the current playing song on Smooth FM for various stations around Australia.
+Author: M0ntyP
+"""
+
+load("http.star", "http")
+load("render.star", "render")
+load("schema.star", "schema")
+load("xpath.star", "xpath")
+
+CACHE_TIMEOUT = 60
+
+NOWPLAYING_PREFIX_URL = "https://np.tritondigital.com/public/nowplaying?mountName="
+NOWPLAYING_SUFFIX_URL = "&numberToFetch=1&eventType=track&request.preventCache=1687472073814"
+
+def main(config):
+    StationSelection = config.get("station", "SMOOTH_ADELAIDE")
+    NOWPLAYING_URL = NOWPLAYING_PREFIX_URL + StationSelection + NOWPLAYING_SUFFIX_URL
+
+    feed = get_cachable_data(NOWPLAYING_URL, CACHE_TIMEOUT)
+    rss = xpath.loads(feed)
+    heading = rss.query_all("//nowplaying-info-list/nowplaying-info/property name")
+    artist = ""
+    songtitle = ""
+
+    if len(heading) == 6:
+        artist = heading[4]
+    elif len(heading) == 5:
+        artist = heading[3]
+
+    songtitle = heading[2]
+
+    return render.Root(
+        delay = 100,
+        show_full_animation = True,
+        child = render.Column(
+            children = [
+                render.Box(
+                    width = 64,
+                    height = 7,
+                    padding = 0,
+                    color = "#005094",
+                    child = render.Text(content = "Smooth FM", color = "#fff", font = "CG-pixel-4x5-mono", offset = 0),
+                ),
+                render.Box(
+                    width = 64,
+                    height = 8,
+                    padding = 0,
+                    color = "#000",
+                    child = render.Text("NOW PLAYING...", color = "#fff", font = "CG-pixel-3x5-mono", offset = 0),
+                ),
+                render.Box(
+                    width = 64,
+                    height = 2,
+                    padding = 0,
+                ),
+                render.Marquee(
+                    width = 64,
+                    child = render.Text(content = songtitle, color = "#42f545", font = "CG-pixel-3x5-mono"),
+                ),
+                render.Box(
+                    width = 64,
+                    height = 3,
+                    padding = 0,
+                ),
+                render.Marquee(
+                    width = 64,
+                    child = render.Text(content = artist, color = "#fff", font = "CG-pixel-3x5-mono", offset = 0),
+                ),
+            ],
+        ),
+    )
+
+def get_schema():
+    return schema.Schema(
+        version = "1",
+        fields = [
+            schema.Dropdown(
+                id = "station",
+                name = "Choose your station",
+                desc = "Choose the station",
+                icon = "radio",
+                default = StationOptions[0].value,
+                options = StationOptions,
+            ),
+        ],
+    )
+
+def get_cachable_data(url, timeout):
+    res = http.get(url = url, ttl_seconds = timeout)
+
+    if res.status_code != 200:
+        fail("request to %s failed with status code: %d - %s" % (url, res.status_code, res.body()))
+
+    return res.body()
+
+StationOptions = [
+    schema.Option(
+        display = "Smooth FM (Adelaide)",
+        value = "SMOOTH_ADELAIDE",
+    ),
+    schema.Option(
+        display = "Smooth FM (Brisbane)",
+        value = "SMOOTH_BRISBANE",
+    ),
+    schema.Option(
+        display = "Smooth FM (Melbourne)",
+        value = "SMOOTH915",
+    ),
+    schema.Option(
+        display = "Smooth FM (Perth)",
+        value = "SMOOTH_PERTH",
+    ),
+    schema.Option(
+        display = "Smooth FM (Sydney)",
+        value = "SMOOTH953",
+    ),
+]


### PR DESCRIPTION
# Description
Very simple app that shows the current song on Smooth FM for various stations around Australia


# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 44709e6</samp>

### Summary
📝🎵📡

<!--
1.  📝 - This emoji can represent the creation of the manifest file, which is a document that describes the applet and its metadata.
2.  🎵 - This emoji can represent the main feature of the applet, which is to show the music playing on Smooth FM, a radio station that plays smooth and relaxing songs.
3.  📡 - This emoji can represent the network communication and data parsing that the applet script performs, as it fetches and displays the XML data from the Smooth FM website.
-->
This pull request adds a new applet for the Tidbyt device that shows the current playing song on Smooth FM radio stations. It includes a `manifest.yaml` file with the applet metadata and a `smooth_fm.star` file with the applet script. The script uses various modules and features of the Tidbyt API and Starlark language to fetch and display the song information and allow the user to configure their station.

> _`Smooth FM` applet_
> _Shows the song of the season_
> _With Starlark magic_

### Walkthrough
* Create and implement a new applet for displaying the current playing song on Smooth FM radio stations ([link](https://github.com/tidbyt/community/pull/1602/files?diff=unified&w=0#diff-7bf0e32561b585a87fe6a3bbbdf4f78d1f1528793a7bf508d9b475ec5acd3ca9R1-R8), [link](https://github.com/tidbyt/community/pull/1602/files?diff=unified&w=0#diff-751a7dfd117dd66ba52e14cad86f4826529ec53af5fcf3eea322da49f7f5e9e8R1-R120))
  - Add a manifest file `manifest.yaml` with applet metadata and configuration ([link](https://github.com/tidbyt/community/pull/1602/files?diff=unified&w=0#diff-7bf0e32561b585a87fe6a3bbbdf4f78d1f1528793a7bf508d9b475ec5acd3ca9R1-R8))
  - Add a script file `smooth_fm.star` with applet logic and rendering ([link](https://github.com/tidbyt/community/pull/1602/files?diff=unified&w=0#diff-751a7dfd117dd66ba52e14cad86f4826529ec53af5fcf3eea322da49f7f5e9e8R1-R120))


