### PR TITLE
Bug fix for users seeing URI mismatch error

### DIFF
--- a/apps/outlookcalendar/outlook_calendar.star
+++ b/apps/outlookcalendar/outlook_calendar.star
@@ -139,7 +139,7 @@ def main(config):
         OUTLOOK_ACCESS_TOKEN = cache.get(outlook_refresh_token)
 
     if not OUTLOOK_ACCESS_TOKEN:
-        refresh_body = "refresh_token=" + outlook_refresh_token + "&redirect_uri=http://127.0.0.1:8080/oauth-callback" + "&client_id=" + client_id + "&client_secret=" + client_secret + "&grant_type=refresh_token" + "&scope=Calendars.read"
+        refresh_body = "refresh_token=" + outlook_refresh_token + "&client_id=" + client_id + "&client_secret=" +client_secret + "&grant_type=refresh_token" + "&scope=Calendars.read"
 
         # CURL can be handy for debug ops from the Linux command line
 


### PR DESCRIPTION
The app was erroneously including "redirect_uri" parameter to the Token endpoint call.   The likely reason for users seeing their calendars stop updating.

# Description
Replace this with a description of your changes.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d4912a9</samp>

### Summary
🔄🗑️🧹

<!--
1.  🔄 This emoji can signify refreshing or updating something, which is what the code does with the access token using the refresh token.
2.  🗑️ This emoji can signify removing or discarding something, which is what the code does with the `redirect_uri` parameter that is no longer needed.
3.  🧹 This emoji can signify cleaning or simplifying something, which is what the code does by making the `refresh_body` string shorter and easier to read.
-->
Removed unnecessary `redirect_uri` parameter from token refresh logic in `outlook_calendar.star` app. This improves code clarity and reliability.

> _`redirect_uri`_
> _gone from `refresh_body` / no more callback woes_
> _simpler code for spring_

### Walkthrough
*  Removed `redirect_uri` parameter from `refresh_body` string, as it is not needed for refreshing access token ([link](https://github.com/tidbyt/community/pull/1609/files?diff=unified&w=0#diff-64305af731aac5231a8761e0cca574f8c16ccb4fe3846df528410a4d2185acb2L142-R142))


