### PR TITLE
Relay FM: Remove member discord listening option

### DIFF
--- a/apps/relay_fm_live/relay_fm_live.star
+++ b/apps/relay_fm_live/relay_fm_live.star
@@ -125,10 +125,6 @@ show_art_options = [
         value = live_broadcasts_url,
     ),
     schema.Option(
-        display = "QR when live: Members' Discord",
-        value = live_discord_url,
-    ),
-    schema.Option(
         display = "QR when live: m3u",
         value = live_m3u_url,
     ),


### PR DESCRIPTION
# Description
Remove the member's discord listening option while it's unavailable.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6b603cb</samp>

### Summary
🗑️🛑🎧

<!--
1.  🗑️ - This emoji represents the removal or deletion of something, in this case the QR code option.
2.  🛑 - This emoji represents the stop or end of something, in this case the Discord access via the QR code.
3.  🎧 - This emoji represents the podcast or audio content that the app is focused on.
-->
Removed the QR code option from the `relay_fm_live` app. This option was outdated and irrelevant for the current Discord server.

> _`QR code` option_
> _gone from app config file_
> _simpler winter code_

### Walkthrough
* Remove QR code option from app configuration ([link](https://github.com/tidbyt/community/pull/1614/files?diff=unified&w=0#diff-44b21248cc7081a01595decbbfa3ddd55da61a8868aede4ecdf8316aa99c9ef5L128-L131))


