### PR TITLE
Minor update: Tennis Rankings

### DIFF
--- a/apps/tennisrankings/tennis_rankings.star
+++ b/apps/tennisrankings/tennis_rankings.star
@@ -22,7 +22,7 @@ load("schema.star", "schema")
 load("time.star", "time")
 
 BASE_RANKING_URL = "https://site.api.espn.com/apis/site/v2/sports/tennis/"
-RANKING_CACHE = 3600  # 1hrs
+RANKING_CACHE = 14400  # 4hrs
 
 def main(config):
     RotationSpeed = config.get("speed", "3")

--- a/apps/tennisrankings/tennis_rankings.star
+++ b/apps/tennisrankings/tennis_rankings.star
@@ -9,6 +9,9 @@ Updated caching function and changed title bar color for WTA
 
 v1.2 
 Added date to title bar so you can see when the rankings were last updated
+
+v1.2.1
+Reduced cache TTL from 6hrs to 1hr as it was taking too long to update
 """
 
 load("encoding/json.star", "json")
@@ -19,7 +22,7 @@ load("schema.star", "schema")
 load("time.star", "time")
 
 BASE_RANKING_URL = "https://site.api.espn.com/apis/site/v2/sports/tennis/"
-RANKING_CACHE = 86400  # 24hrs
+RANKING_CACHE = 3600  # 1hrs
 
 def main(config):
     RotationSpeed = config.get("speed", "3")


### PR DESCRIPTION
# Description
Reduced cache TTL from 24hrs to 4hrs as it was taking too long to update once the new rankings were released

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8c1453a</samp>

### Summary
📝🕒🎾

<!--
1.  📝 - This emoji represents documentation or writing, and can be used for the version comment that was added to the app.
2.  🕒 - This emoji represents time or clocks, and can be used for the shorter cache TTL that was implemented to reduce the delay in updating the rankings data.
3.  🎾 - This emoji represents tennis or sports, and can be used for the app's overall theme and purpose.
-->
Update `tennis_rankings.star` app with better documentation and cache settings. The app now has a version comment and a lower cache TTL to reflect the latest tennis rankings.

> _`tennis_rankings.star` is the app of doom_
> _It shows the fate of those who play_
> _But now it has a version comment_
> _And a shorter cache TTL_

### Walkthrough
*  Update the app version and date in the comment header ([link](https://github.com/tidbyt/community/pull/1616/files?diff=unified&w=0#diff-9a6a1ce720b24d7d54f2a20292d720ce1145432a2c8bd261c8f564368dd7dda1R12-R14))
*  Lower the cache TTL for the ranking data to 4 hours ([link](https://github.com/tidbyt/community/pull/1616/files?diff=unified&w=0#diff-9a6a1ce720b24d7d54f2a20292d720ce1145432a2c8bd261c8f564368dd7dda1L22-R25))


