### PR TITLE
New app: FedEx Cup

### DIFF
--- a/apps/fedexcup/fedex_cup.star
+++ b/apps/fedexcup/fedex_cup.star
@@ -25,7 +25,7 @@ def main():
     # if its Sunday or Monday on the East Coast of US then we check for updates every hour, otherwise check once a day
     if Day == "Sunday" or Day == "Monday":
         STANDINGS_CACHE = 3600
-   
+
     FedExData = get_cachable_data(STANDINGS_URL, STANDINGS_CACHE)
     FedExJSON = json.decode(FedExData)
     player_list = FedExJSON["pageProps"]["tourCupDetails"]["officialPlayers"]

--- a/apps/fedexcup/fedex_cup.star
+++ b/apps/fedexcup/fedex_cup.star
@@ -1,0 +1,220 @@
+"""
+Applet: FedEx Cup
+Summary: Shows FedEx Cup standings
+Description: Shows the standings for the PGA Tour's FedEx Cup.
+Author: M0ntyP
+
+v1.0
+First release
+"""
+
+load("encoding/json.star", "json")
+load("http.star", "http")
+load("render.star", "render")
+load("time.star", "time")
+
+STANDINGS_URL = "https://www.pgatour.com/_next/data/pgatour-prod-1.19.5/en/fedexcup.json?tab=official-standings.html"
+DEFAULT_TIMEZONE = "America/New_York"
+
+def main():
+    STANDINGS_CACHE = 86400  # 24hrs is default
+
+    Day = time.now().in_location(DEFAULT_TIMEZONE)
+    Day = Day.format("Monday")
+
+    # if its Sunday or Monday on the East Coast of US then we check for updates every hour, otherwise check once a day
+    if Day == "Sunday" or Day == "Monday":
+        STANDINGS_CACHE = 3600
+   
+    FedExData = get_cachable_data(STANDINGS_URL, STANDINGS_CACHE)
+    FedExJSON = json.decode(FedExData)
+    player_list = FedExJSON["pageProps"]["tourCupDetails"]["officialPlayers"]
+
+    renderScreen = []
+
+    for x in range(0, 30, 4):
+        renderScreen.extend(
+            [
+                render.Column(
+                    expanded = True,
+                    main_align = "start",
+                    cross_align = "start",
+                    children = [
+                        render.Column(
+                            children = get_screenTrend(x, player_list),
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+    return render.Root(
+        show_full_animation = True,
+        delay = int(2) * 1000,
+        child = render.Animation(
+            children = renderScreen,
+        ),
+    )
+
+def get_screen(x, player_list):
+    output = []
+
+    heading = [
+        render.Box(
+            width = 64,
+            height = 5,
+            color = "#0039A6",
+            child = render.Row(
+                expanded = True,
+                main_align = "start",
+                cross_align = "center",
+                children = [
+                    render.Box(
+                        width = 64,
+                        height = 5,
+                        child = render.Text(content = "FEDEX CUP", color = "#fff", font = "CG-pixel-3x5-mono"),
+                    ),
+                ],
+            ),
+        ),
+    ]
+
+    output.extend(heading)
+
+    for i in range(0, 4):
+        # need to skip over 10
+        if i + x >= 10:
+            i = i + 1
+
+        if i + x < 31:
+            Name = player_list[i + x]["lastName"]
+            Rank = player_list[i + x]["thisWeekRank"]
+            PrevRank = player_list[i + x]["previousWeekRank"]
+
+            print(Rank, Name)
+            intRank = int(Rank)
+            intPrevRank = int(PrevRank)
+
+            diff = intPrevRank - intRank
+            print(diff)
+
+            Player = render.Row(
+                expanded = True,
+                main_align = "space_between",
+                children = [
+                    render.Row(
+                        main_align = "start",
+                        children = [
+                            render.Padding(
+                                pad = (1, 1, 0, 1),
+                                child = render.Text(
+                                    content = Rank + "." + Name,
+                                    color = "#fff",
+                                    font = "CG-pixel-3x5-mono",
+                                ),
+                            ),
+                        ],
+                    ),
+                ],
+            )
+
+            output.extend([Player])
+        else:
+            output.extend([render.Column(children = [render.Box(width = 64, height = 7, color = "#111")])])
+
+    return output
+
+def get_screenTrend(x, player_list):
+    output = []
+
+    TrendColor = "#fff"
+
+    heading = [
+        render.Box(
+            width = 64,
+            height = 5,
+            color = "#0039A6",
+            child = render.Row(
+                expanded = True,
+                main_align = "start",
+                cross_align = "center",
+                children = [
+                    render.Box(
+                        width = 64,
+                        height = 5,
+                        child = render.Text(content = "FEDEX CUP", color = "#fff", font = "CG-pixel-3x5-mono"),
+                    ),
+                ],
+            ),
+        ),
+    ]
+    output.extend(heading)
+
+    for i in range(0, 4):
+        # need to skip over 10
+        if i + x >= 10:
+            i = i + 1
+
+        if i + x < 31:
+            Name = player_list[i + x]["lastName"]
+            Rank = player_list[i + x]["thisWeekRank"]
+            PrevRank = player_list[i + x]["previousWeekRank"]
+            intRank = int(Rank)
+            intPrevRank = int(PrevRank)
+
+            diff = intPrevRank - intRank
+
+            if diff > 0:
+                TrendColor = "#03FF46"
+            elif diff < 0:
+                TrendColor = "#f00"
+            else:
+                diff = "-"
+                TrendColor = "#fff"
+
+            Player = render.Row(
+                expanded = True,
+                main_align = "space_between",
+                children = [
+                    render.Row(
+                        main_align = "start",
+                        children = [
+                            render.Padding(
+                                pad = (1, 1, 0, 1),
+                                child = render.Text(
+                                    content = str(Rank) + "." + Name[:10],
+                                    color = "#fff",
+                                    font = "CG-pixel-3x5-mono",
+                                ),
+                            ),
+                        ],
+                    ),
+                    render.Row(
+                        main_align = "end",
+                        children = [
+                            render.Padding(
+                                pad = (1, 1, 0, 1),
+                                child = render.Text(
+                                    content = str(diff),
+                                    color = TrendColor,
+                                    font = "CG-pixel-3x5-mono",
+                                ),
+                            ),
+                        ],
+                    ),
+                ],
+            )
+
+            output.extend([Player])
+        else:
+            output.extend([render.Column(children = [render.Box(width = 64, height = 7, color = "#111")])])
+
+    return output
+
+def get_cachable_data(url, timeout):
+    res = http.get(url = url, ttl_seconds = timeout)
+
+    if res.status_code != 200:
+        fail("request to %s failed with status code: %d - %s" % (url, res.status_code, res.body()))
+
+    return res.body()

--- a/apps/fedexcup/manifest.yaml
+++ b/apps/fedexcup/manifest.yaml
@@ -1,0 +1,8 @@
+---
+id: fedex-cup
+name: FedEx Cup
+summary: Shows FedEx Cup standings
+desc: Shows the standings for the PGA Tour's FedEx Cup.
+author: M0ntyP
+fileName: fedex_cup.star
+packageName: fedexcup


### PR DESCRIPTION
# Description
Its almost playoff season on the PGA Tour, so I made a little app to show the Top 30 players in the FedEx Cup, with an indication on the positional change for the week

Very similar to the Tennis Rankings app

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 008a10f</samp>

### Summary
🏌️‍♂️🌟📄

<!--
1.  🏌️‍♂️ - This emoji represents the golf theme of the applet, as the FedEx Cup is a competition for the PGA Tour golfers. It also conveys the idea of sports and ranking, which are relevant to the applet's functionality.
2.  🌟 - This emoji represents the Starlark language, which is the programming language used to write the applet code. It also conveys the idea of brightness and creativity, which are desirable qualities for an applet developer.
3.  📄 - This emoji represents the manifest file, which is a document that contains the essential information for the applet. It also conveys the idea of writing and publishing, which are steps involved in creating and sharing an applet.
-->
This pull request adds a new applet for the Tidbyt device that shows the FedEx Cup standings for the PGA Tour. The applet consists of two files: `fedex_cup.star`, which contains the Starlark code for fetching and displaying the data, and `manifest.yaml`, which contains the metadata for the applet. The applet uses the Tidbyt API and two different render functions to show the player names, ranks, and trends. The applet also includes a docstring with the applet summary, description, and author information.

> _FedEx Cup applet_
> _Shows golfers' ranks and trends_
> _`Starlark` code shines_

### Walkthrough
* Create and register a new applet for showing the FedEx Cup standings ([link](https://github.com/tidbyt/community/pull/1618/files?diff=unified&w=0#diff-7925fd807420a440e2b2fe846f94f4291b2293ec39202d6d23c172ffa3380f10R1-R220), [link](https://github.com/tidbyt/community/pull/1618/files?diff=unified&w=0#diff-5cb217d50151c4aba194787de2ffbe52f860295ef5348d0134730cc987ec904dR1-R8))


