### PR TITLE
Update: FedEx Cup

### DIFF
--- a/apps/fedexcup/fedex_cup.star
+++ b/apps/fedexcup/fedex_cup.star
@@ -6,6 +6,9 @@ Author: M0ntyP
 
 v1.0
 First release
+
+v1.1
+Revised API URL
 """
 
 load("encoding/json.star", "json")
@@ -13,7 +16,7 @@ load("http.star", "http")
 load("render.star", "render")
 load("time.star", "time")
 
-STANDINGS_URL = "https://www.pgatour.com/_next/data/pgatour-prod-1.19.5/en/fedexcup.json?tab=official-standings.html"
+STANDINGS_URL = "https://www.pgatour.com/_next/data/pgatour-prod-1.20.11/en/fedexcup.json"
 DEFAULT_TIMEZONE = "America/New_York"
 
 def main():


### PR DESCRIPTION
# Description
PGA Tour changed the API URL ... I hope its not a regular thing

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 438ada5</samp>

### Summary
:arrows_counterclockwise::golf::arrow_up_small:

<!--
1.  :arrows_counterclockwise: - This emoji can be used to indicate that something has been updated or refreshed, such as the API URL in this case.
2.  :golf: - This emoji can be used to represent the domain or topic of the app, which is golf in this case.
3.  :arrow_up_small: - This emoji can be used to indicate that something has been increased or improved, such as the version number in this case.
-->
Improved the `fedex_cup` app by switching to a more reliable data source and bumping the version.

> _Sing, O Muse, of the `fedex_cup` app and its glorious update_
> _That changed the source of the golfers' fame and skill, the API_
> _And raised the version number, as a sign of progress and of might_
> _Like Zeus, who thunders from Olympus, and his scepter wields with pride_

### Walkthrough
* Updated the app version number to 1.0.1 ([link](https://github.com/tidbyt/community/pull/1632/files?diff=unified&w=0#diff-7925fd807420a440e2b2fe846f94f4291b2293ec39202d6d23c172ffa3380f10R9-R11))
* Fixed the API URL for fetching the FedEx Cup standings to match the latest version of the PGA Tour website ([link](https://github.com/tidbyt/community/pull/1632/files?diff=unified&w=0#diff-7925fd807420a440e2b2fe846f94f4291b2293ec39202d6d23c172ffa3380f10L16-R19))


