### PR TITLE
add the new Event Progress app

### DIFF
--- a/apps/eventprogress/eventprogress.star
+++ b/apps/eventprogress/eventprogress.star
@@ -1,0 +1,255 @@
+"""
+Applet: Event Progress
+Summary: Show the progress of an event
+Description: Show the progress of an event by showing which segment is currently active and how long is left for each.
+Author: Mike Toscano
+"""
+
+load("animation.star", "animation")
+load("render.star", "render")
+load("schema.star", "schema")
+
+def main(config):
+    active = {
+        "1": config.bool("active1", False),
+        "2": config.bool("active2", False),
+        "3": config.bool("active3", False),
+        "4": config.bool("active4", False),
+        "5": config.bool("active5", False),
+    }
+    rows = [
+        render.Row(
+            expanded = True,  # Use as much horizontal space as possible
+            main_align = "space_around",  # Controls horizontal alignment
+            cross_align = "start",  # Controls vertical alignment
+            children = [
+                render.Box(width = 1, height = 9, color = "#000"),
+                render.WrappedText(align = "center", content = config.str("title"), font = "tom-thumb"),
+                render.Box(width = 1, height = 9, color = "#000"),
+            ],
+        ),
+        render.Row(
+            expanded = True,  # Use as much horizontal space as possible
+            main_align = "space_around",  # Controls horizontal alignment
+            cross_align = "center",  # Controls vertical alignment
+            children = [
+                render.Box(width = 1, height = 9, color = "#000"),
+                render.WrappedText(align = "center", content = config.str("segment" + getHighestActiveSegment(active)) or "", font = "tom-thumb"),
+                render.Box(width = 1, height = 9, color = "#000"),
+            ],
+        ),
+        squares(int(config.str("numSegments", "1")), active, config.str("color", "#fff"), config.str("activeColor", "#000")),
+    ]
+
+    if int(getHighestActiveSegment(active)) > 0:
+        rows.append(
+            render.Row(
+                expanded = True,  # Use as much horizontal space as possible
+                main_align = "space_around",  # Controls horizontal alignment
+                cross_align = "end",  # Controls vertical alignment
+                children = [
+                    # render.Box(width=1, height=5, color="#000"),
+                    animation.Transformation(
+                        child = render.Box(width = 1, height = 5, color = config.str("progressColor", "#fff")),
+                        duration = int(config.str("progressBarFrames", "690")),
+                        delay = 0,
+                        direction = "normal",
+                        fill_mode = "forwards",
+                        keyframes = [
+                            animation.Keyframe(
+                                percentage = 0.0,
+                                transforms = [animation.Scale(0, 1)],
+                                curve = "linear",
+                            ),
+                            animation.Keyframe(
+                                percentage = 1.0,
+                                transforms = [animation.Scale(128, 1)],
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        )
+    else:
+        rows.append(
+            render.Box(width = 1, height = 5, color = "#000"),
+        )
+
+    return render.Root(
+        show_full_animation = True,
+        delay = 90,
+        child = render.Box(
+            child = render.Column(
+                main_align = "end",
+                # expanded = True,
+                children = rows,
+            ),
+        ),
+    )
+
+def getHighestActiveSegment(active):
+    segment = "0"
+    for i in range(len(active)):
+        if active[str(i + 1)]:
+            segment = str(i + 1)
+
+    return segment
+
+def squares(numSegments, active, color, activeColor):
+    squares = []
+    pixelsTakenByBoxes = numSegments * (12 - numSegments)
+    horizontalPixelsLeftToFill = 64 - pixelsTakenByBoxes
+    widthPerLine = int(horizontalPixelsLeftToFill / numSegments / 2)
+
+    # squares.append(
+    #     render.Box(width=1, height=11, color="#000"),
+    # )
+    for i in range(numSegments):
+        squares.append(
+            render.Box(
+                width = widthPerLine,
+                height = 1,
+                color = color,
+            ),
+        )
+        if active[str(i + 1)]:
+            squares.append(
+                render.Box(
+                    width = 12 - numSegments,
+                    height = 12 - numSegments,
+                    color = color,
+                    child = render.Box(
+                        width = 10 - numSegments,
+                        height = 10 - numSegments,
+                        color = activeColor,
+                    ),
+                ),
+            )
+        else:
+            squares.append(
+                render.Box(
+                    width = 12 - numSegments,
+                    height = 12 - numSegments,
+                    color = color,
+                ),
+            )
+    squares.append(
+        render.Box(
+            width = widthPerLine,
+            height = 1,
+            color = color,
+        ),
+    )
+    squares.append(
+        render.Box(width = 1, height = 11, color = "#000"),
+    )
+    return render.Row(
+        expanded = True,  # Use as much horizontal space as possible
+        main_align = "space_around",  # Controls horizontal alignment
+        cross_align = "center",  # Controls vertical alignment
+        children = squares,
+    )
+
+def more_options(numSegments):
+    additionalOptions = []
+    for i in range(int(numSegments)):
+        additionalOptions.append(
+            schema.Text(
+                id = "segment" + str(i + 1),
+                name = "Segment " + str(i + 1),
+                desc = "Name of segment #" + str(i + 1),
+                icon = "gear",
+                default = "Segment " + str(i + 1),
+            ),
+        )
+
+    for i in range(int(numSegments)):
+        additionalOptions.append(
+            schema.Toggle(
+                id = "active" + str(i + 1),
+                name = "Active " + str(i + 1),
+                desc = "Toggle segment " + str(i + 1) + " active",
+                icon = "check",
+                default = False,
+            ),
+        )
+
+    return additionalOptions
+
+options = [
+    schema.Option(
+        display = "1",
+        value = "1",
+    ),
+    schema.Option(
+        display = "2",
+        value = "2",
+    ),
+    schema.Option(
+        display = "3",
+        value = "3",
+    ),
+    schema.Option(
+        display = "4",
+        value = "4",
+    ),
+    schema.Option(
+        display = "5",
+        value = "5",
+    ),
+]
+
+def get_schema():
+    return schema.Schema(
+        version = "1",
+        fields = [
+            schema.Text(
+                id = "title",
+                name = "Title",
+                desc = "Title of the event",
+                icon = "addressCard",
+                default = "Event title",
+            ),
+            schema.Color(
+                id = "color",
+                name = "Color",
+                desc = "Color of the segments",
+                icon = "brush",
+                default = "#7AB0FF",
+            ),
+            schema.Color(
+                id = "activeColor",
+                name = "Active Color",
+                desc = "Color of the active segments",
+                icon = "brush",
+                default = "#7AB0FF",
+            ),
+            schema.Color(
+                id = "progressColor",
+                name = "Progress Bar Color",
+                desc = "Color of the progress bar",
+                icon = "brush",
+                default = "#EEF485",
+            ),
+            schema.Text(
+                id = "progressBarFrames",
+                name = "Progress Bar Timing",
+                desc = "Number of frames for the progress bar to reach 100%",
+                icon = "clock",
+                default = "690",
+            ),
+            schema.Dropdown(
+                id = "numSegments",
+                name = "Segments",
+                desc = "Number of segments to display",
+                icon = "gear",
+                default = options[0].value,
+                options = options,
+            ),
+            schema.Generated(
+                id = "generated",
+                source = "numSegments",
+                handler = more_options,
+            ),
+        ],
+    )

--- a/apps/eventprogress/eventprogress.star
+++ b/apps/eventprogress/eventprogress.star
@@ -24,7 +24,7 @@ def main(config):
             cross_align = "start",  # Controls vertical alignment
             children = [
                 render.Box(width = 1, height = 9, color = "#000"),
-                render.WrappedText(align = "center", content = config.str("title"), font = "tom-thumb"),
+                render.WrappedText(align = "center", content = config.str("title") or "Main Title", font = "tom-thumb"),
                 render.Box(width = 1, height = 9, color = "#000"),
             ],
         ),
@@ -34,7 +34,7 @@ def main(config):
             cross_align = "center",  # Controls vertical alignment
             children = [
                 render.Box(width = 1, height = 9, color = "#000"),
-                render.WrappedText(align = "center", content = config.str("segment" + getHighestActiveSegment(active)) or "", font = "tom-thumb"),
+                render.WrappedText(align = "center", content = config.str("segment" + getHighestActiveSegment(active)) or "Subtitle", font = "tom-thumb"),
                 render.Box(width = 1, height = 9, color = "#000"),
             ],
         ),

--- a/apps/eventprogress/eventprogress.star
+++ b/apps/eventprogress/eventprogress.star
@@ -34,7 +34,7 @@ def main(config):
             cross_align = "center",  # Controls vertical alignment
             children = [
                 render.Box(width = 1, height = 9, color = "#000"),
-                render.Text(content = config.str("segment" + getHighestActiveSegment(active)) or "", font = "tom-thumb",  color = "B0B0B1"),
+                render.Text(content = config.str("segment" + getHighestActiveSegment(active)) or "", font = "tom-thumb", color = "B0B0B1"),
                 render.Box(width = 1, height = 9, color = "#000"),
             ],
         ),

--- a/apps/eventprogress/eventprogress.star
+++ b/apps/eventprogress/eventprogress.star
@@ -24,7 +24,7 @@ def main(config):
             cross_align = "start",  # Controls vertical alignment
             children = [
                 render.Box(width = 1, height = 9, color = "#000"),
-                render.WrappedText(align = "center", content = config.str("title") or "", font = "tom-thumb"),
+                render.Text(content = config.str("title") or "", font = "tom-thumb"),
                 render.Box(width = 1, height = 9, color = "#000"),
             ],
         ),
@@ -34,7 +34,7 @@ def main(config):
             cross_align = "center",  # Controls vertical alignment
             children = [
                 render.Box(width = 1, height = 9, color = "#000"),
-                render.WrappedText(align = "center", content = config.str("segment" + getHighestActiveSegment(active)) or "", font = "tom-thumb"),
+                render.Text(content = config.str("segment" + getHighestActiveSegment(active)) or "", font = "tom-thumb",  color = "B0B0B1"),
                 render.Box(width = 1, height = 9, color = "#000"),
             ],
         ),
@@ -159,7 +159,7 @@ def more_options(numSegments):
                 name = "Segment " + str(i + 1),
                 desc = "Name of segment #" + str(i + 1),
                 icon = "gear",
-                default = "Segment " + str(i + 1),
+                default = "Edit settings",
             ),
         )
 
@@ -170,7 +170,7 @@ def more_options(numSegments):
                 name = "Active " + str(i + 1),
                 desc = "Toggle segment " + str(i + 1) + " active",
                 icon = "check",
-                default = False,
+                default = False if i > 0 else True,
             ),
         )
 
@@ -208,7 +208,7 @@ def get_schema():
                 name = "Title",
                 desc = "Title of the event",
                 icon = "addressCard",
-                default = "Event title",
+                default = "How to start:",
             ),
             schema.Color(
                 id = "color",
@@ -222,7 +222,7 @@ def get_schema():
                 name = "Active Color",
                 desc = "Color of the active segments",
                 icon = "brush",
-                default = "#7AB0FF",
+                default = "#FBFF7A",
             ),
             schema.Color(
                 id = "progressColor",
@@ -243,7 +243,7 @@ def get_schema():
                 name = "Segments",
                 desc = "Number of segments to display",
                 icon = "gear",
-                default = options[0].value,
+                default = options[3].value,
                 options = options,
             ),
             schema.Generated(

--- a/apps/eventprogress/eventprogress.star
+++ b/apps/eventprogress/eventprogress.star
@@ -24,7 +24,7 @@ def main(config):
             cross_align = "start",  # Controls vertical alignment
             children = [
                 render.Box(width = 1, height = 9, color = "#000"),
-                render.WrappedText(align = "center", content = config.str("title") or "Main Title", font = "tom-thumb"),
+                render.WrappedText(align = "center", content = config.str("title") or "", font = "tom-thumb"),
                 render.Box(width = 1, height = 9, color = "#000"),
             ],
         ),
@@ -34,7 +34,7 @@ def main(config):
             cross_align = "center",  # Controls vertical alignment
             children = [
                 render.Box(width = 1, height = 9, color = "#000"),
-                render.WrappedText(align = "center", content = config.str("segment" + getHighestActiveSegment(active)) or "Subtitle", font = "tom-thumb"),
+                render.WrappedText(align = "center", content = config.str("segment" + getHighestActiveSegment(active)) or "", font = "tom-thumb"),
                 render.Box(width = 1, height = 9, color = "#000"),
             ],
         ),

--- a/apps/eventprogress/manifest.yaml
+++ b/apps/eventprogress/manifest.yaml
@@ -1,0 +1,8 @@
+---
+id: event-progress
+name: Event Progress
+summary: Track event progress
+desc: Track the progress of an event and its segments using sgement nodes and a progress bar.
+author: Mike Toscano
+fileName: eventprogress.star
+packageName: eventprogress


### PR DESCRIPTION
# Description
Adding a new app called Event Progress per the request posted [here](https://discuss.tidbyt.com/t/segment-progress-event-indicator/5130). The app will show an event title, a segment subtitle, a node for each segment with the active segments highlighted, and a progress bar of configurable time.

![image](https://github.com/tidbyt/community/assets/7661715/0753f89b-86fc-4cbe-8bbd-b6bc930c48d8)


# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4ef9ba6</samp>

### Summary
🎉🕒🎨

<!--
1.  🎉 - This emoji represents the celebration or excitement of adding a new applet that shows the progress of an event, which could be useful for various scenarios, such as countdowns, timers, schedules, etc.
2.  🕒 - This emoji represents the time or duration aspect of the applet, which shows how much time is left for each segment of the event and updates the progress bar accordingly.
3.  🎨 - This emoji represents the design or visual aspect of the applet, which uses the render and animation modules to create the UI elements and the schema module to define the configuration options for the applet.
-->
This pull request adds a new applet called Event Progress, which displays the current and remaining time of different segments of an event. The applet consists of two files: `eventprogress.star`, which contains the code for the applet logic and UI, and `manifest.yaml`, which contains the applet metadata and information.

> _`Event Progress` app_
> _Shows segments and time left_
> _Autumn leaves falling_

### Walkthrough
* Create and register the Event Progress applet, which shows the progress of an event by showing which segment is currently active and how long is left for each ([link](https://github.com/tidbyt/community/pull/1643/files?diff=unified&w=0#diff-1aa7db46874fa73da367ed0d346915eaa65ae7492b952cd17edcbc17606cb44cR1-R8), [link](https://github.com/tidbyt/community/pull/1643/files?diff=unified&w=0#diff-33face30c92c1abd009b6bdc98b50d9ca929183ea5cb017e26cc15d60668b3f4R1-R255))


