### PR TITLE
Update: ATP & WTA Tennis

### DIFF
--- a/apps/wtatennis/wta_tennis.star
+++ b/apps/wtatennis/wta_tennis.star
@@ -35,6 +35,10 @@ v1.6
 ESPN changed the structure of the API so had to reflect those changes in the app
 Added feature to show scheduled matches, enable with toggle switch. Will show date & time of scheduled match in Tidbyt's timezone
 Added GroupingsID variable, as sometimes mens & womens results are listed in the API
+
+v1.7
+Updated determination for completed match, using "description" and not "state"
+Now adding suspended matches in the In Progress list
 """
 
 load("encoding/json.star", "json")
@@ -108,6 +112,15 @@ def main(config):
                             InProgressMatchList.append(y)
                             InProgress = InProgress + 1
 
+                    if WTA_JSON["events"][x]["groupings"][GroupingsID]["competitions"][y]["status"]["type"]["description"] == "Suspended":
+                        MatchTime = WTA_JSON["events"][EventIndex]["groupings"][GroupingsID]["competitions"][y]["date"]
+                        MatchTime = time.parse_time(MatchTime, format = "2006-01-02T15:04Z")
+                        diffMatch = MatchTime - now
+
+                        if diffMatch.hours > -24:
+                            InProgressMatchList.append(y)
+                            InProgress = InProgress + 1
+
                     # Another gotcha with the ESPN data feed, some in progress matches are still listed as "Scheduled"
                     # So check if there is a score listed and if so, add it to the list
                     if WTA_JSON["events"][x]["groupings"][GroupingsID]["competitions"][y]["status"]["type"]["description"] == "Scheduled":
@@ -167,7 +180,7 @@ def main(config):
                         GroupingsID = 1
                     for y in range(0, len(WTA_JSON["events"][x]["groupings"][GroupingsID]["competitions"]), 1):
                         # if the match is completed ("post") and its a singles match ("athlete") and the start time of the match was < 24 hrs ago, lets add it to the list of completed matches
-                        if WTA_JSON["events"][x]["groupings"][GroupingsID]["competitions"][y]["status"]["type"]["state"] == "post":
+                        if WTA_JSON["events"][x]["groupings"][GroupingsID]["competitions"][y]["status"]["type"]["description"] == "Final":
                             MatchTime = WTA_JSON["events"][EventIndex]["groupings"][GroupingsID]["competitions"][y]["date"]
                             MatchTime = time.parse_time(MatchTime, format = "2006-01-02T15:04Z")
                             diff = MatchTime - now


### PR DESCRIPTION
# Description
Found scenario where a match state was "post" which usually means its over, but it was just suspended

Updated determination for completed match, using "description" and not "state"
Now adding suspended matches in the In Progress list

# Copilot
<!-- please don't change the line below -->
copilot:all
