### PR TITLE
Update: ATP & WTA Tennis apps

### DIFF
--- a/apps/atptennis/atp_tennis.star
+++ b/apps/atptennis/atp_tennis.star
@@ -38,10 +38,10 @@ Added feature to show scheduled matches, enable with toggle switch. Will show da
 v1.6.1
 Bug fix - the API lookup for a "scheduled" match which is actually in progress was incorrect
 
-v1.6.2
-Found scenario where a match status was "post" which usually means its over, but it was just suspended
+v1.7
 Updated determination for completed match, using "description" and not "state"
 Now adding suspended matches in the In Progress list
+Scheduled matches now in order of play - earliest to latest
 """
 
 load("encoding/json.star", "json")
@@ -224,7 +224,7 @@ def main(config):
                             MatchTime = time.parse_time(MatchTime, format = "2006-01-02T15:04Z")
                             diff = MatchTime - now
                             if diff.hours < 12:
-                                ScheduledMatchList.append(y)
+                                ScheduledMatchList.insert(0,y)
 
         # if there are more than 2 matches completed in past 24hrs, then we'll need to show them across multiple screens
         if len(ScheduledMatchList) > 0:

--- a/apps/atptennis/atp_tennis.star
+++ b/apps/atptennis/atp_tennis.star
@@ -41,6 +41,7 @@ Bug fix - the API lookup for a "scheduled" match which is actually in progress w
 v1.7
 Updated determination for completed match, using "description" and not "state"
 Now adding suspended matches in the In Progress list
+Suspended matches shown in blue
 Scheduled matches now in order of play - earliest to latest
 """
 
@@ -314,6 +315,11 @@ def getLiveScores(SelectedTourneyID, EventIndex, InProgressMatchList, JSON):
                     Player1Color = "#01AF50"
                 elif JSON["events"][EventIndex]["groupings"][0]["competitions"][x]["competitors"][0]["possession"] == False:
                     Player2Color = "#01AF50"
+
+            # if a match is suspended show players in blue
+            if JSON["events"][EventIndex]["groupings"][0]["competitions"][x]["status"]["type"]["description"] == "Suspended":
+                Player1Color = "#6aaeeb"
+                Player2Color = "#6aaeeb"
 
             Number_Sets = len(JSON["events"][EventIndex]["groupings"][0]["competitions"][x]["competitors"][0]["linescores"])
             Player1_Sets = ""

--- a/apps/atptennis/atp_tennis.star
+++ b/apps/atptennis/atp_tennis.star
@@ -224,7 +224,7 @@ def main(config):
                             MatchTime = time.parse_time(MatchTime, format = "2006-01-02T15:04Z")
                             diff = MatchTime - now
                             if diff.hours < 12:
-                                ScheduledMatchList.insert(0,y)
+                                ScheduledMatchList.insert(0, y)
 
         # if there are more than 2 matches completed in past 24hrs, then we'll need to show them across multiple screens
         if len(ScheduledMatchList) > 0:

--- a/apps/atptennis/manifest.yaml
+++ b/apps/atptennis/manifest.yaml
@@ -2,7 +2,7 @@
 id: atp-tennis
 name: ATP Tennis
 summary: Shows ATP scores
-desc: Display tennis scores from an ATP tournament chosen in the dropdown. Shows live matches and if selected, any match completed in the past 24 hours.
+desc: Display tennis scores from a tournament chosen in the dropdown. Shows live matches and if selected, any match completed in the past 24 hours or any scheduled matches in next 12 hours. Server indicated in green when available. If match is suspended it will be shown in blue.
 author: M0ntyP
 fileName: atp_tennis.star
 packageName: atptennis

--- a/apps/wtatennis/manifest.yaml
+++ b/apps/wtatennis/manifest.yaml
@@ -2,7 +2,7 @@
 id: wta-tennis
 name: WTA Tennis
 summary: Shows WTA scores
-desc: Display tennis scores from a WTA tournament chosen in the dropdown. Shows live matches and if selected, any match completed in the past 24 hours.
+desc: Display tennis scores from a WTA tournament chosen in the dropdown. Shows live matches and if selected, any match completed in the past 24 hours or any scheduled matches in next 12 hours. Server indicated in green when available. If match is suspended it will be shown in blue.
 author: M0ntyP
 fileName: wta_tennis.star
 packageName: wtatennis

--- a/apps/wtatennis/wta_tennis.star
+++ b/apps/wtatennis/wta_tennis.star
@@ -35,6 +35,10 @@ v1.6
 ESPN changed the structure of the API so had to reflect those changes in the app
 Added feature to show scheduled matches, enable with toggle switch. Will show date & time of scheduled match in Tidbyt's timezone
 Added GroupingsID variable, as sometimes mens & womens results are listed in the API
+
+v1.7
+Updated determination for completed match, using "description" and not "state"
+Now adding suspended matches in the In Progress list
 """
 
 load("encoding/json.star", "json")
@@ -108,6 +112,15 @@ def main(config):
                             InProgressMatchList.append(y)
                             InProgress = InProgress + 1
 
+                    if WTA_JSON["events"][x]["groupings"][GroupingsID]["competitions"][y]["status"]["type"]["description"] == "Suspended":
+                        MatchTime = WTA_JSON["events"][EventIndex]["groupings"][GroupingsID]["competitions"][y]["date"]
+                        MatchTime = time.parse_time(MatchTime, format = "2006-01-02T15:04Z")
+                        diffMatch = MatchTime - now
+
+                        if diffMatch.hours > -24:
+                            InProgressMatchList.append(y)
+                            InProgress = InProgress + 1
+
                     # Another gotcha with the ESPN data feed, some in progress matches are still listed as "Scheduled"
                     # So check if there is a score listed and if so, add it to the list
                     if WTA_JSON["events"][x]["groupings"][GroupingsID]["competitions"][y]["status"]["type"]["description"] == "Scheduled":
@@ -167,7 +180,7 @@ def main(config):
                         GroupingsID = 1
                     for y in range(0, len(WTA_JSON["events"][x]["groupings"][GroupingsID]["competitions"]), 1):
                         # if the match is completed ("post") and its a singles match ("athlete") and the start time of the match was < 24 hrs ago, lets add it to the list of completed matches
-                        if WTA_JSON["events"][x]["groupings"][GroupingsID]["competitions"][y]["status"]["type"]["state"] == "post":
+                        if WTA_JSON["events"][x]["groupings"][GroupingsID]["competitions"][y]["status"]["type"]["description"] == "Final":
                             MatchTime = WTA_JSON["events"][EventIndex]["groupings"][GroupingsID]["competitions"][y]["date"]
                             MatchTime = time.parse_time(MatchTime, format = "2006-01-02T15:04Z")
                             diff = MatchTime - now

--- a/apps/wtatennis/wta_tennis.star
+++ b/apps/wtatennis/wta_tennis.star
@@ -930,7 +930,7 @@ def get_schema():
         fields = [
             schema.Dropdown(
                 id = "TournamentList",
-                name = "Tourney",
+                name = "Tournament",
                 desc = "Choose the tournament",
                 icon = "gear",
                 default = TournamentOptions[0].value,

--- a/apps/wtatennis/wta_tennis.star
+++ b/apps/wtatennis/wta_tennis.star
@@ -39,6 +39,7 @@ Added GroupingsID variable, as sometimes mens & womens results are listed in the
 v1.7
 Updated determination for completed match, using "description" and not "state"
 Now adding suspended matches in the In Progress list
+Scheduled matches now in order of play - earliest to latest
 """
 
 load("encoding/json.star", "json")
@@ -229,7 +230,7 @@ def main(config):
                             MatchTime = time.parse_time(MatchTime, format = "2006-01-02T15:04Z")
                             diff = MatchTime - now
                             if diff.hours < 12:
-                                ScheduledMatchList.append(y)
+                                ScheduledMatchList.insert(0,y)
 
         # if there are more than 2 matches completed in past 24hrs, then we'll need to show them across multiple screens
         if len(ScheduledMatchList) > 0:

--- a/apps/wtatennis/wta_tennis.star
+++ b/apps/wtatennis/wta_tennis.star
@@ -39,6 +39,7 @@ Added GroupingsID variable, as sometimes mens & womens results are listed in the
 v1.7
 Updated determination for completed match, using "description" and not "state"
 Now adding suspended matches in the In Progress list
+Suspended matches shown in blue
 Scheduled matches now in order of play - earliest to latest
 """
 
@@ -322,6 +323,11 @@ def getLiveScores(SelectedTourneyID, EventIndex, InProgressMatchList, JSON):
                     Player1Color = "#01AF50"
                 elif JSON["events"][EventIndex]["groupings"][GroupingsID]["competitions"][x]["competitors"][0]["possession"] == False:
                     Player2Color = "#01AF50"
+
+            # if a match is suspended show players in blue
+            if JSON["events"][EventIndex]["groupings"][GroupingsID]["competitions"][x]["status"]["type"]["description"] == "Suspended":
+                Player1Color = "#6aaeeb"
+                Player2Color = "#6aaeeb"
 
             Number_Sets = len(JSON["events"][EventIndex]["groupings"][GroupingsID]["competitions"][x]["competitors"][0]["linescores"])
             Player1_Sets = ""

--- a/apps/wtatennis/wta_tennis.star
+++ b/apps/wtatennis/wta_tennis.star
@@ -230,7 +230,7 @@ def main(config):
                             MatchTime = time.parse_time(MatchTime, format = "2006-01-02T15:04Z")
                             diff = MatchTime - now
                             if diff.hours < 12:
-                                ScheduledMatchList.insert(0,y)
+                                ScheduledMatchList.insert(0, y)
 
         # if there are more than 2 matches completed in past 24hrs, then we'll need to show them across multiple screens
         if len(ScheduledMatchList) > 0:


### PR DESCRIPTION
# Description
Found that suspended matches were not being captured properly and were treated as completed matches. This caused the app to crash

Updated determination for completed match, using "description" and not "state"
Now adding suspended matches in the In Progress list
Suspended matches shown in blue
Scheduled matches now in order of play - earliest to latest

Update YAML file for both apps also

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7581497</samp>

### Summary
🎾🛠️🔄

<!--
1.  🎾 - This emoji represents the sport of tennis and is a natural choice for any changes related to the ATP and WTA Tennis apps.
2.  🛠️ - This emoji represents a tool or a fix and can be used to indicate that the changes improve the accuracy and usability of the apps, as well as handle some edge cases like suspended matches.
3.  🔄 - This emoji represents a refresh or an update and can be used to show that the changes sync the WTA Tennis app with the latest version of the ATP Tennis app and use a different method to sort the Scheduled list.
-->
This pull request enhances the `atptennis` and `wtatennis` apps for displaying tennis tournament information on the Tidbyt device. It fixes some issues with displaying match statuses, and improves the sorting of the matches by order of play. It also adds version comments to both apps for easier tracking.

> _Sing, O Muse, of the skillful code review_
> _That brought new glory to the tennis apps_
> _And made them shine with accuracy and ease_
> _Like bright Apollo's golden lyre and bow._

### Walkthrough
*  Update the ATP and WTA tennis apps to version 1.1 with improved match status detection and sorting ([link](https://github.com/tidbyt/community/pull/1646/files?diff=unified&w=0#diff-2fe7726a8148e3fb23a64991e8b2661bd9c098395de1a2f1ea0092f21db623bcR40-R44), [link](https://github.com/tidbyt/community/pull/1646/files?diff=unified&w=0#diff-bacac371ef4450963bfae6cc2618e0ce8278c5d02f808e88e0cff7243efed67dR38-R42))
*  Use the "description" field instead of the "state" field to check if a match is completed or suspended in both `atp_tennis.star` and `wta_tennis.star` ([link](https://github.com/tidbyt/community/pull/1646/files?diff=unified&w=0#diff-2fe7726a8148e3fb23a64991e8b2661bd9c098395de1a2f1ea0092f21db623bcL165-R180), [link](https://github.com/tidbyt/community/pull/1646/files?diff=unified&w=0#diff-2fe7726a8148e3fb23a64991e8b2661bd9c098395de1a2f1ea0092f21db623bcR113-R122), [link](https://github.com/tidbyt/community/pull/1646/files?diff=unified&w=0#diff-bacac371ef4450963bfae6cc2618e0ce8278c5d02f808e88e0cff7243efed67dL170-R184), [link](https://github.com/tidbyt/community/pull/1646/files?diff=unified&w=0#diff-bacac371ef4450963bfae6cc2618e0ce8278c5d02f808e88e0cff7243efed67dR116-R124))
*  Use the `insert` method instead of the `append` method to add matches to the Scheduled list in reverse order, so that the earliest matches are shown first in both `atp_tennis.star` and `wta_tennis.star` ([link](https://github.com/tidbyt/community/pull/1646/files?diff=unified&w=0#diff-2fe7726a8148e3fb23a64991e8b2661bd9c098395de1a2f1ea0092f21db623bcL212-R227), [link](https://github.com/tidbyt/community/pull/1646/files?diff=unified&w=0#diff-bacac371ef4450963bfae6cc2618e0ce8278c5d02f808e88e0cff7243efed67dL219-R233))
*  Add commented out lines of code for printing the player name and the index of the match in `atp_tennis.star` for debugging or testing purposes ([link](https://github.com/tidbyt/community/pull/1646/files?diff=unified&w=0#diff-2fe7726a8148e3fb23a64991e8b2661bd9c098395de1a2f1ea0092f21db623bcR488-R489))


