### PR TITLE
Update: WQXR

### DIFF
--- a/apps/wqxr/README.md
+++ b/apps/wqxr/README.md
@@ -7,11 +7,15 @@ Station, on your Tidbyt
 
 You can change the following settings:
 
+- **Scroll direction**: Choose whether to scroll text horizontally or vertically
+- **Scroll speed**: Slow down the scroll speed of the text
 - **Show ensemble**: Show the ensemble, if applicable
 - **Show conductor and soloists**: Show the conductor and/or soloist(s), if applicable
-- **Color: Title**: Choose your own color for the title of the current piece
-- **Color: Composer**: Choose your own color for the composer of the current piece
-- **Color: Ensemble and Conductor/Soloists**: Choose your own color for the ensemble and conductor/soloists
+- **Use custom colors**: Choose your own text colors
+  - **Color: Title**: Choose your own text color for the title of the current piece
+  - **Color: Composer**: Choose your own text color for the composer of the current piece
+  - **Color: Ensemble**: Choose your own text color for the ensemble
+  - **Color: Conductor/Soloists**: Choose your own text color for the conductor/soloists
 
 ## Development
 

--- a/apps/wqxr/wqxr.star
+++ b/apps/wqxr/wqxr.star
@@ -24,6 +24,7 @@ COLORS = {
 
 DEFAULT_SHOW_ENSEMBLE = False
 DEFAULT_SHOW_PEOPLE = True
+DEFAULT_USE_CUSTOM_COLORS = False
 DEFAULT_COLOR_TITLE = COLORS["light_blue"]
 DEFAULT_COLOR_COMPOSER = COLORS["white"]
 DEFAULT_COLOR_ENSEMBLE = COLORS["medium_gray"]
@@ -87,18 +88,31 @@ def main(config):
 
         people = build_people(conductor, soloists)
 
+    use_custom_colors = config.bool("use_custom_colors", DEFAULT_USE_CUSTOM_COLORS)
+
+    if use_custom_colors:
+        color_title = config.str("color_title", DEFAULT_COLOR_TITLE)
+        color_composer = config.str("color_composer", DEFAULT_COLOR_COMPOSER)
+        color_ensemble = config.str("color_ensemble", DEFAULT_COLOR_ENSEMBLE)
+        color_people = config.str("color_people", DEFAULT_COLOR_PEOPLE)
+    else:
+        color_title = DEFAULT_COLOR_TITLE
+        color_composer = DEFAULT_COLOR_COMPOSER
+        color_ensemble = DEFAULT_COLOR_ENSEMBLE
+        color_people = DEFAULT_COLOR_PEOPLE
+
     children = []
     should_show_ensemble = config.bool("show_ensemble", DEFAULT_SHOW_ENSEMBLE)
     should_show_people = config.bool("show_people", DEFAULT_SHOW_PEOPLE)
 
     if title:
-        children.append(render.Marquee(width = 64, child = render.Text(content = title, font = "tb-8", color = config.str("color_title", DEFAULT_COLOR_TITLE))))
+        children.append(render.Marquee(width = 64, child = render.Text(content = title, font = "tb-8", color = color_title)))
     if composer:
-        children.append(render.Marquee(width = 64, child = render.Text(content = composer, font = "tom-thumb", color = config.str("color_composer", DEFAULT_COLOR_COMPOSER))))
+        children.append(render.Marquee(width = 64, child = render.Text(content = composer, font = "tom-thumb", color = color_composer)))
     if should_show_ensemble and ensemble:
-        children.append(render.Marquee(width = 64, child = render.Text(content = ensemble, font = "tom-thumb", color = config.str("color_ensemble", DEFAULT_COLOR_ENSEMBLE))))
+        children.append(render.Marquee(width = 64, child = render.Text(content = ensemble, font = "tom-thumb", color = color_ensemble)))
     if should_show_people and people:
-        children.append(render.Marquee(width = 64, child = render.Text(content = people, font = "tom-thumb", color = config.str("color_people", DEFAULT_COLOR_PEOPLE))))
+        children.append(render.Marquee(width = 64, child = render.Text(content = people, font = "tom-thumb", color = color_people)))
 
     return render.Root(
         max_age = 60,
@@ -146,10 +160,28 @@ def get_schema():
                 icon = "wandMagicSparkles",
                 default = DEFAULT_SHOW_PEOPLE,
             ),
+            schema.Toggle(
+                id = "use_custom_colors",
+                name = "Use custom colors",
+                desc = "Choose your own text colors",
+                icon = "palette",
+                default = DEFAULT_USE_CUSTOM_COLORS,
+            ),
+            schema.Generated(
+                id = "custom_colors",
+                source = "use_custom_colors",
+                handler = custom_colors,
+            ),
+        ],
+    )
+
+def custom_colors(use_custom_colors):
+    if use_custom_colors == "true":  # Not a real Boolean, it's a string!
+        return [
             schema.Color(
                 id = "color_title",
                 name = "Color: Title",
-                desc = "Choose your own text color for the title of the current piece",
+                desc = "Choose your own color for the title of the current piece",
                 icon = "palette",
                 default = DEFAULT_COLOR_TITLE,
                 palette = [
@@ -161,7 +193,7 @@ def get_schema():
             schema.Color(
                 id = "color_composer",
                 name = "Color: Composer",
-                desc = "Choose your own text color for the composer of the current piece",
+                desc = "Choose your own color for the composer of the current piece",
                 icon = "palette",
                 default = DEFAULT_COLOR_COMPOSER,
                 palette = [
@@ -174,7 +206,7 @@ def get_schema():
             schema.Color(
                 id = "color_ensemble",
                 name = "Color: Ensemble",
-                desc = "Choose your own text color for the ensemble",
+                desc = "Choose your own color for the ensemble",
                 icon = "palette",
                 default = DEFAULT_COLOR_ENSEMBLE,
                 palette = [
@@ -186,8 +218,8 @@ def get_schema():
             ),
             schema.Color(
                 id = "color_people",
-                name = "Color: Soloists/Conductor",
-                desc = "Choose your own text color for the soloists and conductor",
+                name = "Color: Conductor/Soloists",
+                desc = "Choose your own color for the conductor/soloists",
                 icon = "palette",
                 default = DEFAULT_COLOR_PEOPLE,
                 palette = [
@@ -197,5 +229,6 @@ def get_schema():
                     COLORS["dark_gray"],
                 ],
             ),
-        ],
-    )
+        ]
+    else:
+        return []

--- a/apps/wqxr/wqxr.star
+++ b/apps/wqxr/wqxr.star
@@ -44,10 +44,9 @@ SCROLL_SPEED_OPTIONS = [
     ),
     schema.Option(
         display = "Slowest",
-        value = "200"
-    )
+        value = "200",
+    ),
 ]
-
 
 DEFAULT_SCROLL_DIRECTION = SCROLL_DIRECTION_OPTIONS[0].value
 DEFAULT_SCROLL_SPEED = SCROLL_SPEED_OPTIONS[0].value

--- a/apps/wqxr/wqxr.star
+++ b/apps/wqxr/wqxr.star
@@ -33,7 +33,24 @@ SCROLL_DIRECTION_OPTIONS = [
     ),
 ]
 
+SCROLL_SPEED_OPTIONS = [
+    schema.Option(
+        display = "Fast",
+        value = "0",
+    ),
+    schema.Option(
+        display = "Slower",
+        value = "100",
+    ),
+    schema.Option(
+        display = "Slowest",
+        value = "200"
+    )
+]
+
+
 DEFAULT_SCROLL_DIRECTION = SCROLL_DIRECTION_OPTIONS[0].value
+DEFAULT_SCROLL_SPEED = SCROLL_SPEED_OPTIONS[0].value
 DEFAULT_SHOW_ENSEMBLE = False
 DEFAULT_SHOW_PEOPLE = True
 DEFAULT_USE_CUSTOM_COLORS = False
@@ -60,6 +77,7 @@ ERROR_CONTENT = render.Column(
 def main(config):
     # Get settings values
     scroll_direction = config.str("scroll_direction", DEFAULT_SCROLL_DIRECTION)
+    scroll_speed = int(config.str("scroll_speed", DEFAULT_SCROLL_SPEED))
     should_show_ensemble = config.bool("show_ensemble", DEFAULT_SHOW_ENSEMBLE)
     should_show_people = config.bool("show_people", DEFAULT_SHOW_PEOPLE)
     use_custom_colors = config.bool("use_custom_colors", DEFAULT_USE_CUSTOM_COLORS)
@@ -167,6 +185,7 @@ def main(config):
 
     return render.Root(
         max_age = 60,
+        delay = scroll_speed,
         child = render.Column(
             children = [
                 BLUE_HEADER_BAR,
@@ -200,6 +219,14 @@ def get_schema():
                 icon = "alignJustify",
                 options = SCROLL_DIRECTION_OPTIONS,
                 default = DEFAULT_SCROLL_DIRECTION,
+            ),
+            schema.Dropdown(
+                id = "scroll_speed",
+                name = "Scroll speed",
+                desc = "Slow down the scroll speed of the text",
+                icon = "gauge",
+                options = SCROLL_SPEED_OPTIONS,
+                default = DEFAULT_SCROLL_SPEED,
             ),
             schema.Toggle(
                 id = "show_ensemble",

--- a/apps/wqxr/wqxr.star
+++ b/apps/wqxr/wqxr.star
@@ -26,7 +26,8 @@ DEFAULT_SHOW_ENSEMBLE = False
 DEFAULT_SHOW_PEOPLE = True
 DEFAULT_COLOR_TITLE = COLORS["light_blue"]
 DEFAULT_COLOR_COMPOSER = COLORS["white"]
-DEFAULT_COLOR_ENSEMBLE_AND_PEOPLE = COLORS["medium_gray"]
+DEFAULT_COLOR_ENSEMBLE = COLORS["medium_gray"]
+DEFAULT_COLOR_PEOPLE = COLORS["medium_gray"]
 
 BLUE_HEADER_BAR = render.Stack(
     children = [
@@ -95,9 +96,9 @@ def main(config):
     if composer:
         children.append(render.Marquee(width = 64, child = render.Text(content = composer, font = "tom-thumb", color = config.str("color_composer", DEFAULT_COLOR_COMPOSER))))
     if should_show_ensemble and ensemble:
-        children.append(render.Marquee(width = 64, child = render.Text(content = ensemble, font = "tom-thumb", color = config.str("color_ensemble_and_people", DEFAULT_COLOR_ENSEMBLE_AND_PEOPLE))))
+        children.append(render.Marquee(width = 64, child = render.Text(content = ensemble, font = "tom-thumb", color = config.str("color_ensemble", DEFAULT_COLOR_ENSEMBLE))))
     if should_show_people and people:
-        children.append(render.Marquee(width = 64, child = render.Text(content = people, font = "tom-thumb", color = config.str("color_ensemble_and_people", DEFAULT_COLOR_ENSEMBLE_AND_PEOPLE))))
+        children.append(render.Marquee(width = 64, child = render.Text(content = people, font = "tom-thumb", color = config.str("color_people", DEFAULT_COLOR_PEOPLE))))
 
     return render.Root(
         max_age = 60,
@@ -148,7 +149,7 @@ def get_schema():
             schema.Color(
                 id = "color_title",
                 name = "Color: Title",
-                desc = "Choose your own color for the title of the current piece",
+                desc = "Choose your own text color for the title of the current piece",
                 icon = "palette",
                 default = DEFAULT_COLOR_TITLE,
                 palette = [
@@ -160,7 +161,7 @@ def get_schema():
             schema.Color(
                 id = "color_composer",
                 name = "Color: Composer",
-                desc = "Choose your own color for the composer of the current piece",
+                desc = "Choose your own text color for the composer of the current piece",
                 icon = "palette",
                 default = DEFAULT_COLOR_COMPOSER,
                 palette = [
@@ -171,11 +172,24 @@ def get_schema():
                 ],
             ),
             schema.Color(
-                id = "color_ensemble_and_people",
-                name = "Color: Ensemble and Conductor/Soloists",
-                desc = "Choose your own color for the ensemble and conductor/soloists",
+                id = "color_ensemble",
+                name = "Color: Ensemble",
+                desc = "Choose your own text color for the ensemble",
                 icon = "palette",
-                default = DEFAULT_COLOR_ENSEMBLE_AND_PEOPLE,
+                default = DEFAULT_COLOR_ENSEMBLE,
+                palette = [
+                    COLORS["white"],
+                    COLORS["light_gray"],
+                    COLORS["medium_gray"],
+                    COLORS["dark_gray"],
+                ],
+            ),
+            schema.Color(
+                id = "color_people",
+                name = "Color: Soloists/Conductor",
+                desc = "Choose your own text color for the soloists and conductor",
+                icon = "palette",
+                default = DEFAULT_COLOR_PEOPLE,
                 palette = [
                     COLORS["white"],
                     COLORS["light_gray"],

--- a/apps/wqxr/wqxr.star
+++ b/apps/wqxr/wqxr.star
@@ -98,6 +98,7 @@ def main(config):
         children.append(render.Marquee(width = 64, child = render.Text(content = people, font = "tom-thumb", color = config.str("color_ensemble_and_people", DEFAULT_COLOR_ENSEMBLE_AND_PEOPLE))))
 
     return render.Root(
+        max_age = 60,
         child = render.Column(
             children = [
                 BLUE_HEADER_BAR,

--- a/apps/wqxr/wqxr.star
+++ b/apps/wqxr/wqxr.star
@@ -22,6 +22,8 @@ COLORS = {
     "red": "#FF0000",
 }
 
+DEFAULT_SHOW_ENSEMBLE = False
+DEFAULT_SHOW_PEOPLE = True
 DEFAULT_COLOR_TITLE = COLORS["light_blue"]
 DEFAULT_COLOR_COMPOSER = COLORS["white"]
 DEFAULT_COLOR_ENSEMBLE_AND_PEOPLE = COLORS["medium_gray"]
@@ -85,8 +87,8 @@ def main(config):
         people = build_people(conductor, soloists)
 
     children = []
-    should_show_ensemble = config.bool("show_ensemble")
-    should_show_people = config.bool("show_people")
+    should_show_ensemble = config.bool("show_ensemble", DEFAULT_SHOW_ENSEMBLE)
+    should_show_people = config.bool("show_people", DEFAULT_SHOW_PEOPLE)
 
     if title:
         children.append(render.Marquee(width = 64, child = render.Text(content = title, font = "tb-8", color = config.str("color_title", DEFAULT_COLOR_TITLE))))
@@ -134,14 +136,14 @@ def get_schema():
                 name = "Show ensemble",
                 desc = "Show the ensemble, if applicable",
                 icon = "peopleGroup",
-                default = False,
+                default = DEFAULT_SHOW_ENSEMBLE,
             ),
             schema.Toggle(
                 id = "show_people",
                 name = "Show conductor and soloists",
                 desc = "Show the conductor and/or soloist(s), if applicable",
                 icon = "wandMagicSparkles",
-                default = True,
+                default = DEFAULT_SHOW_PEOPLE,
             ),
             schema.Color(
                 id = "color_title",

--- a/apps/wqxr/wqxr.star
+++ b/apps/wqxr/wqxr.star
@@ -114,14 +114,14 @@ def main(config):
 def build_people(conductor, soloists):
     output = []
 
-    if conductor:
-        output.append("%s, conductor" % (conductor))
-
     if soloists:
         soloist_parts = []
         for soloist in soloists:
             soloist_parts.append("%s, %s" % (soloist["musician"]["name"], soloist["instruments"][0]))
         output.append(", ".join(soloist_parts))
+
+    if conductor:
+        output.append("%s, conductor" % (conductor))
 
     return ", ".join(output)
 


### PR DESCRIPTION
After this got approved and merged into the Tidbyt apps directory, I used the app on my own Tidbyt for a few days and started noticing a few things I wanted to change

I made a few new features and refinements, listed below:

### Attempt to prevent the app from displaying stale data

I'm adding `max_age` to the Root widget as [is suggested in the docs](https://tidbyt.dev/docs/reference/widgets#root) and as [I saw on Discord](https://discord.com/channels/928484660785336380/928485908842426389/1124419623719288914) for a similar situation. I don't know if this will fix my issues of seeing prior song data, but it's worth a shot

### **Vertical scrolling**
Now there's a "Scroll direction" option to change the data to scroll vertically instead of horizontally. I was finding it annoying to wait for long text to scroll across the screen, especially when the Tidbyt is cycling through apps every 15 seconds (sometimes the text would take longer than 15 seconds to scroll across and I wouldn't even get to see the whole title)
<details>
  <summary>See image</summary>
<img src="https://github.com/expandrew/tidbyt/assets/3157928/4bfd564f-f53f-4b93-8062-c9fd3bebb979" />
</details>

### Scroll speed
When I added the "vertical scrolling" feature above, I noticed that it feels like the text scrolls too fast when it's in a vertical marquee (it's probably the same rate it's just the screen is shorter in the vertical direction so it feels faster). I added a setting for slowing down the scroll speed 🐢

<details>
  <summary>See images</summary>
   Slower:
  <br />
  <img src="https://github.com/expandrew/tidbyt/assets/3157928/11a69349-8ef4-407d-a9fc-2e42fd0ded3c" />
  <br />
  Slowest:
  <br />
  <img src="https://github.com/expandrew/tidbyt/assets/3157928/2310634e-79d2-475b-afcb-fff41bbaf3b9" />
</details>

### Show soloist names ahead of conductor name

For times when the current piece has a soloist, the soloist's name will show before the conductor's name in the "people" line. I tend to care more about the name of the soloist than the conductor, in these situations

<details>
  <summary>See images</summary>
  <img src="https://github.com/expandrew/tidbyt/assets/3157928/d44104a8-2ca4-4020-b458-8fff907373f1" />
  <img src="https://github.com/expandrew/tidbyt/assets/3157928/c92b6ca8-20d4-4a90-8422-414db9074742" />
</details>



# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 443b65f</samp>

### Summary
:sparkles::memo::hammer:

<!--
1.  :sparkles: - This emoji represents the addition of new features or enhancements to the app, such as scroll direction, scroll speed, and custom colors.
2.  :memo: - This emoji represents the update of documentation, such as the README.md file, to reflect the new settings options and explain how to use them.
3.  :hammer: - This emoji represents the improvement of code quality and the fixing of bugs, such as refactoring, linting, or testing.
-->
This pull request enhances the `wqxr` app for the Tidbyt device by adding more customization options and improving the code quality. Users can now choose the scroll direction and speed of the text, and select from a range of colors or generate their own. The `wqxr.star` and `README.md` files are updated accordingly.

> _The `wqxr` app got some upgrades_
> _With new settings and features in spades_
> _You can scroll as you please_
> _And pick custom colors with ease_
> _And the code is more polished and staid_

### Walkthrough
*  Add scroll direction and scroll speed settings for wqxr app ([link](https://github.com/tidbyt/community/pull/1650/files?diff=unified&w=0#diff-dc41be26bb0dcf8d80083b9f03c34f50b65ff35cbfd99218abc52031ab7d9a33L25-R60), [link](https://github.com/tidbyt/community/pull/1650/files?diff=unified&w=0#diff-dc41be26bb0dcf8d80083b9f03c34f50b65ff35cbfd99218abc52031ab7d9a33R215-R230), [link](https://github.com/tidbyt/community/pull/1650/files?diff=unified&w=0#diff-dc41be26bb0dcf8d80083b9f03c34f50b65ff35cbfd99218abc52031ab7d9a33L87-R192))
*  Refactor color settings into a toggle and a generated section ([link](https://github.com/tidbyt/community/pull/1650/files?diff=unified&w=0#diff-dc41be26bb0dcf8d80083b9f03c34f50b65ff35cbfd99218abc52031ab7d9a33L143-R262), [link](https://github.com/tidbyt/community/pull/1650/files?diff=unified&w=0#diff-dc41be26bb0dcf8d80083b9f03c34f50b65ff35cbfd99218abc52031ab7d9a33L171-R293), [link](https://github.com/tidbyt/community/pull/1650/files?diff=unified&w=0#diff-dc41be26bb0dcf8d80083b9f03c34f50b65ff35cbfd99218abc52031ab7d9a33L183-R316))
*  Update README.md to document new settings options ([link](https://github.com/tidbyt/community/pull/1650/files?diff=unified&w=0#diff-9a44b4ff7052ac548e7d14e39c9646f1d43c34bcbcec88827f35f7305cab1cb2L10-R18))
*  Simplify settings variables and constants ([link](https://github.com/tidbyt/community/pull/1650/files?diff=unified&w=0#diff-dc41be26bb0dcf8d80083b9f03c34f50b65ff35cbfd99218abc52031ab7d9a33R78-R85), [link](https://github.com/tidbyt/community/pull/1650/files?diff=unified&w=0#diff-dc41be26bb0dcf8d80083b9f03c34f50b65ff35cbfd99218abc52031ab7d9a33L136-R236))
*  Fix bugs and improve code structure and clarity ([link](https://github.com/tidbyt/community/pull/1650/files?diff=unified&w=0#diff-dc41be26bb0dcf8d80083b9f03c34f50b65ff35cbfd99218abc52031ab7d9a33R98), [link](https://github.com/tidbyt/community/pull/1650/files?diff=unified&w=0#diff-dc41be26bb0dcf8d80083b9f03c34f50b65ff35cbfd99218abc52031ab7d9a33L116-L118), [link](https://github.com/tidbyt/community/pull/1650/files?diff=unified&w=0#diff-dc41be26bb0dcf8d80083b9f03c34f50b65ff35cbfd99218abc52031ab7d9a33R206-R208))


