### PR TITLE
Update: PGA Tour

### DIFF
--- a/apps/pgatour/pga_tour.star
+++ b/apps/pgatour/pga_tour.star
@@ -32,7 +32,10 @@ v2.2
 Added better playoff handling
 
 v2.3 
-IDEA - better tournament naming especially for elevated events?
+Give user a choice of single color for the in progress rounds or use the color gradient option. Single color is the default
+Now showing scores for completed rounds rather than "F" 
+Removed tournament name formatting from both player/score related functions - should add efficiency?
+Added function to revise some tournament names to make them more readable and/or fit the width of the Tidbyt better
 """
 
 load("encoding/json.star", "json")
@@ -42,9 +45,11 @@ load("schema.star", "schema")
 load("time.star", "time")
 
 API = "https://site.web.api.espn.com/apis/v2/scoreboard/header?sport=golf&league=pga"
+API2 = "https://site.api.espn.com/apis/site/v2/sports/golf/pga/scoreboard"
 
 CACHE_TTL_SECS = 60
 DEFAULT_TIMEZONE = "Australia/Adelaide"
+THE_EXCEPTIONS = ["401465539", "401546052"]
 
 def main(config):
     renderCategory = []
@@ -54,9 +59,12 @@ def main(config):
     timezone = config.get("$tz", DEFAULT_TIMEZONE)
     RotationSpeed = config.get("speed", "3")
     OppField = config.bool("OppFieldToggle")
+    ColorGradient = config.get("ColorGradient", "False")
 
     CacheData = get_cachable_data(API, CACHE_TTL_SECS)
+    SecCacheData = get_cachable_data(API2, CACHE_TTL_SECS)
     leaderboard = json.decode(CacheData)
+    leaderboard2 = json.decode(SecCacheData)
 
     Title = leaderboard["sports"][0]["leagues"][0]["shortName"]
 
@@ -71,9 +79,21 @@ def main(config):
 
     # Check if its a major and show a different color in the title bar
     TitleColor = getMajorColor(TournamentID)
-    #print(TitleColor)
 
+    # Get Tournament Name and make it more readable for the Tidbyt
     TournamentName = leaderboard["sports"][0]["leagues"][0]["events"][i]["name"]
+
+    if TournamentID not in THE_EXCEPTIONS:
+        TournamentName = TournamentName.replace("The ", "")
+        TournamentName = TournamentName.replace("THE ", "")
+
+    RevisedName = getTournamentName(TournamentID)
+
+    if RevisedName == "None":
+        TournamentName = TournamentName[:10]
+        TournamentName = TournamentName.rstrip()
+    else:
+        TournamentName = RevisedName
 
     if (leaderboard):
         # where the tournament is at - pre, in progress, post
@@ -82,6 +102,7 @@ def main(config):
         # if in progress or completed tournament
         if status == "in" or status == "post":
             entries = leaderboard["sports"][0]["leagues"][0]["events"][i]["competitors"]
+            entries2 = leaderboard2["events"][i]["competitions"][0]["competitors"]
             stage = leaderboard["sports"][0]["leagues"][0]["events"][i]["fullStatus"]["type"]["detail"]
             state = leaderboard["sports"][0]["leagues"][0]["events"][i]["fullStatus"]["type"]["state"]
 
@@ -105,14 +126,14 @@ def main(config):
                             render.Column(
                                 children = [
                                     render.Column(
-                                        getPlayerScore(x, entries, TournamentName, TitleColor, stage, state),
+                                        getPlayerScore(x, entries, TournamentName, TitleColor, ColorGradient, stage, state),
                                     ),
                                 ],
                             ),
                             render.Column(
                                 children = [
                                     render.Column(
-                                        children = getPlayerProgress(x, entries, TournamentName, TitleColor, stage, state, timezone),
+                                        children = getPlayerProgress(x, entries, entries2, TournamentName, TitleColor, ColorGradient, stage, state, timezone),
                                     ),
                                 ],
                             ),
@@ -196,18 +217,8 @@ def main(config):
 
     return []
 
-def getPlayerScore(x, s, Title, TitleColor, stage, state):
+def getPlayerScore(x, s, Title, TitleColor, ColorGradient, stage, state):
     # Build the 4 rows out with player names & scores
-
-    # Remove "The" or "THE" if its in the title, but not for "The Open", its a major so we treat it with respect...and it will fit anyway
-    if Title.startswith("The") or Title.startswith("THE"):
-        if Title != "The Open":
-            Title = Title.replace("The ", "")
-            Title = Title.replace("THE ", "")
-
-    # keep first 10 chars of the tournament name, then remove any extra " " at the end
-    Title = Title[:10]
-    Title = Title.rstrip()
 
     mainFont = "CG-pixel-3x5-mono"
     output = []
@@ -236,7 +247,7 @@ def getPlayerScore(x, s, Title, TitleColor, stage, state):
                 HolesCompleted = 18
 
             # Players who have completed their round are shown in white, in progress rounds are in yellow which slowly transitions to white as the round progresses.
-            playerFontColor = getPlayerFontColor(HolesCompleted)
+            playerFontColor = getPlayerFontColor(HolesCompleted, ColorGradient)
 
             # if tournament is over, show winner in blue
             if (i + x) == 0 and stage == "F":
@@ -279,18 +290,8 @@ def getPlayerScore(x, s, Title, TitleColor, stage, state):
 
     return output
 
-def getPlayerProgress(x, s, Title, TitleColor, stage, state, timezone):
+def getPlayerProgress(x, s, t, Title, TitleColor, ColorGradient, stage, state, timezone):
     # Build the 4 rows out with player names & how many holes completed or tee times
-
-    # Remove "The" or "THE" if its in the title, but not for "The Open", its a major so we treat it with respect...and it will fit anyway
-    if Title.startswith("The") or Title.startswith("THE"):
-        if Title != "The Open":
-            Title = Title.replace("The ", "")
-            Title = Title.replace("THE ", "")
-
-    # keep first 10 chars of the tournament name, then remove any extra " " at the end
-    Title = Title[:10]
-    Title = Title.rstrip()
 
     mainFont = "CG-pixel-3x5-mono"
     output = []
@@ -306,6 +307,7 @@ def getPlayerProgress(x, s, Title, TitleColor, stage, state, timezone):
         if i + x < len(s):
             playerName = s[i + x]["lastName"]
             playerState = s[i + x]["status"]["state"]
+            playerID = s[i + x]["id"]
 
             # check if they've played at least 1 hole this round
             if (s[i + x]["status"]["thru"]) > 0:
@@ -320,29 +322,44 @@ def getPlayerProgress(x, s, Title, TitleColor, stage, state, timezone):
 
             # if the player hasn't started their round, show their tee time in your local time
             # also check its not a playoff
+            # Now added to show score for the round if less than 12 hrs until tee time
             if playerState == "pre":
                 if s[i + x]["status"]["playoff"] != True:
                     TeeTime = s[i + x]["status"]["teeTime"]
                     TeeTimeFormat = time.parse_time(TeeTime, format = "2006-01-02T15:04Z").in_location(timezone)
-                    TeeTime = TeeTimeFormat.format("15:04")
-                    ProgressStr = TeeTime
+                    TimeDiff = TeeTimeFormat - time.now()
+                    if TimeDiff.hours < 12:
+                        TeeTime = TeeTimeFormat.format("15:04")
+                        ProgressStr = TeeTime
+                    else:
+                        RoundNumber = len(t[0]["linescores"]) - 2
+                        for i in range(0, len(t), 1):
+                            if playerID == t[i]["id"]:
+                                RoundScore = t[i]["linescores"][RoundNumber]["value"]
+                                ProgressStr = str(int(RoundScore))
                 else:
                     ProgressStr = "PO"
 
             # if the player's round is underway, show how many completed holes
             # also check its not a playoff
-            if playerState == "in" or playerState == "post":
+            if playerState == "in":
                 if s[i + x]["status"]["playoff"] != True:
                     ProgressStr = str(HolesCompleted)
                 else:
                     ProgressStr = "PO"
 
-            # if the player's round is completed, show "F"
+            # if the player's round is completed, show their score
             if playerState == "post":
-                ProgressStr = "F"
+                RoundNumber = len(t[0]["linescores"]) - 2
+                for i in range(0, len(t), 1):
+                    if playerID == t[i]["id"]:
+                        RoundScore = t[i]["linescores"][RoundNumber]["value"]
+                        ProgressStr = str(int(RoundScore))
 
-            # Players who have completed their round are shown in white, in progress rounds are in yellow which slowly transitions to white as the round progresses.
-            playerFontColor = getPlayerFontColor(HolesCompleted)
+            # If ColorGradient is selected...
+            # Players who have completed their round are shown in white, in progress rounds are in dark yellow/orange which slowly transitions to white as the round progresses.
+            # Otherwise in progress is a single shade of yellow
+            playerFontColor = getPlayerFontColor(HolesCompleted, ColorGradient)
 
             # show condensed player names (down to 10 due to potential tee time being shown, so need more room) and how many holes they've played
             player = render.Row(
@@ -381,35 +398,70 @@ def getPlayerProgress(x, s, Title, TitleColor, stage, state, timezone):
             output.extend([player])
     return output
 
-def getPlayerFontColor(HolesCompleted):
-    if HolesCompleted == 18:
-        playerFontColor = "#fff"
-    elif HolesCompleted == 17:
-        playerFontColor = "#ffa"
-    elif HolesCompleted == 16:
-        playerFontColor = "#ff5"
-    elif HolesCompleted == 14 or HolesCompleted == 15:
-        playerFontColor = "#ff0"
-    elif HolesCompleted == 12 or HolesCompleted == 13:
-        playerFontColor = "#fe0"
-    elif HolesCompleted == 10 or HolesCompleted == 11:
-        playerFontColor = "#fd0"
-    elif HolesCompleted == 8 or HolesCompleted == 9:
-        playerFontColor = "#fc0"
-    elif HolesCompleted == 6 or HolesCompleted == 7:
-        playerFontColor = "#fb0"
-    elif HolesCompleted == 4 or HolesCompleted == 5:
-        playerFontColor = "#fa0"
-    elif HolesCompleted == 2 or HolesCompleted == 3:
-        playerFontColor = "#f90"
-    elif HolesCompleted == 1:
-        playerFontColor = "#f80"
-    elif HolesCompleted == 0:
-        playerFontColor = "#4ec9b0"
-    else:
-        playerFontColor = ""
+def getPlayerFontColor(HolesCompleted, ColorGradient):
+    playerFontColor = ""
+
+    if ColorGradient == "False":
+        if HolesCompleted == 18:
+            playerFontColor = "#fff"
+        elif HolesCompleted == 0:
+            playerFontColor = "#4ec9b0"
+        else:
+            playerFontColor = "#ff0"
+
+    elif ColorGradient == "True":
+        if HolesCompleted == 18:
+            playerFontColor = "#fff"
+        elif HolesCompleted == 17:
+            playerFontColor = "#ffa"
+        elif HolesCompleted == 16:
+            playerFontColor = "#ff5"
+        elif HolesCompleted == 14 or HolesCompleted == 15:
+            playerFontColor = "#ff0"
+        elif HolesCompleted == 12 or HolesCompleted == 13:
+            playerFontColor = "#fe0"
+        elif HolesCompleted == 10 or HolesCompleted == 11:
+            playerFontColor = "#fd0"
+        elif HolesCompleted == 8 or HolesCompleted == 9:
+            playerFontColor = "#fc0"
+        elif HolesCompleted == 6 or HolesCompleted == 7:
+            playerFontColor = "#fb0"
+        elif HolesCompleted == 4 or HolesCompleted == 5:
+            playerFontColor = "#fa0"
+        elif HolesCompleted == 2 or HolesCompleted == 3:
+            playerFontColor = "#f90"
+        elif HolesCompleted == 1:
+            playerFontColor = "#f80"
+        elif HolesCompleted == 0:
+            playerFontColor = "#4ec9b0"
+        else:
+            playerFontColor = ""
 
     return playerFontColor
+
+def getTournamentName(ID):
+    # Provide friendly shortened name
+    # For the rest of the year, will update for next year
+    TournamentName = ""
+
+    if ID == "401465538":
+        TournamentName = "Barbasol"
+    elif ID == "401465537":
+        TournamentName = "Scottish"
+    elif ID == "401465542":
+        TournamentName = "Wyndham"
+    elif ID == "401465543":
+        TournamentName = "FedEx St.J"
+    elif ID == "401465544":
+        TournamentName = "BMW Champ"
+    elif ID == "401552854":
+        TournamentName = "Fortinet"
+    elif ID == "401552856":
+        TournamentName = "Shriners"
+    else:
+        TournamentName = "None"
+
+    return TournamentName
 
 def getMajorColor(ID):
     # check if its a major and if so show different title bar color
@@ -462,6 +514,17 @@ RotationOptions = [
     ),
 ]
 
+ColorGradientOptions = [
+    schema.Option(
+        display = "Color Gradient",
+        value = "True",
+    ),
+    schema.Option(
+        display = "Single Color",
+        value = "False",
+    ),
+]
+
 def get_schema():
     return schema.Schema(
         version = "1",
@@ -473,6 +536,14 @@ def get_schema():
                 icon = "gear",
                 default = RotationOptions[1].value,
                 options = RotationOptions,
+            ),
+            schema.Dropdown(
+                id = "ColorGradient",
+                name = "Show in progress round as ...",
+                desc = "How to show in progress rounds",
+                icon = "gear",
+                default = ColorGradientOptions[0].value,
+                options = ColorGradientOptions,
             ),
             schema.Toggle(
                 id = "OppFieldToggle",


### PR DESCRIPTION
# Description
**A few updates for the golf fans!**

- Users have a choice of showing the in progress rounds in a single shade of yellow or they can continue to use the color gradient option. The single color is the default 
- Completed rounds will now show their final score, rather than "F" and the scores will be displayed until 12hrs from the tee times so you have a chance to see them
- Allowed for formatting of the tournament names so they read better on the Tidbyt

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f665f31</samp>

### Summary
🎨📊📝

<!--
1.  🎨 This emoji represents the new option to show in progress rounds as a color gradient or a single color, which is a visual enhancement that allows users to customize the appearance of the app and see the variation of scores more easily.
2.  📊 This emoji represents the improvement of the display of scores for completed rounds, which is a data enhancement that allows users to see more information about the players' performance and compare them with others.
3.  📝 This emoji represents the improvement of the formatting of tournament names, which is a text enhancement that allows users to see the names of the tournaments more clearly and consistently.
-->
Updated `pga_tour` app to version 2.3, which adds a new display option and enhances the score and tournament information. The app now uses two API endpoints to fetch more data.

> _Oh, we're the crew of the app version two_
> _And we've added some features for you_
> _On the count of three, we'll pull the API_
> _And show you the scores and the hue_

### Walkthrough
*  Update comment at the top of `pga_tour.star` to reflect new features and changes in version 2.3 ([link](https://github.com/tidbyt/community/pull/1654/files?diff=unified&w=0#diff-a03b8905919094b4578f67df044fa3753e58ba27788b134404c13e79a61ff75bL35-R38))
*  Add new constants API2 and THE_EXCEPTIONS to store the URL of a second API endpoint and a list of tournament IDs that need special treatment for their names ([link](https://github.com/tidbyt/community/pull/1654/files?diff=unified&w=0#diff-a03b8905919094b4578f67df044fa3753e58ba27788b134404c13e79a61ff75bL45-R52))
*  Add new variables ColorGradient, SecCacheData, and leaderboard2 to get the user's preference, the cached data, and the JSON data from the second API endpoint ([link](https://github.com/tidbyt/community/pull/1654/files?diff=unified&w=0#diff-a03b8905919094b4578f67df044fa3753e58ba27788b134404c13e79a61ff75bL57-R67))
*  Move and modify the logic for checking if the tournament is a major and getting the title color and the tournament name using the getTournamentName function ([link](https://github.com/tidbyt/community/pull/1654/files?diff=unified&w=0#diff-a03b8905919094b4578f67df044fa3753e58ba27788b134404c13e79a61ff75bL74-R97))
*  Add new variable entries2 to get the list of competitors from the second API endpoint for the current event ([link](https://github.com/tidbyt/community/pull/1654/files?diff=unified&w=0#diff-a03b8905919094b4578f67df044fa3753e58ba27788b134404c13e79a61ff75bR105))
*  Modify the getPlayerScore, getPlayerProgress, and getPlayerFontColor functions to take the ColorGradient variable as an argument and use it to show the score for the round or the color gradient option for in progress rounds ([link](https://github.com/tidbyt/community/pull/1654/files?diff=unified&w=0#diff-a03b8905919094b4578f67df044fa3753e58ba27788b134404c13e79a61ff75bL108-R129), [link](https://github.com/tidbyt/community/pull/1654/files?diff=unified&w=0#diff-a03b8905919094b4578f67df044fa3753e58ba27788b134404c13e79a61ff75bL115-R136), [link](https://github.com/tidbyt/community/pull/1654/files?diff=unified&w=0#diff-a03b8905919094b4578f67df044fa3753e58ba27788b134404c13e79a61ff75bL239-R250))
*  Remove the logic for removing "The" or "THE" from the tournament name from the getPlayerScore and getPlayerProgress functions, as it was already done in the main function ([link](https://github.com/tidbyt/community/pull/1654/files?diff=unified&w=0#diff-a03b8905919094b4578f67df044fa3753e58ba27788b134404c13e79a61ff75bL199-R222), [link](https://github.com/tidbyt/community/pull/1654/files?diff=unified&w=0#diff-a03b8905919094b4578f67df044fa3753e58ba27788b134404c13e79a61ff75bL282-R295))
*  Add new variable playerID to get the ID of the current player from the first API endpoint ([link](https://github.com/tidbyt/community/pull/1654/files?diff=unified&w=0#diff-a03b8905919094b4578f67df044fa3753e58ba27788b134404c13e79a61ff75bR310))
*  Modify the logic for showing the tee time or the score for the round for the player who hasn't started their round, using the data from the second API endpoint ([link](https://github.com/tidbyt/community/pull/1654/files?diff=unified&w=0#diff-a03b8905919094b4578f67df044fa3753e58ba27788b134404c13e79a61ff75bL323-R339))
*  Modify the logic for showing the number of completed holes or the score for the round for the player whose round is underway or completed, using the data from the second API endpoint ([link](https://github.com/tidbyt/community/pull/1654/files?diff=unified&w=0#diff-a03b8905919094b4578f67df044fa3753e58ba27788b134404c13e79a61ff75bL334-R345), [link](https://github.com/tidbyt/community/pull/1654/files?diff=unified&w=0#diff-a03b8905919094b4578f67df044fa3753e58ba27788b134404c13e79a61ff75bL340-R362))
*  Modify the getPlayerFontColor function to return an empty string as the default value for the player font color ([link](https://github.com/tidbyt/community/pull/1654/files?diff=unified&w=0#diff-a03b8905919094b4578f67df044fa3753e58ba27788b134404c13e79a61ff75bL384-R465))
*  Add new function getTournamentName to return a revised name for some tournaments based on their ID ([link](https://github.com/tidbyt/community/pull/1654/files?diff=unified&w=0#diff-a03b8905919094b4578f67df044fa3753e58ba27788b134404c13e79a61ff75bL384-R465))
*  Add new list ColorGradientOptions and new schema.Dropdown element to the config schema to allow the user to choose the color gradient preference ([link](https://github.com/tidbyt/community/pull/1654/files?diff=unified&w=0#diff-a03b8905919094b4578f67df044fa3753e58ba27788b134404c13e79a61ff75bR517-R527), [link](https://github.com/tidbyt/community/pull/1654/files?diff=unified&w=0#diff-a03b8905919094b4578f67df044fa3753e58ba27788b134404c13e79a61ff75bR540-R547))


