### PR TITLE
[Fuzzy Clock] Fix a minor whoopsie in the English locali[zs]ations

### DIFF
--- a/apps/fuzzyclock/fuzzy_clock.star
+++ b/apps/fuzzyclock/fuzzy_clock.star
@@ -154,7 +154,7 @@ patternsPerLang = {
         50: "ZEHN,VOR,{next_hour}",
         55: "FÜNF,VOR,{next_hour}",
     },
-    "en-GB": {
+    "en-US": {
         0: "{hour},O’CLOCK",
         5: "FIVE,PAST,{hour}",
         10: "TEN,PAST,{hour}",
@@ -168,7 +168,7 @@ patternsPerLang = {
         50: "TEN,TILL,{next_hour}",
         55: "FIVE,TILL,{next_hour}",
     },
-    "en-US": {
+    "en-GB": {
         0: "{hour},O’CLOCK",
         5: "FIVE,PAST,{hour}",
         10: "TEN,PAST,{hour}",


### PR DESCRIPTION
# Description
Swap "en-US" and "en-GB" labels 🙈 

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c9fe6ba</samp>

### Summary
🇬🇧🇺🇸🕒

<!--
1.  🇬🇧 - This emoji represents the British English language code and spelling, which is one of the main aspects of this pull request.
2.  🇺🇸 - This emoji represents the American English language code and spelling, which is another main aspect of this pull request.
3.  🕒 - This emoji represents the fuzzy clock app and the time display, which is the functionality that this pull request affects.
-->
This pull request fixes language issues in the `fuzzy_clock` app. It allows users to choose between British or American English for the time display.

> _Time is running out, the clock is ticking_
> _Don't let them fool you with their `lang` code tricks_
> _We know the difference between British and American_
> _We spell our words with honour and color, we are the fuzzy clock fans_

### Walkthrough
* Fix typo in language code for American English ([link](https://github.com/tidbyt/community/pull/1658/files?diff=unified&w=0#diff-8fb3dcfaadcf41d62c73625b4184543811a3a96d7cef336fb39226487e3d0d40L157-R157))
* Swap language codes for British and American English to match spelling and pronunciation of "O’CLOCK" and "TILL" ([link](https://github.com/tidbyt/community/pull/1658/files?diff=unified&w=0#diff-8fb3dcfaadcf41d62c73625b4184543811a3a96d7cef336fb39226487e3d0d40L171-R171))


