### PR TITLE
Bug fix: ATP & WTA Tennis apps

### DIFF
--- a/apps/atptennis/atp_tennis.star
+++ b/apps/atptennis/atp_tennis.star
@@ -43,6 +43,9 @@ Updated determination for completed match, using "description" and not "state"
 Now adding suspended matches in the In Progress list
 Suspended matches shown in blue
 Scheduled matches now in order of play - earliest to latest
+
+v1.7.1
+Bug fix - Retired matches were not being captured after changing completed match determination to description
 """
 
 load("encoding/json.star", "json")
@@ -177,8 +180,10 @@ def main(config):
                 # check if we are between the start & end date of the tournament
                 if diffTournStart.hours < 0 and diffTournEnd.hours > 0:
                     for y in range(0, len(ATP_JSON["events"][x]["groupings"][0]["competitions"]), 1):
-                        # if the match is completed ("post") and the start time of the match was < 24 hrs ago, lets add it to the list of completed matches
-                        if ATP_JSON["events"][x]["groupings"][0]["competitions"][y]["status"]["type"]["description"] == "Final":
+                        MatchState = ATP_JSON["events"][x]["groupings"][0]["competitions"][y]["status"]["type"]["description"]
+
+                        # if the match is completed and the start time of the match was < 24 hrs ago, lets add it to the list of completed matches
+                        if MatchState == "Final" or MatchState == "Retired":
                             MatchTime = ATP_JSON["events"][EventIndex]["groupings"][0]["competitions"][y]["date"]
                             MatchTime = time.parse_time(MatchTime, format = "2006-01-02T15:04Z")
                             diff = MatchTime - now
@@ -488,11 +493,12 @@ def getCompletedMatches(SelectedTourneyID, EventIndex, CompletedMatchList, JSON)
             # pop the index from the list and go straight to that match
             x = CompletedMatchList.pop()
 
+            # print(x)
             Player1_Name = JSON["events"][EventIndex]["groupings"][0]["competitions"][x]["competitors"][0]["athlete"]["shortName"]
             Player2_Name = JSON["events"][EventIndex]["groupings"][0]["competitions"][x]["competitors"][1]["athlete"]["shortName"]
 
             #print(Player1_Name)
-            #print(x)
+
             # display the match winner in yellow, however sometimes both are false even when the match is completed
             Player1_Winner = JSON["events"][EventIndex]["groupings"][0]["competitions"][x]["competitors"][0]["winner"]
             Player2_Winner = JSON["events"][EventIndex]["groupings"][0]["competitions"][x]["competitors"][1]["winner"]

--- a/apps/wtatennis/wta_tennis.star
+++ b/apps/wtatennis/wta_tennis.star
@@ -41,6 +41,9 @@ Updated determination for completed match, using "description" and not "state"
 Now adding suspended matches in the In Progress list
 Suspended matches shown in blue
 Scheduled matches now in order of play - earliest to latest
+
+v1.7.1
+Bug fix - Retired matches were not being captured after changing completed match determination to description
 """
 
 load("encoding/json.star", "json")
@@ -181,8 +184,10 @@ def main(config):
                     if WTA_JSON["events"][x]["groupings"][0]["grouping"]["slug"] == "mens-singles":
                         GroupingsID = 1
                     for y in range(0, len(WTA_JSON["events"][x]["groupings"][GroupingsID]["competitions"]), 1):
-                        # if the match is completed ("post") and its a singles match ("athlete") and the start time of the match was < 24 hrs ago, lets add it to the list of completed matches
-                        if WTA_JSON["events"][x]["groupings"][GroupingsID]["competitions"][y]["status"]["type"]["description"] == "Final":
+                        MatchState = WTA_JSON["events"][x]["groupings"][GroupingsID]["competitions"][y]["status"]["type"]["description"]
+
+                        # if the match is completed and the start time of the match was < 24 hrs ago, lets add it to the list of completed matches
+                        if MatchState == "Final" or MatchState == "Retired":
                             MatchTime = WTA_JSON["events"][EventIndex]["groupings"][GroupingsID]["competitions"][y]["date"]
                             MatchTime = time.parse_time(MatchTime, format = "2006-01-02T15:04Z")
                             diff = MatchTime - now


### PR DESCRIPTION
# Description
When you fix one bug , but create another....

Matches that ended with a retirement were not being captured after the latest update, fixed now

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c772935</samp>

### Summary
🐛🎾🧹

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of both pull requests.
2.  🎾 - This emoji represents tennis, which is the domain of both apps that are modified by the pull requests.
3.  🧹 - This emoji represents cleaning, which is a secondary effect of both pull requests, as they remove some unnecessary print statements and update some comments.
-->
This pull request fixes a bug in the `atp_tennis.star` and `wta_tennis.star` apps that affected the display of retired matches. It also removes some unnecessary print statements and improves code consistency.

> _Sing, O Muse, of the swift and skillful coder_
> _Who fixed the bug that plagued the tennis apps_
> _And made the stars of ATP and WTA shine brighter_
> _By showing all the matches, even those that end in laps_

### Walkthrough
*  Fix bug in atp_tennis.star and wta_tennis.star apps to include retired matches in completed match list ([link](https://github.com/tidbyt/community/pull/1662/files?diff=unified&w=0#diff-2fe7726a8148e3fb23a64991e8b2661bd9c098395de1a2f1ea0092f21db623bcL180-R186), [link](https://github.com/tidbyt/community/pull/1662/files?diff=unified&w=0#diff-bacac371ef4450963bfae6cc2618e0ce8278c5d02f808e88e0cff7243efed67dL184-R190))
*  Update version history comments in both apps to reflect bug fix ([link](https://github.com/tidbyt/community/pull/1662/files?diff=unified&w=0#diff-2fe7726a8148e3fb23a64991e8b2661bd9c098395de1a2f1ea0092f21db623bcR46-R48), [link](https://github.com/tidbyt/community/pull/1662/files?diff=unified&w=0#diff-bacac371ef4450963bfae6cc2618e0ce8278c5d02f808e88e0cff7243efed67dR44-R46))
*  Remove and relocate print statements in atp_tennis.star app for code clarity ([link](https://github.com/tidbyt/community/pull/1662/files?diff=unified&w=0#diff-2fe7726a8148e3fb23a64991e8b2661bd9c098395de1a2f1ea0092f21db623bcL491-R501))


