### PR TITLE
New app: SF Fog Today

### DIFF
--- a/apps/sffogtoday/manifest.yaml
+++ b/apps/sffogtoday/manifest.yaml
@@ -1,0 +1,8 @@
+---
+id: sf-fog-today
+name: SF Fog Today
+summary: Satellite fog info for SF
+desc: Displays GOES-16 satellite fog image for San Francisco, from fog.today.
+author: Matt Broussard
+fileName: sf_fog_today.star
+packageName: sffogtoday

--- a/apps/sffogtoday/sf_fog_today.star
+++ b/apps/sffogtoday/sf_fog_today.star
@@ -1,0 +1,52 @@
+"""
+Applet: SF Fog Today
+Summary: Satellite fog info for SF
+Description: Displays GOES-16 satellite fog image for San Francisco, from fog.today.
+Author: Matt Broussard
+"""
+
+load("cache.star", "cache")
+load("http.star", "http")
+load("render.star", "render")
+
+IMAGE_URL = "https://fog.today/current.jpg"
+NATIVE_RES = (1600, 2048)
+NATIVE_ORIGIN = (628, 675)
+DISPLAY_SCALE = 0.5  # scale by half so that effective area is 128x64 in the original image
+
+def main():
+    image_src = load_image()
+    if not image_src:
+        return render.Root(
+            child = render.WrappedText("Error loading fog.today :("),
+        )
+
+    return render.Root(
+        child = render.Padding(
+            child = render.Image(
+                src = image_src,
+                width = int(NATIVE_RES[0] * DISPLAY_SCALE),
+                height = int(NATIVE_RES[1] * DISPLAY_SCALE),
+            ),
+            pad = (
+                -int(NATIVE_ORIGIN[0] * DISPLAY_SCALE),
+                -int(NATIVE_ORIGIN[1] * DISPLAY_SCALE),
+                0,
+                0,
+            ),
+        ),
+    )
+
+def load_image():
+    image_src = cache.get(IMAGE_URL)
+    if image_src != None:
+        return image_src
+
+    resp = http.get(IMAGE_URL)
+    if resp.status_code != 200:
+        return None
+
+    image_src = resp.body()
+
+    cache.set(IMAGE_URL, image_src, ttl_seconds = 60)
+    return image_src


### PR DESCRIPTION
This adds a new app which display the current satellite (from GOES-16) fog cover image from @loganwilliams's [fog.today](https://fog.today/) website, cropped into main part of San Francisco. Image data is cached to be requested at most once per minute.

In the future it might be nice to transform the image a bit (increase contrast so the areas with no fog cover are black pixels) or maybe even use a GOES image directly with a map border overlay pixel-optimized for the Tidbyt, but both of these require image manipulation that is currently impossible with the APIs available from Pixlet.

![sf_fog_today](https://github.com/tidbyt/community/assets/3347176/d4c7256d-cc5c-4e83-ad2b-ac83a52eccda)
