### PR TITLE
Bug fix: PGA Tour

### DIFF
--- a/apps/pgatour/pga_tour.star
+++ b/apps/pgatour/pga_tour.star
@@ -36,6 +36,9 @@ Give user a choice of single color for the in progress rounds or use the color g
 Now showing scores for completed rounds rather than "F" 
 Removed tournament name formatting from both player/score related functions - should add efficiency?
 Added function to revise some tournament names to make them more readable and/or fit the width of the Tidbyt better
+
+v2.3.1
+Fixed bug regarding opposite field events
 """
 
 load("encoding/json.star", "json")
@@ -70,19 +73,22 @@ def main(config):
 
     # Check if there is an opposite field event, happens 4 times a season
     # Get the ID of the first event listed in the API
-    TournamentID = leaderboard["sports"][0]["leagues"][0]["events"][0]["id"]
-    i = OppositeFieldCheck(TournamentID)
+    FirstTournamentID = leaderboard["sports"][0]["leagues"][0]["events"][0]["id"]
+    i = OppositeFieldCheck(FirstTournamentID)
 
     # if user wants to see opposite event
     if i == 1 and OppField == True:
         i = 0
 
+    # Get Tournament Name and ID
+    TournamentName = leaderboard["sports"][0]["leagues"][0]["events"][i]["name"]
+    PreTournamentName = TournamentName
+    TournamentID = leaderboard["sports"][0]["leagues"][0]["events"][i]["id"]
+
     # Check if its a major and show a different color in the title bar
     TitleColor = getMajorColor(TournamentID)
 
-    # Get Tournament Name and make it more readable for the Tidbyt
-    TournamentName = leaderboard["sports"][0]["leagues"][0]["events"][i]["name"]
-
+    # Make it more readable
     if TournamentID not in THE_EXCEPTIONS:
         TournamentName = TournamentName.replace("The ", "")
         TournamentName = TournamentName.replace("THE ", "")
@@ -200,7 +206,7 @@ def main(config):
                             main_align = "space_between",
                             cross_align = "end",
                             children = [
-                                render.Marquee(width = 64, height = 12, child = render.Text(content = TournamentName + " - " + Location, color = "#FFF", font = mainFont)),
+                                render.Marquee(width = 64, height = 12, child = render.Text(content = PreTournamentName + " - " + Location, color = "#FFF", font = mainFont)),
                             ],
                         ),
                         render.Row(


### PR DESCRIPTION
# Description
Fixed bug regarding opposite field events not displaying correctly and the modified names being used in the pre-tournament display, which only needs to be used during play 

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2b381c5</samp>

### Summary
🐛📝🏆

<!--
1.  🐛 - This emoji is commonly used to represent a bug fix, and it fits well with the first change of fixing a bug with opposite field events.
2.  📝 - This emoji is often used to indicate documentation, writing, or editing, and it suits the second change of improving the code readability and variable naming, which are aspects of code quality and clarity.
3.  🏆 - This emoji is a symbol of achievement, success, or competition, and it matches the third change of displaying the full tournament name on the marquee for the PGA Tour app, which is related to the theme of golf and sports.
-->
Fix bug and enhance display for `pga_tour` app. The app now handles opposite field events correctly, shows the full tournament name on the marquee, and has more readable and consistent code.

> _Oh we're the crew of the PGA Tour app_
> _And we work hard to fix every gap_
> _We heave away on the `oppositeField` bug_
> _And we show the full name on the marquee with a tug_

### Walkthrough
*  Document bug fix for opposite field events in changelog ([link](https://github.com/tidbyt/community/pull/1668/files?diff=unified&w=0#diff-a03b8905919094b4578f67df044fa3753e58ba27788b134404c13e79a61ff75bR39-R41))
*  Rename `TournamentID` to `FirstTournamentID` to avoid confusion ([link](https://github.com/tidbyt/community/pull/1668/files?diff=unified&w=0#diff-a03b8905919094b4578f67df044fa3753e58ba27788b134404c13e79a61ff75bL73-R77))
*  Reorder code to get tournament name and ID before checking major status and color ([link](https://github.com/tidbyt/community/pull/1668/files?diff=unified&w=0#diff-a03b8905919094b4578f67df044fa3753e58ba27788b134404c13e79a61ff75bL80-R91), [link](https://github.com/tidbyt/community/pull/1668/files?diff=unified&w=0#diff-a03b8905919094b4578f67df044fa3753e58ba27788b134404c13e79a61ff75bL203-R209))
*  Use `PreTournamentName` instead of `TournamentName` in marquee to show full tournament name ([link](https://github.com/tidbyt/community/pull/1668/files?diff=unified&w=0#diff-a03b8905919094b4578f67df044fa3753e58ba27788b134404c13e79a61ff75bL203-R209))


