### PR TITLE
sffogtoday: use http cache

### DIFF
--- a/apps/sffogtoday/sf_fog_today.star
+++ b/apps/sffogtoday/sf_fog_today.star
@@ -5,7 +5,6 @@ Description: Displays GOES-16 satellite fog image for San Francisco, from fog.to
 Author: Matt Broussard
 """
 
-load("cache.star", "cache")
 load("http.star", "http")
 load("render.star", "render")
 
@@ -38,15 +37,8 @@ def main():
     )
 
 def load_image():
-    image_src = cache.get(IMAGE_URL)
-    if image_src != None:
-        return image_src
-
-    resp = http.get(IMAGE_URL)
+    resp = http.get(IMAGE_URL, ttl_seconds = 60)
     if resp.status_code != 200:
         return None
 
-    image_src = resp.body()
-
-    cache.set(IMAGE_URL, image_src, ttl_seconds = 60)
-    return image_src
+    return resp.body()


### PR DESCRIPTION
# Description
Replace this with a description of your changes.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5c6202f</samp>

### Summary
🚀🧹🌫️

<!--
1.  🚀 - This emoji conveys the idea of speed, performance, and launching something new or improved. It can be used to highlight the enhancement of the app's functionality and efficiency by using the built-in caching feature.
2.  🧹 - This emoji conveys the idea of cleaning, tidying, and removing unnecessary or unwanted things. It can be used to emphasize the deletion of the unused `cache` module and its functions, which simplified the code and reduced the dependencies.
3.  🌫️ - This emoji conveys the idea of fog, mist, or haze, which is the main topic of the app. It can be used to remind the users or developers of the app's purpose and functionality, and to add some visual appeal and relevance to the changes.
-->
Enhanced the `sf_fog_today` app by leveraging the `http` caching feature and removing unused code.

> _We're sailing on the web with `sf_fog_today`_
> _We need to fetch the data without delay_
> _We use the `http` cache to speed our way_
> _And toss the `cache` module in the bay_

### Walkthrough
*  Simplify image loading and caching with `http.get` ([link](https://github.com/tidbyt/community/pull/1669/files?diff=unified&w=0#diff-272735703f9d1fed925ed38eceda5e9e924f48b504474c8fe782076c39de3d76L8), [link](https://github.com/tidbyt/community/pull/1669/files?diff=unified&w=0#diff-272735703f9d1fed925ed38eceda5e9e924f48b504474c8fe782076c39de3d76L41-R44))
*  Remove `cache` module and its functions as they are no longer needed ([link](https://github.com/tidbyt/community/pull/1669/files?diff=unified&w=0#diff-272735703f9d1fed925ed38eceda5e9e924f48b504474c8fe782076c39de3d76L8), [link](https://github.com/tidbyt/community/pull/1669/files?diff=unified&w=0#diff-272735703f9d1fed925ed38eceda5e9e924f48b504474c8fe782076c39de3d76L41-R44))
*  Update `apps/sffogtoday/sf_fog_today.star` to use the new image loading function ([link](https://github.com/tidbyt/community/pull/1669/files?diff=unified&w=0#diff-272735703f9d1fed925ed38eceda5e9e924f48b504474c8fe782076c39de3d76L41-R44))


