### PR TITLE
UV App: demo mode

### DIFF
--- a/apps/uv/uv.star
+++ b/apps/uv/uv.star
@@ -18,6 +18,8 @@ OPENUV_URL = "https://api.openuv.io/api/v1/uv"
 OPENWEATHER_REFRESH_RATE = 60 * 60  # 60 minutes in seconds
 OPENWEATHERMAP_URL = "https://api.openweathermap.org/data/3.0/onecall"
 
+DEMO_DATA = 3, 11  # what to render when the app isn't configured
+
 uv_colors = [
     "#299501",
     "#299501",
@@ -34,26 +36,31 @@ uv_colors = [
 ]
 
 def main(config):
-    if config.get("api_key") == None:
-        return render.Root(render.WrappedText("Fix config:\nMissing\nAPI key"))
-    if config.get("location") == None:
-        return render.Root(render.WrappedText("Fix config:\nMissing\nlocation"))
-
-    service = config.get("service", "openweather")
-
     current_uv, max_uv = None, None
 
-    if service == "openweather":
-        current_uv, max_uv = get_openweather_uv(config)
+    if config.get("api_key") == None and config.get("location") == None:
+        # demo mode
+        current_uv, max_uv = DEMO_DATA
 
-        if current_uv == None and max_uv == None:
-            return render.Root(render.WrappedText("OpenWeather needs OneCall subscription"))
+    else:
+        if config.get("api_key") == None or config.get("api_key") == "":
+            return render.Root(render.WrappedText("Fix config:\nMissing\nAPI key"))
+        if config.get("location") == None:
+            return render.Root(render.WrappedText("Fix config:\nMissing\nlocation"))
 
-    elif service == "openuv":
-        current_uv, max_uv = get_openuv_uv(config)
+        service = config.get("service", "openweather")
 
-    if current_uv == None or max_uv == None:
-        return []
+        if service == "openweather":
+            current_uv, max_uv = get_openweather_uv(config)
+
+            if current_uv == None and max_uv == None:
+                return render.Root(render.WrappedText("OpenWeather needs OneCall subscription"))
+
+        elif service == "openuv":
+            current_uv, max_uv = get_openuv_uv(config)
+
+        if current_uv == None or max_uv == None:
+            return []
 
     columns = [
         render_uv_circle_column("UV", current_uv),


### PR DESCRIPTION
# Description
Display demo data when the UV app is unconfigured (instead of an error message)

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 420bcff</samp>

### Summary
🌞🎭🆕

<!--
1.  🌞 - This emoji represents the UV feature of the app, which is the main functionality that the demo mode showcases.
2.  🎭 - This emoji represents the demo mode itself, which is a way of pretending or acting out the app behavior without the real data.
3.  🆕 - This emoji represents the novelty of the feature, which is a new addition to the app that enhances the user experience.
-->
Added a demo mode feature to the `uv` app that shows sample UV values when the app is not configured. This improves the user experience and showcases the app functionality.

> _Sing, O Muse, of the `uv` app and its wondrous feature_
> _That shows the sun's fierce rays and how they burn the skin_
> _When no API key or location is given by the user_
> _A demo mode appears, like a gift from Zeus, to lure them in_

### Walkthrough
* Add a demo mode feature to render sample UV values when the app is not configured with an API key or a location ([link](https://github.com/tidbyt/community/pull/1678/files?diff=unified&w=0#diff-07111d5ac1e85fe1f027c67e0e3a58f5771a1df153c524df11a021b030b24cb8R21-R22), [link](https://github.com/tidbyt/community/pull/1678/files?diff=unified&w=0#diff-07111d5ac1e85fe1f027c67e0e3a58f5771a1df153c524df11a021b030b24cb8L37-R64))
* Validate the config and fetch the UV data from the selected service using the existing logic ([link](https://github.com/tidbyt/community/pull/1678/files?diff=unified&w=0#diff-07111d5ac1e85fe1f027c67e0e3a58f5771a1df153c524df11a021b030b24cb8L37-R64))


