### PR TITLE
Add nouns auction app.

### DIFF
--- a/apps/nouns/manifest.yaml
+++ b/apps/nouns/manifest.yaml
@@ -1,0 +1,8 @@
+---
+id: nouns
+name: Nouns
+summary: Show current Noun auction
+desc: Displays the Noun currently under auctionand bid details.
+author: miracle2k
+fileName: nouns.star
+packageName: nouns

--- a/apps/nouns/nouns.star
+++ b/apps/nouns/nouns.star
@@ -53,8 +53,11 @@ def render_screen():
 
     time_text = humanize.relative_time(time.now(), time.from_timestamp(int(auction["endTime"])))
     time_text = time_text.replace(" hours", "h")
+    time_text = time_text.replace(" hour", "h")
     time_text = time_text.replace(" minutes", "m")
-    time_text = time_text.strip()
+    time_text = time_text.replace(" minute", "m")
+    time_text = time_text.replace(" seconds", "s")
+    time_text = time_text.replace(" second", "s")
 
     # render two columns
     return render.Row(

--- a/apps/nouns/nouns.star
+++ b/apps/nouns/nouns.star
@@ -1,0 +1,90 @@
+"""
+Applet: Nouns
+Summary: Show current Noun auction
+Description: Displays the Noun currently under auction and bid details.
+Author: miracle2k
+"""
+
+load("encoding/json.star", "json")
+load("http.star", "http")
+load("humanize.star", "humanize")
+load("render.star", "render")
+load("time.star", "time")
+
+def main():
+    screen = render_screen()
+    return render.Root(child = screen)
+
+def render_screen():
+    rep = http.post(
+        "https://api.goldsky.com/api/public/project_cldf2o9pqagp43svvbk5u3kmo/subgraphs/nouns/0.1.0/gn",
+        body = json.encode({
+            "query": """
+                query {
+                    auctions(first:1, orderDirection: desc, orderBy: endTime) {
+                        id,
+                        amount,
+                        startTime,
+                        endTime,
+                        bidder {
+                            id,
+                        },
+                        settled
+                        noun {
+                            id,      
+                        }
+                    }
+                }
+            """,
+        }),
+        headers = {
+            "content-type": "application/json",
+        },
+        ttl_seconds = 60,
+    )
+    if rep.status_code != 200:
+        fail("nouns request failed with status %d", rep.status_code)
+    auction = rep.json()["data"]["auctions"][0]
+
+    img_data = http.get("https://noun.pics/{}.jpg".format(auction["noun"]["id"]), ttl_seconds = 3600 * 6).body()
+    img = render.Image(src = img_data, width = 32)
+
+    ether = int(auction["amount"]) / 1000000000000000000
+
+    time_text = humanize.relative_time(time.now(), time.from_timestamp(int(auction["endTime"])))
+    time_text = time_text.replace(" hours", "h")
+    time_text = time_text.replace(" minutes", "m")
+    time_text = time_text.strip()
+
+    # render two columns
+    return render.Row(
+        expanded = True,
+        children = [
+            img,
+            render.Box(
+                color = "#000000",
+                child = render.Column(
+                    expanded = True,
+                    cross_align = "center",
+                    #main_align="space_around",
+                    main_align = "space_evenly",
+                    children = [
+                        # Without this box, the text centering
+                        # of the middle row depends on the length
+                        # of the last row...
+                        render.Box(
+                            height = 6,
+                            child = render.Text("{}".format(auction["noun"]["id"]), font = "tom-thumb", color = "#ffffff"),
+                        ),
+                        render.Row(
+                            children = [
+                                render.Text("Ξ", font = "5x8", color = "#ffffffcc"),
+                                render.Text("{}".format(humanize.comma(ether)), font = "tb-8", color = "#ffffff"),
+                            ],
+                        ),
+                        render.Text("{}".format(time_text), font = "tom-thumb", color = "#ffffff77"),
+                    ],
+                ),
+            ),
+        ],
+    )


### PR DESCRIPTION
# Description

Shows the current auction from https://nouns.wtf/. Nouns are sized 32x32 and thus a great fit for the Tidbyt.

![nouns](https://github.com/tidbyt/community/assets/13807/86c4a4fc-35bf-44a4-af10-116c71dacc60)


# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 79b079f</samp>

### Summary
📄🎨📈

<!--
1.  📄 for adding the manifest file
2.  🎨 for adding the applet code that renders the UI
3.  📈 for adding the applet code that fetches and displays the auction data
-->
This pull request adds a new applet called nouns, which shows the latest Noun auction data from the Nouns DAO project. It includes a manifest file `apps/nouns/manifest.yaml` and a Starlark script `apps/nouns/nouns.star` that implement the applet logic and UI.

> _`nouns` applet code_
> _fetches and shows Noun bids_
> _autumn auction ends_

### Walkthrough
* Create and register a new applet for displaying Noun auctions ([link](https://github.com/tidbyt/community/pull/1681/files?diff=unified&w=0#diff-aadae2a5ec7e24835cb22eceec366a37ce829771408eea47dc58f1a637c9e27aR1-R8), [link](https://github.com/tidbyt/community/pull/1681/files?diff=unified&w=0#diff-71ab500a3e04593821ac37395750325dca11e310c6a05a774981b10684fad274R1-R90))
  - Add a manifest file `manifest.yaml` with applet metadata ([link](https://github.com/tidbyt/community/pull/1681/files?diff=unified&w=0#diff-aadae2a5ec7e24835cb22eceec366a37ce829771408eea47dc58f1a637c9e27aR1-R8))
  - Add a Starlark script `nouns.star` with applet logic ([link](https://github.com/tidbyt/community/pull/1681/files?diff=unified&w=0#diff-71ab500a3e04593821ac37395750325dca11e310c6a05a774981b10684fad274R1-R90))


