### PR TITLE
Gitlab Issues Update: Optional config for self hosted gitlab projects

### DIFF
--- a/apps/gitlabissues/gitlab_issues.star
+++ b/apps/gitlabissues/gitlab_issues.star
@@ -9,8 +9,10 @@ ICON = base64.decode("""iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAABM0lEQVRY
 
 def main(config):
     token = config.get("api-token")
+    domain = config.get("custom-domain")
+
     icon = render.Image(src = ICON)
-    text = render.WrappedText(get_issues(token))
+    text = render.WrappedText(get_issues(token, domain))
     return render.Root(
         child = render.Row(
             expanded = True,
@@ -20,12 +22,12 @@ def main(config):
         ),
     )
 
-def get_issues(accesstoken):
+def get_issues(accesstoken, domain):
     if accesstoken == None:
         return "You have 3 open issues!"
 
     # Set the GitLab API endpoint and access token
-    api_endpoint = "https://gitlab.com/api/v4"
+    api_endpoint = domain + "api/v4"
 
     url = api_endpoint + "/user?access_token=" + accesstoken
     user_data = http.get(url)
@@ -81,6 +83,13 @@ def get_schema():
                 desc = "Your Gitlab access token",
                 icon = "key",
                 default = "",
+            ),
+            schema.Text(
+                id = "custom-domain",
+                name = "Custom domain for hosted Gitlab",
+                desc = "If applicable, a custom domain for your hosted Gitlab instance",
+                icon = "cube",
+                default = "https://gitlab.com/",
             ),
         ],
     )


### PR DESCRIPTION
# Description
For private, or self hosted, gitlab projects, the domain is often not `https://gitlab.com/`. This adds an optional config to provide a custom domain in these situations.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2240653</samp>

### Summary
🌐🛠️🐙

<!--
1.  🌐 - This emoji represents the concept of domains, web, or internet, and can be used to indicate the addition of custom domain support for the GitLab Issues app.
2.  🛠️ - This emoji represents the concept of tools, fixing, or building, and can be used to indicate the improvement or enhancement of the GitLab Issues app functionality.
3.  🐙 - This emoji represents the concept of GitLab, as it is part of their logo and mascot, and can be used to indicate the integration or connection with the GitLab API or platform.
-->
Added custom domain support for GitLab Issues app. The app can now display issues from any GitLab instance, not just gitlab.com, by setting the `domain` parameter in `apps/gitlabissues/gitlab_issues.star`.

> _We are the rebels of the code, we defy the status quo_
> _We host our own GitLab, we don't need your `domain`_
> _We use the Issues app, we track our bugs and tasks_
> _We rock the GitLab API, we make it bend to our will_

### Walkthrough
*  Add `domain` parameter to `main` and `get_issues` functions to support custom domains for hosted GitLab instances ([link](https://github.com/tidbyt/community/pull/1695/files?diff=unified&w=0#diff-2abfd5f8db6c8df0d0ff0b1dd190dd9d8d4b192d207fbf69e9c469bb1f93282eL12-R15), [link](https://github.com/tidbyt/community/pull/1695/files?diff=unified&w=0#diff-2abfd5f8db6c8df0d0ff0b1dd190dd9d8d4b192d207fbf69e9c469bb1f93282eL23-R30))
*  Add `custom-domain` field to config schema to allow user input of custom domain for hosted GitLab instance ([link](https://github.com/tidbyt/community/pull/1695/files?diff=unified&w=0#diff-2abfd5f8db6c8df0d0ff0b1dd190dd9d8d4b192d207fbf69e9c469bb1f93282eR87-R93))


