### PR TITLE
Update: PGA Tour

### DIFF
--- a/apps/pgatour/pga_tour.star
+++ b/apps/pgatour/pga_tour.star
@@ -307,12 +307,19 @@ def getPlayerProgress(x, s, t, Title, TitleColor, ColorGradient, stage, state, t
 
     mainFont = "CG-pixel-3x5-mono"
     output = []
+    ShowTeeTimes = False
 
     topColumn = [render.Box(width = 64, height = 5, color = TitleColor, child = render.Row(expanded = True, main_align = "start", cross_align = "center", children = [
         render.Box(width = 64, height = 5, child = render.Text(content = Title + " - " + stage, color = "#fff", font = mainFont)),
     ]))]
 
     output.extend(topColumn)
+
+    LeaderTeeTime = s[0]["status"]["teeTime"]
+    LeaderTeeTimeFormat = time.parse_time(LeaderTeeTime, format = "2006-01-02T15:04Z").in_location(timezone)
+    TimeDiff = LeaderTeeTimeFormat - time.now()
+    if TimeDiff.hours < 12:
+        ShowTeeTimes = True
 
     for i in range(0, 4):
         ProgressStr = ""
@@ -337,10 +344,7 @@ def getPlayerProgress(x, s, t, Title, TitleColor, ColorGradient, stage, state, t
             # Only show tee times if its less than 12hrs until the leader tees off
             if playerState == "pre":
                 if s[i + x]["status"]["playoff"] != True:
-                    LeaderTeeTime = s[0]["status"]["teeTime"]
-                    LeaderTeeTimeFormat = time.parse_time(LeaderTeeTime, format = "2006-01-02T15:04Z").in_location(timezone)
-                    TimeDiff = LeaderTeeTimeFormat - time.now()
-                    if TimeDiff.hours < 12:
+                    if ShowTeeTimes == True:
                         TeeTime = s[i + x]["status"]["teeTime"]
                         TeeTimeFormat = time.parse_time(TeeTime, format = "2006-01-02T15:04Z").in_location(timezone)
                         TeeTime = TeeTimeFormat.format("15:04")

--- a/apps/pgatour/pga_tour.star
+++ b/apps/pgatour/pga_tour.star
@@ -39,6 +39,9 @@ Added function to revise some tournament names to make them more readable and/or
 
 v2.3.1
 Fixed bug regarding opposite field events
+
+v2.4
+Changed tee times feature to only display them when the leader's time is less than 12hrs away, and then show everyone's tee time. Previously it was showing a mix of round scores and tee times, which didnt look right
 """
 
 load("encoding/json.star", "json")
@@ -76,15 +79,18 @@ def main(config):
     FirstTournamentID = leaderboard["sports"][0]["leagues"][0]["events"][0]["id"]
     i = OppositeFieldCheck(FirstTournamentID)
 
+    # print(i)
     # if user wants to see opposite event
     if i == 1 and OppField == True:
         i = 0
 
+    # print(FirstTournamentID)
     # Get Tournament Name and ID
     TournamentName = leaderboard["sports"][0]["leagues"][0]["events"][i]["name"]
     PreTournamentName = TournamentName
     TournamentID = leaderboard["sports"][0]["leagues"][0]["events"][i]["id"]
 
+    # print(TournamentName)
     # Check if its a major and show a different color in the title bar
     TitleColor = getMajorColor(TournamentID)
 
@@ -328,13 +334,15 @@ def getPlayerProgress(x, s, t, Title, TitleColor, ColorGradient, stage, state, t
 
             # if the player hasn't started their round, show their tee time in your local time
             # also check its not a playoff
-            # Now added to show score for the round if less than 12 hrs until tee time
+            # Only show tee times if its less than 12hrs until the leader tees off
             if playerState == "pre":
                 if s[i + x]["status"]["playoff"] != True:
-                    TeeTime = s[i + x]["status"]["teeTime"]
-                    TeeTimeFormat = time.parse_time(TeeTime, format = "2006-01-02T15:04Z").in_location(timezone)
-                    TimeDiff = TeeTimeFormat - time.now()
+                    LeaderTeeTime = s[0]["status"]["teeTime"]
+                    LeaderTeeTimeFormat = time.parse_time(LeaderTeeTime, format = "2006-01-02T15:04Z").in_location(timezone)
+                    TimeDiff = LeaderTeeTimeFormat - time.now()
                     if TimeDiff.hours < 12:
+                        TeeTime = s[i + x]["status"]["teeTime"]
+                        TeeTimeFormat = time.parse_time(TeeTime, format = "2006-01-02T15:04Z").in_location(timezone)
                         TeeTime = TeeTimeFormat.format("15:04")
                         ProgressStr = TeeTime
                     else:


### PR DESCRIPTION
# Description
Tee times will only be displayed when the leader's time is less than 12hrs away. Previously it was showing a mix of round scores and tee times, which didnt look right

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4797bc0</samp>

### Summary
🕒🏌️‍♂️📺

<!--
1.  🕒 - This emoji represents the time-related aspect of the change, as the app now checks the current time and compares it to the leader's tee time before displaying the tee times of the players.
2.  🏌️‍♂️ - This emoji represents the golf-related aspect of the change, as the app is about the PGA Tour and the tee times of the golfers.
3.  📺 - This emoji represents the display-related aspect of the change, as the app is meant to be shown on the tidbyt device and the change affects how the information is presented on the screen.
-->
Improved the `pga_tour.star` app to show tee times only when relevant. This avoids showing outdated or incomplete information on the tidbyt device.

> _Oh we are the coders of the `pga_tour.star` app_
> _And we like to keep our tidbyt display nice and snappy_
> _So we only show the tee times when the leader's near the start_
> _Heave away, me hearties, heave away with all your smart_

### Walkthrough
*  Add comment with version number and feature summary ([link](https://github.com/tidbyt/community/pull/1698/files?diff=unified&w=0#diff-a03b8905919094b4578f67df044fa3753e58ba27788b134404c13e79a61ff75bR42-R44))
*  Add flag to show or hide tee times based on leader's tee time ([link](https://github.com/tidbyt/community/pull/1698/files?diff=unified&w=0#diff-a03b8905919094b4578f67df044fa3753e58ba27788b134404c13e79a61ff75bR310), [link](https://github.com/tidbyt/community/pull/1698/files?diff=unified&w=0#diff-a03b8905919094b4578f67df044fa3753e58ba27788b134404c13e79a61ff75bL331-R349))
*  Add print statements for debugging tournament selection and name ([link](https://github.com/tidbyt/community/pull/1698/files?diff=unified&w=0#diff-a03b8905919094b4578f67df044fa3753e58ba27788b134404c13e79a61ff75bL79-R87), [link](https://github.com/tidbyt/community/pull/1698/files?diff=unified&w=0#diff-a03b8905919094b4578f67df044fa3753e58ba27788b134404c13e79a61ff75bR93))


