### PR TITLE
Update: Test Cricket

### DIFF
--- a/apps/testcricket/test_cricket.star
+++ b/apps/testcricket/test_cricket.star
@@ -107,6 +107,7 @@ def main(config):
         MatchID = str(MatchID)
         SeriesID = str(SeriesID)
         Match_URL = "https://hs-consumer-api.espncricinfo.com/v1/pages/match/details?lang=en&seriesId=" + SeriesID + "&matchId=" + MatchID + "&latest=true"
+
         #print(Match_URL)
         # cache specific match data for 1 minute
         MatchData = get_cachable_data(Match_URL, MATCH_CACHE)
@@ -238,7 +239,7 @@ def main(config):
             if len(CurrentBowler) > 10:
                 if Match_JSON["livePerformance"]["bowlers"][0]["player"]["mobileName"] != "":
                     CurrentBowler = Match_JSON["livePerformance"]["bowlers"][0]["player"]["mobileName"]
-            
+
             CurrentBowler_Wkts = Match_JSON["livePerformance"]["bowlers"][0]["wickets"]
             CurrentBowler_Runs = Match_JSON["livePerformance"]["bowlers"][0]["conceded"]
 
@@ -346,7 +347,7 @@ def main(config):
             Status3Color = "#fff"
             Status4 = "Part'ship: " + CurrentPartnership
             Status4Color = BattingTeamColor
-            
+
             if IsOut == True and Wickets != "10" and Break == False:
                 StatusColor = "#f00"
                 Status2Color = "#f00"
@@ -910,7 +911,7 @@ def FinalTeamScore(BattingTeam, BattingTeamColor, Wickets1, Runs1, Wickets2, Run
     )
 
 def BatsmanScore(Batsman, Runs, BatsmanColor):
-     # Display the batsman & their score, with name cropped to 11 characters
+    # Display the batsman & their score, with name cropped to 11 characters
     return render.Row(
         expanded = True,
         main_align = "space_between",

--- a/apps/testcricket/test_cricket.star
+++ b/apps/testcricket/test_cricket.star
@@ -34,6 +34,11 @@ Fixed bug for "need to win" amount in 4th innings
 v1.6
 For a test that's about to start, cycle between the start time and the title of the match, eg 1st Test, 2nd Test etc
 Added handling for when details of the venue/ground are not yet available
+
+v1.7
+Updated "Wet Outfield" status
+Updated status messages displayed during breaks in play
+Updated BatsmanScore function, removed use of marquee for batsmen name
 """
 
 load("encoding/json.star", "json")
@@ -102,7 +107,7 @@ def main(config):
         MatchID = str(MatchID)
         SeriesID = str(SeriesID)
         Match_URL = "https://hs-consumer-api.espncricinfo.com/v1/pages/match/details?lang=en&seriesId=" + SeriesID + "&matchId=" + MatchID + "&latest=true"
-
+        #print(Match_URL)
         # cache specific match data for 1 minute
         MatchData = get_cachable_data(Match_URL, MATCH_CACHE)
         Match_JSON = json.decode(MatchData)
@@ -231,7 +236,9 @@ def main(config):
             # Bowler details
             CurrentBowler = Match_JSON["livePerformance"]["bowlers"][0]["player"]["fieldingName"]
             if len(CurrentBowler) > 10:
-                CurrentBowler = Match_JSON["livePerformance"]["bowlers"][0]["player"]["mobileName"]
+                if Match_JSON["livePerformance"]["bowlers"][0]["player"]["mobileName"] != "":
+                    CurrentBowler = Match_JSON["livePerformance"]["bowlers"][0]["player"]["mobileName"]
+            
             CurrentBowler_Wkts = Match_JSON["livePerformance"]["bowlers"][0]["wickets"]
             CurrentBowler_Runs = Match_JSON["livePerformance"]["bowlers"][0]["conceded"]
 
@@ -261,6 +268,8 @@ def main(config):
             TheSess = Match_JSON["match"]["liveSession"]
             TheSess = str(TheSess)
 
+            Break = False
+
             # display the day number, or if a wicket has fallen, show that instead as the "status"
             if Batsmen == 2:
                 Status2 = "Rem Overs: " + RemOvers
@@ -277,6 +286,7 @@ def main(config):
                     Status = TheSess + " - " + TheDay
                     Status5 = CurrentBowler + " " + CurrentBowler_Wkts + "/" + CurrentBowler_Runs
                 elif Status == "Stumps" or Status == "Lunch" or Status == "Tea" or Status == "Drinks":
+                    Break = True
                     Status = Status + " - Day " + TheDay
                     Status2 = Status
                     Status5 = Status
@@ -285,10 +295,14 @@ def main(config):
                     Status = Status
                 elif Status == "Match delayed by rain":
                     Status = "Rain Delay"
+                    Status5 = Status
                 elif Status == "Match delayed by bad light":
                     Status = "Bad Light delay"
-                elif Status == "Match delayed - wet outfield":
+                    Status5 = Status
+                elif Status == "Match delayed by a wet outfield":
                     Status = "Wet outfield"
+                    Status5 = Status
+                    Status5Color = "#fff"
 
             elif Batsmen == 1:
                 # if someone is just out, show a wicket has fallen
@@ -300,6 +314,7 @@ def main(config):
                     Status5 = CurrentBowler + " " + CurrentBowler_Wkts + "/" + CurrentBowler_Runs
                     Status5Color = "#f00"
                 elif Status == "Stumps" or Status == "Lunch" or Status == "Tea" or Status == "Drinks":
+                    Break = True
                     Status = Status + " - Day " + TheDay
                     Status2 = Status
                     Status5 = Status
@@ -321,7 +336,7 @@ def main(config):
                     Status2 = "Rem Overs: " + RemOvers
                     Status5 = Status
                     Status5Color = "#fff"
-                elif Status == "Match delayed - wet outfield":
+                elif Status == "Match delayed by a wet outfield":
                     Status = "Wet outfield"
                     Status2 = "Rem Overs: " + RemOvers
                     Status5 = Status
@@ -331,9 +346,8 @@ def main(config):
             Status3Color = "#fff"
             Status4 = "Part'ship: " + CurrentPartnership
             Status4Color = BattingTeamColor
-            #Status5 = CurrentBowler + " " + CurrentBowler_Wkts + "/" + CurrentBowler_Runs
-
-            if IsOut == True and Wickets != "10":
+            
+            if IsOut == True and Wickets != "10" and Break == False:
                 StatusColor = "#f00"
                 Status2Color = "#f00"
                 Status3Color = "#f00"
@@ -619,7 +633,6 @@ def main(config):
         if SeriesID != 0:
             Match_URL = "https://hs-consumer-api.espncricinfo.com/v1/pages/match/details?lang=en&seriesId=" + str(SeriesID) + "&matchId=" + str(MatchID) + "&latest=true"
 
-            # print(Match_URL)
             # get data, hold cache for 6 hrs
             MatchData = get_cachable_data(Match_URL, FUTURE_FIXTURE_CACHE)
             Match_JSON = json.decode(MatchData)
@@ -897,24 +910,49 @@ def FinalTeamScore(BattingTeam, BattingTeamColor, Wickets1, Runs1, Wickets2, Run
     )
 
 def BatsmanScore(Batsman, Runs, BatsmanColor):
+     # Display the batsman & their score, with name cropped to 11 characters
     return render.Row(
+        expanded = True,
+        main_align = "space_between",
         children = [
-            render.Box(width = 50, height = 8, child = render.Padding(
-                pad = (2, 1, 0, 0),
-                child = render.Marquee(
-                    width = 50,
-                    child = render.Text(content = Batsman, color = BatsmanColor, font = "CG-pixel-3x5-mono", offset = 0),
-                ),
-            )),
-            render.Box(width = 14, height = 8, child = render.Padding(
-                pad = (0, 0, 0, 0),
-                child = render.Marquee(
-                    width = 14,
-                    child = render.Text(content = Runs, color = BatsmanColor, font = "CG-pixel-3x5-mono", offset = 0),
-                ),
-            )),
+            render.Row(
+                main_align = "start",
+                children = [
+                    render.Padding(
+                        pad = (2, 2, 2, 1),
+                        child = render.Text(content = Batsman[:11], color = BatsmanColor, font = "CG-pixel-3x5-mono", offset = 0),
+                    ),
+                ],
+            ),
+            render.Row(
+                main_align = "end",
+                children = [
+                    render.Padding(
+                        pad = (2, 2, 2, 1),
+                        child = render.Text(content = Runs, color = BatsmanColor, font = "CG-pixel-3x5-mono", offset = 0),
+                    ),
+                ],
+            ),
         ],
     )
+    # return render.Row(
+    #     children = [
+    #         render.Box(width = 50, height = 8, child = render.Padding(
+    #             pad = (2, 1, 0, 0),
+    #             child = render.Marquee(
+    #                 width = 50,
+    #                 child = render.Text(content = Batsman, color = BatsmanColor, font = "CG-pixel-3x5-mono", offset = 0),
+    #             ),
+    #         )),
+    #         render.Box(width = 14, height = 8, child = render.Padding(
+    #             pad = (0, 0, 0, 0),
+    #             child = render.Marquee(
+    #                 width = 14,
+    #                 child = render.Text(content = Runs, color = BatsmanColor, font = "CG-pixel-3x5-mono", offset = 0),
+    #             ),
+    #         )),
+    #     ],
+    # )
 
 def StatusRow(StatusMsg, StatusColor):
     return render.Row(


### PR DESCRIPTION
# Description
Updated "Wet Outfield" status
Updated status messages displayed during breaks in play 
Updated BatsmanScore function, removed use of marquee for batsmen name

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3b39454</samp>

### Summary
🌧️🖼️🐛

<!--
1.  🌧️ for the wet outfield and other breaks in play feature, as this emoji conveys the idea of rain or bad weather affecting the game.
2.  🖼️ for the improved display of the batsman score, as this emoji suggests a better visual presentation or layout of the information.
3.  🐛 for the fixed typos and removed unused code, as this emoji implies fixing bugs or errors in the code.
-->
This pull request enhances the test cricket app to handle different scenarios of interrupted play and show more information about the current batsman. It also cleans up the code and fixes some minor errors in `test_cricket.star`.

> _`test cricket` app_
> _wet outfield, breaks in play_
> _autumn raindrops fall_

### Walkthrough
*  Add comment with version number and updates ([link](https://github.com/tidbyt/community/pull/1699/files?diff=unified&w=0#diff-bdfdb775effb3cb43889928dd455c5a25b68afb7fcdb3cf3b8f8f56f0170a2bdR37-R41))
*  Check and use mobile name for bowler if fielding name is too long ([link](https://github.com/tidbyt/community/pull/1699/files?diff=unified&w=0#diff-bdfdb775effb3cb43889928dd455c5a25b68afb7fcdb3cf3b8f8f56f0170a2bdL234-R241))
*  Add and update Break variable to indicate breaks in play ([link](https://github.com/tidbyt/community/pull/1699/files?diff=unified&w=0#diff-bdfdb775effb3cb43889928dd455c5a25b68afb7fcdb3cf3b8f8f56f0170a2bdR271-R272), [link](https://github.com/tidbyt/community/pull/1699/files?diff=unified&w=0#diff-bdfdb775effb3cb43889928dd455c5a25b68afb7fcdb3cf3b8f8f56f0170a2bdR289), [link](https://github.com/tidbyt/community/pull/1699/files?diff=unified&w=0#diff-bdfdb775effb3cb43889928dd455c5a25b68afb7fcdb3cf3b8f8f56f0170a2bdR317))
*  Fix typo in wet outfield status message ([link](https://github.com/tidbyt/community/pull/1699/files?diff=unified&w=0#diff-bdfdb775effb3cb43889928dd455c5a25b68afb7fcdb3cf3b8f8f56f0170a2bdL324-R339))
*  Avoid showing red color for out batsman during breaks ([link](https://github.com/tidbyt/community/pull/1699/files?diff=unified&w=0#diff-bdfdb775effb3cb43889928dd455c5a25b68afb7fcdb3cf3b8f8f56f0170a2bdL334-R350))
*  Modify BatsmanScore function to use render.Row instead of render.Box and render.Marquee ([link](https://github.com/tidbyt/community/pull/1699/files?diff=unified&w=0#diff-bdfdb775effb3cb43889928dd455c5a25b68afb7fcdb3cf3b8f8f56f0170a2bdL900-R955))


