### PR TITLE
airthings : guard against missing pm25 value in sensor data

### DIFF
--- a/apps/airthings/airthings.star
+++ b/apps/airthings/airthings.star
@@ -82,7 +82,10 @@ def main(config):
     print(samples)
 
     co2 = samples["data"]["co2"]
-    pm25 = samples["data"]["pm25"]
+    if 'pm25' in samples['data']:
+        pm25 = samples["data"]["pm25"]
+    else:
+        pm25 = -1
     temp = samples["data"]["temp"]
     voc = samples["data"]["voc"]
     humidity = samples["data"]["humidity"]
@@ -143,6 +146,7 @@ def main(config):
         return []
 
     items = []
+    if pm25 == -1: pm25 = 'n/a'
     for (hide, reading, color, displayName) in [
         (hideCo2, co2, co2_color, "Co2"),
         (hidePm25, pm25, pm25_color, "Pm2.5"),


### PR DESCRIPTION
# Description
If the airtag does not report pm25 then the script crashes when trying to access.  This fix check for the presence of the data and if it's missing set it to -1 and then display n/a when rendering.

# Copilot
<!-- please don't change the line below -->
copilot:all
