### PR TITLE
Add caching to HTTP request

### DIFF
--- a/apps/bbcradio/bbc_radio.star
+++ b/apps/bbcradio/bbc_radio.star
@@ -89,6 +89,7 @@ def load_stations():
         headers = {
             "User-Agent": "USER_AGENT",
         },
+        ttl_seconds = 60,
     )
     page = html(resp.body())
     raw = json.decode(page.find("div#main > script").text()[len(JSON_PREFIX):-2])


### PR DESCRIPTION
Oops, missed this earlier.

# Description
Replace this with a description of your changes.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a45e613</samp>

### Summary
📻🕒🚀

<!--
1.  📻 - This emoji represents the radio feature of the app and the BBC Radio API that is used to fetch the station information.
2.  🕒 - This emoji represents the time aspect of the change, as the new parameter controls how long the cached response is valid for and how often the app refreshes the data.
3.  🚀 - This emoji represents the performance improvement of the change, as it reduces the number of requests to the API and the network bandwidth usage.
-->
Added a `ttl_seconds` parameter to `get_bbc_radio` function in `apps/bbcradio/bbc_radio.star` to control the cache expiration time of the API response. This improves the app's performance and reduces network traffic.

> _`get_bbc_radio`_
> _now has `ttl_seconds`_
> _cache for spring breeze_

### Walkthrough
*  Add a new parameter `ttl_seconds` to the `get_bbc_radio` function to control the cache expiration time ([link](https://github.com/tidbyt/community/pull/1708/files?diff=unified&w=0#diff-b774e6991be23e138581b7e762a0297f361c91c7c8285a3d4ea61f5466696c47R92))


