### PR TITLE
Fix for no "direction" field in JSON

### DIFF
--- a/apps/nightscout/manifest.yaml
+++ b/apps/nightscout/manifest.yaml
@@ -2,7 +2,7 @@
 id: nightscout
 name: Nightscout
 summary: Shows Nightscout CGM Data
-desc: Displays Continuous Glucose Monitoring (CGM) blood sugar data from the Nightscout Open Source project (https://nightscout.github.io/). Will display blood sugar as mg/dL or mmol/L. Optionally display historical readings on a graph. Also a clock. (v2.3.2).
+desc: Displays Continuous Glucose Monitoring (CGM) blood sugar data from the Nightscout Open Source project (https://nightscout.github.io/). Will display blood sugar as mg/dL or mmol/L. Optionally display historical readings on a graph. Also a clock. (v2.3.3).
 author: Jeremy Tavener, Paul Murphy
 fileName: nightscout.star
 packageName: nightscout

--- a/apps/nightscout/nightscout.star
+++ b/apps/nightscout/nightscout.star
@@ -853,7 +853,7 @@ def get_nightscout_data(nightscout_url, nightscout_token, show_mgdl):
         print("sgv_delta:" + str(sgv_delta))
 
     # Get the direction
-    direction = latest_reading["direction"]
+    direction = latest_reading["direction"] if 'direction' in latest_reading else "None"
     history = []
 
     for x in resp.json():

--- a/apps/nightscout/nightscout.star
+++ b/apps/nightscout/nightscout.star
@@ -1,7 +1,7 @@
 """
 Applet: Nightscout
 Summary: Shows Nightscout CGM Data
-Description: Displays Continuous Glucose Monitoring (CGM) blood sugar data from the Nightscout Open Source project (https://nightscout.github.io/). Will display blood sugar as mg/dL or mmol/L. Optionally display historical readings on a graph. Also a clock. (v2.3.2).
+Description: Displays Continuous Glucose Monitoring (CGM) blood sugar data from the Nightscout Open Source project (https://nightscout.github.io/). Will display blood sugar as mg/dL or mmol/L. Optionally display historical readings on a graph. Also a clock. (v2.3.3).
 Authors: Jeremy Tavener, Paul Murphy
 """
 

--- a/apps/nightscout/nightscout.star
+++ b/apps/nightscout/nightscout.star
@@ -853,7 +853,7 @@ def get_nightscout_data(nightscout_url, nightscout_token, show_mgdl):
         print("sgv_delta:" + str(sgv_delta))
 
     # Get the direction
-    direction = latest_reading["direction"] if 'direction' in latest_reading else "None"
+    direction = latest_reading["direction"] if "direction" in latest_reading else "None"
     history = []
 
     for x in resp.json():


### PR DESCRIPTION
Fix for no "direction" field in JSON - apply default "None"

# Description
Replace this with a description of your changes.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e8c2b1f</samp>

### Summary
🐛🔄🚫

<!--
1.  🐛 This emoji represents a bug, which is what the KeyError exception was. The code change fixed this bug and made the app more robust.
2.  🔄 This emoji represents a refresh or an update, which is what the code change did to the direction variable. The code change updated the direction variable to "None" if it was missing, instead of leaving it undefined or raising an error.
3.  🚫 This emoji represents a prohibition or a stop, which is what the code change did to the app crashing. The code change prevented the app from crashing and allowed it to continue running.
-->
Improved error handling for missing direction data in `nightscout` app. The app now assigns a default value instead of crashing when the direction key is absent in the latest reading.

> _`direction` key gone_
> _app does not crash, shows data_
> _autumn wind of change_

### Walkthrough
*  Handle missing direction key in Nightscout data ([link](https://github.com/tidbyt/community/pull/1726/files?diff=unified&w=0#diff-76126fb2f5f6edd57d467ea196a5537f9f0f062d734669d13d9fa5c63bc7fdd4L856-R856))


