### PR TITLE
Fix destination row splitting

### DIFF
--- a/apps/sfnextmuni/sf_next_muni.star
+++ b/apps/sfnextmuni/sf_next_muni.star
@@ -390,7 +390,7 @@ def getPredictions(api_key, config, stop):
         seconds = predictedTimes[0] - time.now().unix
         minutes = int(seconds / 60)
 
-        titleKey = routeTag if "short" == config.get("prediction_format") else (routeTag, destTitle)
+        titleKey = (routeTag, routeTag) if config.get("prediction_format") in ("short", "medium", "two_line_four_times") else (routeTag, destTitle)
         if titleKey not in prediction_map:
             prediction_map[titleKey] = []
 
@@ -560,9 +560,9 @@ def shortPredictions(output, lines):
                             render.Row(
                                 children = [
                                     render.Circle(
-                                        child = render.Text(routeTag, font = "tom-thumb", color = "#000000" if routeTag in MUNI_BLACK_TEXT else "#ffffff"),
+                                        child = render.Text(routeTag[0], font = "tom-thumb", color = "#000000" if routeTag[0] in MUNI_BLACK_TEXT else "#ffffff"),
                                         diameter = 7,
-                                        color = MUNI_COLORS[routeTag] if routeTag in MUNI_COLORS else "#000000",
+                                        color = MUNI_COLORS[routeTag[0]] if routeTag[0] in MUNI_COLORS else "#000000",
                                     ),
                                     render.Text(" "),
                                     render.Text(",".join(predictions[:2]), font = "tom-thumb"),


### PR DESCRIPTION
When the user is not using one of the display format the includes the destination, if there are multiple destinations being served by same route, they will split into multiple lines. e.g.:

K 4, 28
K 16

This corrects that by ignoring the destination name when it is not being displayed and the above would instead be rendered as K 4,16,28 which is more useful to the user.
