### PR TITLE
feat(developer-excuse): to add developer excuse app

### DIFF
--- a/apps/developerexcuse/developer_excuse.star
+++ b/apps/developerexcuse/developer_excuse.star
@@ -10,32 +10,82 @@ load("render.star", "render")
 load("schema.star", "schema")
 
 EXCUSE_URL = "https://excuser-three.vercel.app/v1/excuse/developers/"
+DEFAULT_COLOR = "#ffffff"
+DEFAULT_DIRECTION = "horizontal"
 
-def main():
+def main(config):
     rep = http.get(EXCUSE_URL)
     if rep.status_code != 200:
         fail("Excuse request failed with status %d", rep.status_code)
 
     excuse = rep.json()[0]["excuse"]
+    direction = config.get("direction", DEFAULT_DIRECTION)
+    color = config.get("text_color", DEFAULT_COLOR)
 
-    return render.Root(
-        child = render.Box(
-            render.Row(
-                expanded = True,
-                main_align = "space_evenly",
-                cross_align = "cebter",
-                children = [
-                    render.Marquee(
-                        width = 64,
-                        child = render.Text(excuse),
-                    ),
-                ],
+    if (direction == "vertical"):
+        return render.Root(
+            child = render.Box(
+                render.Row(
+                    expanded = True,
+                    main_align = "space_evenly",
+                    cross_align = "center",
+                    children = [
+                        render.Marquee(
+                            height = 32,
+                            scroll_direction = "vertical",
+                            child = render.WrappedText(
+                                content = excuse,
+                                width = 64,
+                                color = color,
+                            ),
+                        ),
+                    ],
+                ),
             ),
-        ),
-    )
+        )
+    else:
+        return render.Root(
+            child = render.Box(
+                render.Row(
+                    expanded = True,
+                    main_align = "space_evenly",
+                    cross_align = "center",
+                    children = [
+                        render.Marquee(
+                            width = 64,
+                            child = render.Text(
+                                content = excuse,
+                                color = color,
+                            ),
+                        ),
+                    ],
+                ),
+            ),
+        )
 
 def get_schema():
+    directions = [
+        schema.Option(display = "Horizontal", value = "horizontal"),
+        schema.Option(display = "Vertical", value = "vertical"),
+    ]
+
     return schema.Schema(
         version = "1",
-        fields = [],
+        fields = [
+            schema.Color(
+                id = "text_color",
+                name = "Text Color",
+                desc = "To set the color of the text.",
+                icon = "brush",
+                default = DEFAULT_COLOR,
+            ),
+            schema.Dropdown(
+                id = "direction",
+                icon = "cogs",
+                name = "Direction",
+                desc = "To control the direction of the marquee.",
+                options = directions,
+                default = DEFAULT_DIRECTION,
+            ),
+        ],
     )

--- a/apps/developerexcuse/developer_excuse.star
+++ b/apps/developerexcuse/developer_excuse.star
@@ -11,7 +11,6 @@ load("schema.star", "schema")
 
 EXCUSE_URL = "https://excuser-three.vercel.app/v1/excuse/developers/"
 
-
 def main(config):
     rep = http.get(EXCUSE_URL)
     if rep.status_code != 200:
@@ -20,24 +19,23 @@ def main(config):
     excuse = rep.json()[0]["excuse"]
 
     return render.Root(
-        child=render.Box(
+        child = render.Box(
             render.Row(
-                expanded=True,
-                main_align="space_evenly",
-                cross_align="cebter",
-                children=[
+                expanded = True,
+                main_align = "space_evenly",
+                cross_align = "cebter",
+                children = [
                     render.Marquee(
-                        width=64,
-                        child=render.Text(excuse),
-                    )
+                        width = 64,
+                        child = render.Text(excuse),
+                    ),
                 ],
-            )
-        )
+            ),
+        ),
     )
-
 
 def get_schema():
     return schema.Schema(
-        version="1",
-        fields=[],
+        version = "1",
+        fields = [],
     )

--- a/apps/developerexcuse/developer_excuse.star
+++ b/apps/developerexcuse/developer_excuse.star
@@ -5,8 +5,8 @@ Description: Developer Excuse app generates playful and imaginative excuses to b
 Author: masonwongcs
 """
 
-load("render.star", "render")
 load("http.star", "http")
+load("render.star", "render")
 load("schema.star", "schema")
 
 EXCUSE_URL = "https://excuser-three.vercel.app/v1/excuse/developers/"

--- a/apps/developerexcuse/developer_excuse.star
+++ b/apps/developerexcuse/developer_excuse.star
@@ -11,7 +11,7 @@ load("schema.star", "schema")
 
 EXCUSE_URL = "https://excuser-three.vercel.app/v1/excuse/developers/"
 
-def main(config):
+def main():
     rep = http.get(EXCUSE_URL)
     if rep.status_code != 200:
         fail("Excuse request failed with status %d", rep.status_code)

--- a/apps/developerexcuse/developer_excuse.star
+++ b/apps/developerexcuse/developer_excuse.star
@@ -81,7 +81,7 @@ def get_schema():
             ),
             schema.Dropdown(
                 id = "direction",
-                icon = "cogs",
+                icon = "gear",
                 name = "Direction",
                 desc = "To control the direction of the marquee.",
                 options = directions,

--- a/apps/developerexcuse/developer_excuse.star
+++ b/apps/developerexcuse/developer_excuse.star
@@ -1,0 +1,43 @@
+"""
+Applet: Developer Excuse
+Summary: Developer Excuse
+Description: Developer Excuse app generates playful and imaginative excuses to bring a smile to developers facing coding hiccups and bugs.
+Author: masonwongcs
+"""
+
+load("render.star", "render")
+load("http.star", "http")
+load("schema.star", "schema")
+
+EXCUSE_URL = "https://excuser-three.vercel.app/v1/excuse/developers/"
+
+
+def main(config):
+    rep = http.get(EXCUSE_URL)
+    if rep.status_code != 200:
+        fail("Excuse request failed with status %d", rep.status_code)
+
+    excuse = rep.json()[0]["excuse"]
+
+    return render.Root(
+        child=render.Box(
+            render.Row(
+                expanded=True,
+                main_align="space_evenly",
+                cross_align="cebter",
+                children=[
+                    render.Marquee(
+                        width=64,
+                        child=render.Text(excuse),
+                    )
+                ],
+            )
+        )
+    )
+
+
+def get_schema():
+    return schema.Schema(
+        version="1",
+        fields=[],
+    )

--- a/apps/developerexcuse/manifest.yaml
+++ b/apps/developerexcuse/manifest.yaml
@@ -1,0 +1,8 @@
+---
+id: developer-excuse
+name: Developer Excuse
+summary: Developer Excuse
+desc: Developer Excuse app generates playful and imaginative excuses to bring a smile to developers facing coding hiccups and bugs.
+author: masonwongcs
+fileName: developer_excuse.star
+packageName: developerexcuse


### PR DESCRIPTION
# Description
Adding a useful app for all developers to generate excuses. 😄

![developer_excuse](https://github.com/tidbyt/community/assets/30920904/a26c707a-729d-4dc7-875e-bb0fcf85eb10)

 
# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5b969f3</samp>

### Summary
🛠️🌐📝

<!--
1.  🛠️ - This emoji represents the tool or wrench, and can be used to indicate that the change adds some code or functionality to the applet.
2.  🌐 - This emoji represents the globe or world, and can be used to indicate that the change involves fetching data from an external API or web service.
3.  📝 - This emoji represents the memo or document, and can be used to indicate that the change adds some documentation or metadata to the applet.
-->
This pull request adds a new applet called Developer Excuse, which displays a random excuse for software developers on the Tidbyt device. It consists of the applet code in `developer_excuse.star` and the manifest file in `manifest.yaml`.

> _`Developer Excuse`_
> _Fetching and rendering jokes_
> _A fun applet for fall_

### Walkthrough
* Create and register a new applet for displaying random developer excuses ([link](https://github.com/tidbyt/community/pull/1745/files?diff=unified&w=0#diff-1538cf1c58b80ea905f29d6551955957e2f4925d22c26f5cbad5029257f45947R1-R43), [link](https://github.com/tidbyt/community/pull/1745/files?diff=unified&w=0#diff-950026eeee1b6c0cf901259888d86ce78011b3ee5e6f1f98c7cc72ee5805ce89R1-R8))
  - Fetch excuses from https://developerexcuses.com/ using the `http` module ([link](https://github.com/tidbyt/community/pull/1745/files?diff=unified&w=0#diff-1538cf1c58b80ea905f29d6551955957e2f4925d22c26f5cbad5029257f45947R1-R43))
  - Display excuses on the Tidbyt device using the `render` module ([link](https://github.com/tidbyt/community/pull/1745/files?diff=unified&w=0#diff-1538cf1c58b80ea905f29d6551955957e2f4925d22c26f5cbad5029257f45947R1-R43))
  - Define the `main` and `get_schema` functions as required by the applet framework ([link](https://github.com/tidbyt/community/pull/1745/files?diff=unified&w=0#diff-1538cf1c58b80ea905f29d6551955957e2f4925d22c26f5cbad5029257f45947R1-R43))
  - Provide applet metadata in `manifest.yaml` ([link](https://github.com/tidbyt/community/pull/1745/files?diff=unified&w=0#diff-950026eeee1b6c0cf901259888d86ce78011b3ee5e6f1f98c7cc72ee5805ce89R1-R8))


