### PR TITLE
fix SailGP : remove leading zeros from date display

### DIFF
--- a/apps/sailgp/sailgp.star
+++ b/apps/sailgp/sailgp.star
@@ -90,7 +90,7 @@ def nri(nri, standings, config):
     date_and_time_second = nri["endDateTime"]
     date_and_time_first_dt = time.parse_time(date_and_time_first, "2006-01-02T15:04-07:00").in_location(timezone)
     date_and_time_second_dt = time.parse_time(date_and_time_second, "2006-01-02T15:04-07:00").in_location(timezone)
-    date_time_format = date_and_time_first_dt.format("Jan 02-") + date_and_time_second_dt.format("02 2006") if config.bool("is_us_date_format", DEFAULTS["date_us"]) else date_and_time_first_dt.format("02-") + date_and_time_second_dt.format("02 Jan 2006")
+    date_time_format = date_and_time_first_dt.format("Jan 2-") + date_and_time_second_dt.format("2 2006") if config.bool("is_us_date_format", DEFAULTS["date_us"]) else date_and_time_first_dt.format("2-") + date_and_time_second_dt.format("2 Jan 2006")
 
     standing_text = ""
     for i in standings:


### PR DESCRIPTION
# Description
remove leading zeros from date display

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 443fb15</samp>

### Summary
🗓️🚫🌐

<!--
1.  🗓️ - This emoji represents the date and calendar aspect of the change, as the date_time_format variable is used to format the dates of the SailGP events.
2.  🚫 - This emoji represents the removal or deletion of something, as the leading zeros from the day numbers were removed from the formatted string.
3.  🌐 - This emoji represents the global and international aspect of the change, as the SailGP app shows the sailing championship that takes place in different countries and regions around the world.
-->
Removed leading zeros from day numbers in `date_time_format` for the sailgp app. This improves the date display on the tidbyt device.

> _`sailgp` app changes_
> _no more zeros in the dates_
> _springtime of sailing_

### Walkthrough
*  Removed leading zeros from day numbers in date display ([link](https://github.com/tidbyt/community/pull/1750/files?diff=unified&w=0#diff-2399292d6aefa701a3b6039085581cb5dd858a3ced689775d60cf2fc425c87d8L93-R93))


