### PR TITLE
Add Awair applet to get air quality data from local API forwarded

### DIFF
--- a/apps/awair/awair.star
+++ b/apps/awair/awair.star
@@ -1,0 +1,224 @@
+"""
+Applet: Awair
+Summary: Local Awair air data
+Description: Get air quality data from Awair's local API.
+Author: tabrindle
+"""
+
+load("encoding/json.star", "json")
+load("http.star", "http")
+load("render.star", "render")
+load("schema.star", "schema")
+
+def get_schema():
+    return schema.Schema(
+        version = "1",
+        fields = [
+            schema.Text(
+                id = "ip_address",
+                name = "Public IP Address and port of Awair device",
+                desc = "Your public IP address with port forwarding set up to your awair device",
+                icon = "computer",
+            ),
+            schema.Toggle(
+                id = "celsius",
+                name = "Use Celsius?",
+                desc = "Use Celsius instead of default Fahrenheit.",
+                icon = "temperatureLow",
+                default = False,
+            ),
+        ],
+    )
+
+green = "#41b942"
+yellow = "#fcd026"
+yellow_orange = "#fba905"
+orange = "f78703"
+red = "#e8333a"
+
+awair_color_map = [
+    {"range": 80, "color": green},
+    {"range": 60, "color": yellow_orange},
+    {"range": 0, "color": red},
+]
+
+rh_color_map = [
+    {"range": 81, "color": red},
+    {"range": 66, "color": orange},
+    {"range": 61, "color": yellow_orange},
+    {"range": 51, "color": yellow},
+    {"range": 41, "color": green},
+    {"range": 36, "color": yellow},
+    {"range": 21, "color": yellow_orange},
+    {"range": 16, "color": orange},
+    {"range": 0, "color": red},
+]
+
+co2_color_map = [
+    {"range": 2500, "color": red},
+    {"range": 1500, "color": orange},
+    {"range": 1000, "color": yellow_orange},
+    {"range": 600, "color": yellow},
+    {"range": 400, "color": green},
+]
+
+temp_color_map = [
+    {"range": 33.333, "color": red},  # 92F
+    {"range": 31.667, "color": orange},  # 89F
+    {"range": 26.111, "color": yellow_orange},  # 79F
+    {"range": 25, "color": yellow},  # 77F
+    {"range": 17.778, "color": green},  # 64F
+    {"range": 16.667, "color": yellow},  # 62F
+    {"range": 10.556, "color": yellow_orange},  # 51F
+    {"range": 8.889, "color": orange},  # 48F
+    {"range": 0, "color": red},
+]
+
+pm_color_map = [
+    {"range": 75, "color": red},
+    {"range": 55, "color": orange},
+    {"range": 35, "color": yellow_orange},
+    {"range": 15, "color": yellow},
+    {"range": 0, "color": green},
+]
+
+def get_color(score, color_map):
+    default = "#fff"
+
+    for item in color_map:
+        if score >= item["range"]:
+            return item["color"]
+
+    return default
+
+def main(config):
+    celsius = config.bool("celsius", False)
+    ip_address = config.str("ip_address", "")
+
+    if not ip_address:
+        return render.Root(
+            child = render.Text(
+                content = "Bad IP Address",
+                font = "tb-8",
+                color = "#f00",
+            ),
+        )
+
+    response = http.get("http://{}/air-data/latest".format(ip_address))
+    body = response.body()
+    data = json.decode(body)
+
+    if celsius:
+        temperature = data["temp"]
+    else:
+        temperature = data["temp"] * 9 / 5 + 32
+
+    return render.Root(
+        child = render.Box(
+            padding = 0,
+            child = render.Row(
+                children = [
+                    render.Box(
+                        height = 32,
+                        width = 38,
+                        child = render.Column(
+                            children = [
+                                render.Text(
+                                    content = "Temp " +
+                                              str(temperature)[0:2],
+                                    font = "tb-8",
+                                    color = get_color(data["temp"], temp_color_map),
+                                ),
+                                render.Text(
+                                    content = "RH%   " + str(data["humid"])[0:2],
+                                    font = "tb-8",
+                                    color = get_color(data["humid"], rh_color_map),
+                                ),
+                                render.Row(
+                                    children = [
+                                        render.Text(
+                                            content = "CO",
+                                            font = "tb-8",
+                                            color = get_color(data["co2"], co2_color_map),
+                                        ),
+                                        render.Text(
+                                            content = "2 ",
+                                            height = 8,
+                                            font = "CG-pixel-3x5-mono",
+                                            color = get_color(data["co2"], co2_color_map),
+                                        ),
+                                        render.Text(
+                                            content = str(data["co2"]),
+                                            font = "tb-8",
+                                            color = get_color(data["co2"], co2_color_map),
+                                        ),
+                                    ],
+                                ),
+                                render.Row(
+                                    children = [
+                                        render.Text(
+                                            content = "PM",
+                                            font = "tb-8",
+                                            color = get_color(data["pm25"], pm_color_map),
+                                        ),
+                                        render.Text(
+                                            content = "2",
+                                            height = 7,
+                                            font = "CG-pixel-3x5-mono",
+                                            color = get_color(data["pm25"], pm_color_map),
+                                        ),
+                                        render.Text(
+                                            content = ".",
+                                            height = 7,
+                                            font = "tb-8",
+                                            color = get_color(data["pm25"], pm_color_map),
+                                        ),
+                                        render.Text(
+                                            content = "5 ",
+                                            height = 7,
+                                            font = "CG-pixel-3x5-mono",
+                                            color = get_color(data["pm25"], pm_color_map),
+                                        ),
+                                        render.Text(
+                                            content = (" " + str(data["pm25"]))[-2:],
+                                            font = "tb-8",
+                                            color = get_color(data["pm25"], pm_color_map),
+                                        ),
+                                    ],
+                                ),
+                            ],
+                        ),
+                    ),
+                    render.Box(
+                        height = 32,
+                        width = 28,
+                        child = render.Column(
+                            main_align = "start",
+                            children = [
+                                render.Stack(
+                                    children = [
+                                        render.Circle(
+                                            diameter = 18,
+                                            color = get_color(
+                                                data["score"],
+                                                awair_color_map,
+                                            ),
+                                        ),
+                                        render.Box(
+                                            height = 18,
+                                            width = 18,
+                                            child = render.Text(
+                                                content = str(data["score"]),
+                                                font = "Dina_r400-6",
+                                                color = "#fff",
+                                            ),
+                                        ),
+                                    ],
+                                ),
+                            ],
+                        ),
+                    ),
+                ],
+            ),
+        ),
+    )

--- a/apps/awair/manifest.yaml
+++ b/apps/awair/manifest.yaml
@@ -1,0 +1,8 @@
+---
+id: awair
+name: Awair
+summary: Local Awair air data
+desc: Get air quality data from Awair's local API.
+author: tabrindle
+fileName: awair.star
+packageName: awair


### PR DESCRIPTION
# Description
- Get air quality data from local API exposed via public IP address through port forwarding.
- Allows Celsius/Fahrenheit conversion
- Displays Temperature, Humidity, CO2 and PM2.5, along with awair score
- Shows color coded thresholds that match the awair app

![awair](https://github.com/tidbyt/community/assets/2925048/7437184c-5cd6-4eed-b27d-a0665524d63a)
![awair-1](https://github.com/tidbyt/community/assets/2925048/dfae9d5a-51ec-4d98-9056-2ad76683150d)

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6eb34ff</samp>

### Summary
🌬️📊🌡️

<!--
1.  🌬️ - This emoji represents air, which is the main subject of the applet. It also suggests the idea of freshness and quality, which are related to the applet's purpose.
2.  📊 - This emoji represents data, which is what the applet fetches and displays. It also suggests the idea of analysis and measurement, which are related to the applet's functionality.
3.  🌡️ - This emoji represents temperature, which is one of the metrics that the applet shows. It also suggests the idea of climate and comfort, which are related to the applet's value.
-->
This pull request adds a new applet for displaying air quality data from an Awair device on the Tidbyt. It consists of two files: `awair.star`, which contains the applet code and logic, and `manifest.yaml`, which contains the applet metadata.

> _`Awair` applet code_
> _Fetches and shows air quality_
> _Breath of fresh `spring`_

### Walkthrough
*  Add Awair applet to fetch and display air quality data from a local device ([link](https://github.com/tidbyt/community/pull/1762/files?diff=unified&w=0#diff-225a496920643ab9b79cc15f51b1fb1cada84f944f579f111dd239f9a04f2bfaR1-R182), [link](https://github.com/tidbyt/community/pull/1762/files?diff=unified&w=0#diff-0d88a65d9a1682f623bf5482b2b5a1c346d3c1c80399b45435b2682a2f4bf467R1-R8))
   * Use `http`, `json`, `render`, and `schema` modules to implement applet logic and schema in `awair.star` ([link](https://github.com/tidbyt/community/pull/1762/files?diff=unified&w=0#diff-225a496920643ab9b79cc15f51b1fb1cada84f944f579f111dd239f9a04f2bfaR1-R182))
   * Define color maps to map air quality scores to different colors ([link](https://github.com/tidbyt/community/pull/1762/files?diff=unified&w=0#diff-225a496920643ab9b79cc15f51b1fb1cada84f944f579f111dd239f9a04f2bfaR1-R182))
   * Handle option to use Celsius or Fahrenheit for temperature display ([link](https://github.com/tidbyt/community/pull/1762/files?diff=unified&w=0#diff-225a496920643ab9b79cc15f51b1fb1cada84f944f579f111dd239f9a04f2bfaR1-R182))
   * Include docstring with applet summary and description in `awair.star` ([link](https://github.com/tidbyt/community/pull/1762/files?diff=unified&w=0#diff-225a496920643ab9b79cc15f51b1fb1cada84f944f579f111dd239f9a04f2bfaR1-R182))
   * Specify applet metadata in `manifest.yaml` ([link](https://github.com/tidbyt/community/pull/1762/files?diff=unified&w=0#diff-0d88a65d9a1682f623bf5482b2b5a1c346d3c1c80399b45435b2682a2f4bf467R1-R8))


