### PR TITLE
canvas app : off by one parse bug fix

### DIFF
--- a/apps/canvas/canvas.star
+++ b/apps/canvas/canvas.star
@@ -77,7 +77,7 @@ def getcourse(api_token):
                     time_stamp = course[index + 13:index + 33]
                     dur = time.now() - time.parse_time(time_stamp)
                     if 8760 > dur.hours:
-                        classes.append(course[1:18])
+                        classes.append(course[1:course.index(',')])
 
         #cache for one day
         cache_data = ",".join(classes)

--- a/apps/canvas/canvas.star
+++ b/apps/canvas/canvas.star
@@ -77,7 +77,7 @@ def getcourse(api_token):
                     time_stamp = course[index + 13:index + 33]
                     dur = time.now() - time.parse_time(time_stamp)
                     if 8760 > dur.hours:
-                        classes.append(course[1:course.index(',')])
+                        classes.append(course[1:course.index(",")])
 
         #cache for one day
         cache_data = ",".join(classes)


### PR DESCRIPTION
# Description
The app used hard coded string length to parse class id which has since  grown and was chopping off last digit and causing crash. Replaced with the index of the ending comma instead.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 06ef683</samp>

### Summary
🖥️📚✂️

<!--
1.  🖥️ This emoji represents the tidbyt device, which is a small computer screen that can show different apps and widgets. It also conveys the idea of technology and innovation.
2.  📚 This emoji represents the Canvas app, which is related to education, learning, and courses. It also conveys the idea of knowledge and study.
3.  ✂️ This emoji represents the modification of the slicing operation, which is a way of cutting or trimming a string. It also conveys the idea of improvement and precision.
-->
Fixed a bug in the `Canvas` app that caused some course names to be cut off. Modified the `classes.append` statement in `apps/canvas/canvas.star` to use the first comma as a delimiter instead of a fixed slice.

> _`classes.append`_
> _No more slicing course names_
> _Autumn learning blooms_

### Walkthrough
*  Adjust the course name extraction to use the first comma instead of a fixed slice of 18 characters, to avoid truncating long names and include the full course code and name ([link](https://github.com/tidbyt/community/pull/1764/files?diff=unified&w=0#diff-eddaf9963f93dca71c003b1a7c53d4d38229dbf55d7c11d6360bd3b9ee2759eaL80-R80))


