### PR TITLE
feat:  IndyCar add qualifying date and time to display rotation for Next Race…

### DIFF
--- a/apps/indycar/indy_car.star
+++ b/apps/indycar/indy_car.star
@@ -8,6 +8,9 @@ Author: jvivona
 # 20230407  v23097
 #  changed to new color schema option
 #  samhi113 provided all the track images
+# 20230826 jvivona  v23238
+#  add qualifing date/time to json on server for NRI
+#  add display of qualifing date/time on app
 
 load("encoding/base64.star", "base64")
 load("encoding/json.star", "json")
@@ -16,7 +19,7 @@ load("render.star", "render")
 load("schema.star", "schema")
 load("time.star", "time")
 
-VERSION = 23132
+VERSION = 23238
 
 IMAGES = {
     #Indycar track type logos
@@ -54,7 +57,7 @@ DEFAULTS = {
 
 SIZES = {
     "regular_font": "tom-thumb",
-    "datetime_font": "tb-8",
+    "datetime_font": "tom-thumb",
     "animation_frames": 30,
     "animation_hold_frames": 75,
     "data_box_bkg": "#000",
@@ -104,20 +107,29 @@ def nextrace(config, data):
     date_and_time3 = time.parse_time(date_and_time, "2006-01-02T15:04:05-0700").in_location(timezone)
     date_str = date_and_time3.format("Jan 02" if config.bool("is_us_date_format", DEFAULTS["date_us"]) else "02 Jan").title()  #current format of your current date str
     time_str = "TBD" if date_and_time.endswith("T00:00:00-0500") else date_and_time3.format("15:04 " if config.bool("is_24_hour_format", DEFAULTS["time_24"]) else "3:04pm")[:-1]
+    if data.get("qual", "TBD") == "TBD":
+        qual_date_str = "TBD"
+        qual_time_str = "TBD"
+    else:
+        qual_date_and_time = data.get("qual", "TBD")
+        qual_date_and_time3 = time.parse_time(qual_date_and_time, "2006-01-02T15:04:05-0700").in_location(timezone)
+        qual_date_str = qual_date_and_time3.format("Jan 02" if config.bool("is_us_date_format", DEFAULTS["date_us"]) else "02 Jan").title()  #current format of your current date str
+        qual_time_str = "TBD" if qual_date_and_time.endswith("T00:00:00-0500") else qual_date_and_time3.format("15:04 " if config.bool("is_24_hour_format", DEFAULTS["time_24"]) else "3:04pm")[:-1]
     text_color = config.get("text_color", DEFAULTS["text_color"])
 
     return render.Row(expanded = True, children = [
         render.Box(width = 16, height = 26, child = render.Image(src = base64.decode(IMAGES[data["trackid"]]), height = 24, width = 14)),
         #render.Box(width = 16, height = 26, child = render.Image(src = base64.decode(IMAGES[data["type"]]), height = 24, width = 14)),
-        fade_child(data["name"], data["track"], "{}\n{}\nTV: {}".format(date_str, time_str, data["tv"].upper()), text_color),
+        fade_child(data["name"], data["track"], "Race\n{}\n{}\nTV: {}".format(date_str, time_str, data["tv"].upper()), "Qual\n{}\n{}".format(qual_date_str, qual_time_str), text_color),
     ])
 
-def fade_child(race, track, date_time_tv, text_color):
+def fade_child(race, track, date_time_tv, qual_string, text_color):
     # IndyNXT doesn't name their races, so we're just going to flip back & forth between track & date/time/tv
     if race == track:
         return render.Animation(
             children =
                 createfadelist(track, SIZES["animation_hold_frames"], SIZES["regular_font"], text_color, SIZES["nri_data_box_width"], "center") +
+                createfadelist(qual_string, SIZES["animation_hold_frames"], SIZES["datetime_font"], text_color, SIZES["nri_data_box_width"], "center") +
                 createfadelist(date_time_tv, SIZES["animation_hold_frames"], SIZES["datetime_font"], text_color, SIZES["nri_data_box_width"], "center"),
         )
     else:
@@ -125,6 +137,7 @@ def fade_child(race, track, date_time_tv, text_color):
             children =
                 createfadelist(race, SIZES["animation_hold_frames"], SIZES["regular_font"], text_color, SIZES["nri_data_box_width"], "center") +
                 createfadelist(track, SIZES["animation_hold_frames"], SIZES["regular_font"], text_color, SIZES["nri_data_box_width"], "center") +
+                createfadelist(qual_string, SIZES["animation_hold_frames"], SIZES["datetime_font"], text_color, SIZES["nri_data_box_width"], "center") +
                 createfadelist(date_time_tv, SIZES["animation_hold_frames"], SIZES["datetime_font"], text_color, SIZES["nri_data_box_width"], "center"),
         )
 

--- a/apps/indycar/indy_car.star
+++ b/apps/indycar/indy_car.star
@@ -11,6 +11,8 @@ Author: jvivona
 # 20230826 jvivona  v23238
 #  add qualifing date/time to json on server for NRI
 #  add display of qualifing date/time on app
+# 20230904 jvivona
+#  fix date display remove leading 0
 
 load("encoding/base64.star", "base64")
 load("encoding/json.star", "json")
@@ -19,7 +21,7 @@ load("render.star", "render")
 load("schema.star", "schema")
 load("time.star", "time")
 
-VERSION = 23238
+VERSION = 23247
 
 IMAGES = {
     #Indycar track type logos
@@ -105,7 +107,7 @@ def nextrace(config, data):
     timezone = config.get("$tz", DEFAULTS["timezone"])  # Utilize special timezone variable to get TZ - otherwise assume US Eastern w/DST
     date_and_time = data["start"]
     date_and_time3 = time.parse_time(date_and_time, "2006-01-02T15:04:05-0700").in_location(timezone)
-    date_str = date_and_time3.format("Jan 02" if config.bool("is_us_date_format", DEFAULTS["date_us"]) else "02 Jan").title()  #current format of your current date str
+    date_str = date_and_time3.format("Jan 2" if config.bool("is_us_date_format", DEFAULTS["date_us"]) else "2 Jan").title()  #current format of your current date str
     time_str = "TBD" if date_and_time.endswith("T00:00:00-0500") else date_and_time3.format("15:04 " if config.bool("is_24_hour_format", DEFAULTS["time_24"]) else "3:04pm")[:-1]
     if data.get("qual", "TBD") == "TBD":
         qual_date_str = "TBD"
@@ -113,7 +115,7 @@ def nextrace(config, data):
     else:
         qual_date_and_time = data.get("qual", "TBD")
         qual_date_and_time3 = time.parse_time(qual_date_and_time, "2006-01-02T15:04:05-0700").in_location(timezone)
-        qual_date_str = qual_date_and_time3.format("Jan 02" if config.bool("is_us_date_format", DEFAULTS["date_us"]) else "02 Jan").title()  #current format of your current date str
+        qual_date_str = qual_date_and_time3.format("Jan 2" if config.bool("is_us_date_format", DEFAULTS["date_us"]) else "2 Jan").title()  #current format of your current date str
         qual_time_str = "TBD" if qual_date_and_time.endswith("T00:00:00-0500") else qual_date_and_time3.format("15:04 " if config.bool("is_24_hour_format", DEFAULTS["time_24"]) else "3:04pm")[:-1]
     text_color = config.get("text_color", DEFAULTS["text_color"])
 


### PR DESCRIPTION
# Description
add qualifying date and time to display rotation for Next Race

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d342653</samp>

### Summary
🗓️🕒🔢

<!--
1.  🗓️ - This emoji can be used to represent the addition of qualifying date and time information, as it is a calendar symbol that implies scheduling or planning events.
2. 🕒 - This emoji can be used to represent the addition of qualifying time information, as it is a clock symbol that shows a specific hour and minute.
3. 🔢 - This emoji can be used to represent the update of the version number, as it is a symbol for numbers or digits. Alternatively, one could use 🆙 to indicate an upgrade or improvement.
-->
Added qualifying info to `indycar` app. Updated version and fade functions.

> _`indycar` app, racing to the end_
> _Qualifying date and time, the fate of every driver_
> _Version number rising, fade functions blazing_
> _The speed of metal, the thrill of the challenge_

### Walkthrough
*  Add qualifying date and time feature for the NRI app and display ([link](https://github.com/tidbyt/community/pull/1768/files?diff=unified&w=0#diff-cfe68139033f465b97af504645c809b9f97f1075ef7bb1436e6ca51e8af36f63R11-R13), [link](https://github.com/tidbyt/community/pull/1768/files?diff=unified&w=0#diff-cfe68139033f465b97af504645c809b9f97f1075ef7bb1436e6ca51e8af36f63L19-R22), [link](https://github.com/tidbyt/community/pull/1768/files?diff=unified&w=0#diff-cfe68139033f465b97af504645c809b9f97f1075ef7bb1436e6ca51e8af36f63L57-R60), [link](https://github.com/tidbyt/community/pull/1768/files?diff=unified&w=0#diff-cfe68139033f465b97af504645c809b9f97f1075ef7bb1436e6ca51e8af36f63R110-R117), [link](https://github.com/tidbyt/community/pull/1768/files?diff=unified&w=0#diff-cfe68139033f465b97af504645c809b9f97f1075ef7bb1436e6ca51e8af36f63L112-R126), [link](https://github.com/tidbyt/community/pull/1768/files?diff=unified&w=0#diff-cfe68139033f465b97af504645c809b9f97f1075ef7bb1436e6ca51e8af36f63R132), [link](https://github.com/tidbyt/community/pull/1768/files?diff=unified&w=0#diff-cfe68139033f465b97af504645c809b9f97f1075ef7bb1436e6ca51e8af36f63R140))
  * Update version number and comment header in `indy_car.star` ([link](https://github.com/tidbyt/community/pull/1768/files?diff=unified&w=0#diff-cfe68139033f465b97af504645c809b9f97f1075ef7bb1436e6ca51e8af36f63R11-R13), [link](https://github.com/tidbyt/community/pull/1768/files?diff=unified&w=0#diff-cfe68139033f465b97af504645c809b9f97f1075ef7bb1436e6ca51e8af36f63L19-R22))
  * Change font for qualifying date and time to tom-thumb for consistency ([link](https://github.com/tidbyt/community/pull/1768/files?diff=unified&w=0#diff-cfe68139033f465b97af504645c809b9f97f1075ef7bb1436e6ca51e8af36f63L57-R60))
  * Parse and format qualifying date and time from server data and handle TBD case ([link](https://github.com/tidbyt/community/pull/1768/files?diff=unified&w=0#diff-cfe68139033f465b97af504645c809b9f97f1075ef7bb1436e6ca51e8af36f63R110-R117))
  * Convert qualifying date and time to local timezone and preferred format based on config ([link](https://github.com/tidbyt/community/pull/1768/files?diff=unified&w=0#diff-cfe68139033f465b97af504645c809b9f97f1075ef7bb1436e6ca51e8af36f63R110-R117))
  * Add "Race" prefix to race date and time to distinguish from qualifying ([link](https://github.com/tidbyt/community/pull/1768/files?diff=unified&w=0#diff-cfe68139033f465b97af504645c809b9f97f1075ef7bb1436e6ca51e8af36f63L112-R126))
  * Modify fade_child function to take and pass qualifying string argument to render function ([link](https://github.com/tidbyt/community/pull/1768/files?diff=unified&w=0#diff-cfe68139033f465b97af504645c809b9f97f1075ef7bb1436e6ca51e8af36f63L112-R126))
  * Create fade list for qualifying string and append to existing fade list for race information ([link](https://github.com/tidbyt/community/pull/1768/files?diff=unified&w=0#diff-cfe68139033f465b97af504645c809b9f97f1075ef7bb1436e6ca51e8af36f63R132), [link](https://github.com/tidbyt/community/pull/1768/files?diff=unified&w=0#diff-cfe68139033f465b97af504645c809b9f97f1075ef7bb1436e6ca51e8af36f63R140))


