### PR TITLE
update NASCAR - driver name format and text_color to schema.Color

### DIFF
--- a/apps/nascarnextrace/nascarnextrace.star
+++ b/apps/nascarnextrace/nascarnextrace.star
@@ -5,6 +5,7 @@ Description: Shows NASCAR next race, standings, playoffs for Cup, Xfinity and Tr
 Author: jvivona
 """
 
+# 20230904 - jvivona - fix date display
 # 20230828 - jvivona - with Kurt Busch officially retiring, changed driver names to only have 1 char for 1st name - will eval in future if necessary
 #                    - change text color to be schema.Color instead of drop down
 
@@ -16,7 +17,7 @@ load("render.star", "render")
 load("schema.star", "schema")
 load("time.star", "time")
 
-VERSION = 23240
+VERSION = 23247
 
 # cache data for 15 minutes - cycle through with cache on the API side
 CACHE_TTL_SECONDS = 900
@@ -92,7 +93,7 @@ def nextrace(api_data, config):
     timezone = config.get("$tz", DEFAULT_TIMEZONE)  # Utilize special timezone variable to get TZ - otherwise assume US Eastern w/DST
     date_and_time = api_data["Race_Date"]
     date_and_time3 = time.parse_time(date_and_time, "2006-01-02T15:04:05-0700").in_location(timezone)
-    date_str = date_and_time3.format("Jan 02" if config.bool("is_us_date_format", DEFAULT_DATE_US) else "02 Jan").title()  #current format of your current date str
+    date_str = date_and_time3.format("Jan 2" if config.bool("is_us_date_format", DEFAULT_DATE_US) else "2 Jan").title()  #current format of your current date str
     time_str = "TBD" if date_and_time.endswith("T00:00:00-0500") else date_and_time3.format("15:04 " if config.bool("is_24_hour_format", DEFAULT_TIME_24) else "3:04pm")[:-1]
     tv_str = api_data["Race_TV_Display"] if api_data["Race_TV_Display"] != "" else "TBD"
 

--- a/apps/nascarnextrace/nascarnextrace.star
+++ b/apps/nascarnextrace/nascarnextrace.star
@@ -5,6 +5,9 @@ Description: Shows NASCAR next race, standings, playoffs for Cup, Xfinity and Tr
 Author: jvivona
 """
 
+# 20230828 - jvivona - with Kurt Busch officially retiring, changed driver names to only have 1 char for 1st name - will eval in future if necessary
+#                    - change text color to be schema.Color instead of drop down
+
 load("animation.star", "animation")
 load("encoding/json.star", "json")
 load("http.star", "http")
@@ -13,7 +16,7 @@ load("render.star", "render")
 load("schema.star", "schema")
 load("time.star", "time")
 
-VERSION = 23132
+VERSION = 23240
 
 # cache data for 15 minutes - cycle through with cache on the API side
 CACHE_TTL_SECONDS = 900
@@ -28,6 +31,7 @@ DEFAULT_DATE_US = True
 
 REGULAR_FONT = "tom-thumb"
 DATETIME_FONT = "tb-8"
+DEFAULT_TEXT_COLOR = "#ffffff"
 
 ANIMATION_FRAMES = 30
 ANIMATION_HOLD_FRAMES = 75
@@ -92,7 +96,7 @@ def nextrace(api_data, config):
     time_str = "TBD" if date_and_time.endswith("T00:00:00-0500") else date_and_time3.format("15:04 " if config.bool("is_24_hour_format", DEFAULT_TIME_24) else "3:04pm")[:-1]
     tv_str = api_data["Race_TV_Display"] if api_data["Race_TV_Display"] != "" else "TBD"
 
-    text_color = config.get("text_color", coloropt[0].value)
+    text_color = config.get("text_color", DEFAULT_TEXT_COLOR)
 
     if config.get("fade_slide", DEFAULT_ANIMATION) == "slide":
         data_child = slideinout_child(api_data["Race_Name"], api_data["Track_Name"], "%s %s\nTV: %s" % (date_str, time_str, tv_str), text_color)
@@ -201,7 +205,7 @@ def standings(api_data, config, data_display):
     else:
         text = playoff(api_data)
 
-    text_color = config.get("text_color", coloropt[0].value)
+    text_color = config.get("text_color", DEFAULT_TEXT_COLOR)
 
     return [
         render.Marquee(offset_start = 48, child = render.Text(height = 6, content = text[0], font = REGULAR_FONT, color = text_color), scroll_direction = "horizontal", width = 64),
@@ -231,7 +235,7 @@ def drvrtext(data):
     positions = len(data) if len(data) <= 9 else 9
 
     for i in range(0, positions):
-        text[int(math.mod(i, 3))] = text[int(math.mod(i, 3))] + "{} {} {} {} / {}    ".format(data[i]["position"], data[i]["driver_first_name"][0:2], text_justify_trunc(10, data[i]["driver_last_name"], "left"), text_justify_trunc(4, str(data[i]["points"]), "right"), text_justify_trunc(2, str(data[i]["wins"]), "right"))
+        text[int(math.mod(i, 3))] = text[int(math.mod(i, 3))] + "{} {} {} {} / {}    ".format(data[i]["position"], data[i]["driver_first_name"][0:1], text_justify_trunc(10, data[i]["driver_last_name"], "left"), text_justify_trunc(4, str(data[i]["points"]), "right"), text_justify_trunc(2, str(data[i]["wins"]), "right"))
 
     return text
 
@@ -243,7 +247,7 @@ def playoff(data):
     positions = len(data) if len(data) <= 9 else 9
 
     for i in range(0, positions):
-        text[int(math.mod(i, 3))] = text[int(math.mod(i, 3))] + "{} {} {} {} / {}    ".format(data[i]["playoff_rank"], data[i]["driver_first_name"][0:2], text_justify_trunc(10, data[i]["driver_last_name"], "left"), text_justify_trunc(4, str(data[i]["playoff_points"]), "right"), text_justify_trunc(2, str(data[i]["playoff_race_wins"]), "right"))
+        text[int(math.mod(i, 3))] = text[int(math.mod(i, 3))] + "{} {} {} {} / {}    ".format(data[i]["playoff_rank"], data[i]["driver_first_name"][0:1], text_justify_trunc(10, data[i]["driver_last_name"], "left"), text_justify_trunc(4, str(data[i]["playoff_points"]), "right"), text_justify_trunc(2, str(data[i]["playoff_race_wins"]), "right"))
 
     return text
 
@@ -262,45 +266,6 @@ def owners(data):
 # ###################################################
 #          Schema Stuff
 # ###################################################
-
-coloropt = [
-    schema.Option(
-        display = "White",
-        value = "#FFFFFF",
-    ),
-    schema.Option(
-        display = "Red",
-        value = "#FF0000",
-    ),
-    schema.Option(
-        display = "Orange",
-        value = "#FFA500",
-    ),
-    schema.Option(
-        display = "Yellow",
-        value = "#FFFF00",
-    ),
-    schema.Option(
-        display = "Green",
-        value = "#008000",
-    ),
-    schema.Option(
-        display = "Blue",
-        value = "#0000FF",
-    ),
-    schema.Option(
-        display = "Indigo",
-        value = "#4B0082",
-    ),
-    schema.Option(
-        display = "Violet",
-        value = "#EE82EE",
-    ),
-    schema.Option(
-        display = "Pink",
-        value = "#FC46AA",
-    ),
-]
 
 dispopt = [
     schema.Option(
@@ -358,13 +323,12 @@ def get_schema():
                 default = "nri",
                 options = dispopt,
             ),
-            schema.Dropdown(
+            schema.Color(
                 id = "text_color",
                 name = "Text Color",
                 desc = "The color for Standings / Race / Track / Time text.",
                 icon = "palette",
-                default = coloropt[0].value,
-                options = coloropt,
+                default = DEFAULT_TEXT_COLOR,
             ),
             schema.Generated(
                 id = "nascar_generated",


### PR DESCRIPTION
# Description
with Kurt Busch retiring, no need for 2 char 1st names at this time, reduced down to 1
changed text color drop down to schema.Color

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9c571e8</samp>

### Summary
🎨🗜️♻️

<!--
1.  🎨 - This emoji represents the change from a dropdown menu to a color picker for the text color option, which gives the user more flexibility and control over the appearance of the app.
2.  🗜️ - This emoji represents the change from using the full first name to using one character for the first name of the drivers, which reduces the width of the standings table and makes it more compact and readable.
3.  ♻️ - This emoji represents the refactoring of the code to use the `schema.Color` type instead of the `schema.Dropdown` type, which simplifies the code and makes it more consistent with the rest of the app.
-->
Refactor text color option and driver names format in `nascarnextrace` app. Use `schema.Color` for more flexibility and one-character first names for better readability.

> _Sing, O Muse, of the nascarnextrace app, the work of skillful coders_
> _Who refactored the text color option, to please the eyes of users_
> _And changed the driver names format, to show their first initials_
> _Like swift-footed Achilles or noble-hearted Odysseus_

### Walkthrough
*  Refactor text color option to use schema.Color instead of schema.Dropdown, allowing user to choose any color from a color picker ([link](https://github.com/tidbyt/community/pull/1777/files?diff=unified&w=0#diff-b1c40f21af46b32ce867ca5487d2de7ca7fb741c7fe133f2fe2a2ddf06ea4ff2R34), [link](https://github.com/tidbyt/community/pull/1777/files?diff=unified&w=0#diff-b1c40f21af46b32ce867ca5487d2de7ca7fb741c7fe133f2fe2a2ddf06ea4ff2L95-R99), [link](https://github.com/tidbyt/community/pull/1777/files?diff=unified&w=0#diff-b1c40f21af46b32ce867ca5487d2de7ca7fb741c7fe133f2fe2a2ddf06ea4ff2L204-R208), [link](https://github.com/tidbyt/community/pull/1777/files?diff=unified&w=0#diff-b1c40f21af46b32ce867ca5487d2de7ca7fb741c7fe133f2fe2a2ddf06ea4ff2L266-L304), [link](https://github.com/tidbyt/community/pull/1777/files?diff=unified&w=0#diff-b1c40f21af46b32ce867ca5487d2de7ca7fb741c7fe133f2fe2a2ddf06ea4ff2L361-R331))
*  Modify driver names format to use one character for first name, to avoid confusion with retiring driver Kurt Busch ([link](https://github.com/tidbyt/community/pull/1777/files?diff=unified&w=0#diff-b1c40f21af46b32ce867ca5487d2de7ca7fb741c7fe133f2fe2a2ddf06ea4ff2R8-R10), [link](https://github.com/tidbyt/community/pull/1777/files?diff=unified&w=0#diff-b1c40f21af46b32ce867ca5487d2de7ca7fb741c7fe133f2fe2a2ddf06ea4ff2L234-R238), [link](https://github.com/tidbyt/community/pull/1777/files?diff=unified&w=0#diff-b1c40f21af46b32ce867ca5487d2de7ca7fb741c7fe133f2fe2a2ddf06ea4ff2L246-R250))
*  Update VERSION variable to reflect latest version of app ([link](https://github.com/tidbyt/community/pull/1777/files?diff=unified&w=0#diff-b1c40f21af46b32ce867ca5487d2de7ca7fb741c7fe133f2fe2a2ddf06ea4ff2L16-R19))


