### PR TITLE
Update: MLB Next Games

### DIFF
--- a/apps/mlbnextgames/mlb_next_games.star
+++ b/apps/mlbnextgames/mlb_next_games.star
@@ -131,7 +131,7 @@ def create_game_display(game_date, opponent_nickname, logo):
 
 def main(config):
     team = config.get("team", "Angels")
-    timezone = config.get("timezone") or "America/New_York"
+    timezone = config.get("$tz") or "America/New_York"
 
     url_params = generate_url_parameters(team, timezone)
     schedule = get_schedule(BASE + url_params)


### PR DESCRIPTION
# Description
At the moment games times are set for Eastern. This change will show game times in the local timezone of the Tidbyt.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d0660cc</samp>

### Summary
🕒🔄🧩

<!--
1.  🕒 - This emoji represents the concept of time and timezone, and could be used to indicate that the config parameter for timezone was changed.
2.  🔄 - This emoji represents the idea of changing or updating something, and could be used to show that the config parameter was renamed to match a standard format.
3.  🧩 - This emoji represents the notion of fitting or matching pieces together, and could be used to suggest that the config parameter now aligns with other tidbyt apps.
-->
Updated `mlb_next_games.star` app to use `$tz` as the timezone config parameter. This improves consistency and usability of the app.

> _`timezone` to `$tz`_
> _config parameter changed_
> _autumn of tidbyt_

### Walkthrough
*  Rename config parameter for timezone to `$tz` to match standard format ([link](https://github.com/tidbyt/community/pull/1780/files?diff=unified&w=0#diff-bc483a1544358544cbfb29ed97b5ba9a71c7128dc63e6bbdbf7bd4c95bfee951L134-R134))


