### PR TITLE
Fix: Soccer Single - Fix PK Score - wrong location - didn't test enough

### DIFF
--- a/apps/soccersingle/soccer_single.star
+++ b/apps/soccersingle/soccer_single.star
@@ -201,10 +201,10 @@ def main(config):
                 # if FT-Pens - get penalty shootout score & append to score
                 if gameName == "STATUS_FINAL_PEN":
                     scoreFont = "CG-pixel-3x5-mono"
-                    homeShootoutScore = competition["competitors"][0]["shootoutScore"]
-                    awayShootoutScore = competition["competitors"][1]["shootoutScore"]
-                    homeScore = "%s (%s)" % (homeScore, homeShootoutScore)
-                    awayScore = "%s (%s)" % (awayScore, awayShootoutScore)
+                    homeShootoutScore = competition["competitors"][0]["score"]["shootoutScore"]
+                    awayShootoutScore = competition["competitors"][1]["score"]["shootoutScore"]
+                    homeScore = "%s (%s)" % (homeScore, str(int(homeShootoutScore)))
+                    awayScore = "%s (%s)" % (awayScore, str(int(awayShootoutScore)))
                     if (int(homeShootoutScore) > int(awayShootoutScore)):
                         homeScoreColor = "#ff0"
                         awayScoreColor = "#fffc"

--- a/apps/soccersingle/soccer_single.star
+++ b/apps/soccersingle/soccer_single.star
@@ -6,6 +6,7 @@ Author: jvivona
 """
 # 20230812 added display of penalty kick score if applicable
 #          toned down colors when display team colors - you couldn't see winner score if team color was also yellow
+# 20230829 fixed PK score - in a different place for single match results..   Not enough testing :-)
 
 # Tons of thanks to @whyamihere/@rs7q5 for the API assistance - couldn't have gotten here without you
 # and thanks to @dinotash/@dinosaursrarr for making me think deep thoughts about connected schema fields
@@ -17,7 +18,7 @@ load("render.star", "render")
 load("schema.star", "schema")
 load("time.star", "time")
 
-VERSION = 23224
+VERSION = 23241
 
 CACHE_TTL_SECONDS = 60
 


### PR DESCRIPTION
# Description
Fixed Penalty Score display for Single Match - missed that it's somewhere else for single match results.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2f518dc</samp>

### Summary
🐛🆕🔢

<!--
1.  🐛 for fixing a bug
2.  🆕 for adding a new feature
3.  🔢 for updating the app version
-->
Fixed a bug and added a feature to the `soccersingle` app for displaying soccer scores and standings on the Tidbyt device. Updated the app version in `soccer_single.star`.

> _The final whistle blows, the fate is sealed_
> _No more goals, no more appeals_
> _The `penaltyScore` is revealed, the crowd goes wild_
> _The `groupStandings` are updated, the champions smile_

### Walkthrough
*  Fix bug in displaying penalty shootout score for single match results ([link](https://github.com/tidbyt/community/pull/1783/files?diff=unified&w=0#diff-43a82dc095c51decf1aa17eb41bf1cb9e1116d126484d35557e2608d965b4e05R9), [link](https://github.com/tidbyt/community/pull/1783/files?diff=unified&w=0#diff-43a82dc095c51decf1aa17eb41bf1cb9e1116d126484d35557e2608d965b4e05L204-R208))


