### PR TITLE
baywheels : change to new lyft url

### DIFF
--- a/apps/baywheels/bay_wheels.star
+++ b/apps/baywheels/bay_wheels.star
@@ -13,8 +13,8 @@ load("render.star", "render")
 load("schema.star", "schema")
 
 # TODO: query these from https://gbfs.baywheels.com/gbfs/gbfs.json maybe?
-STATIONS_URL = "https://gbfs.baywheels.com/gbfs/fr/station_information.json"
-STATUS_URL = "https://gbfs.baywheels.com/gbfs/fr/station_status.json"
+STATIONS_URL = "https://gbfs.lyft.com/gbfs/2.3/bay/en/station_information.json"
+STATUS_URL = "https://gbfs.lyft.com/gbfs/2.3/bay/en/station_status.json"
 
 DEFAULT_STATION = '{ "display": "18th St at Noe St", "value": "cd7359fc-6798-48ed-af32-9d5f6cff9ffa"}'
 


### PR DESCRIPTION
# Description
Replaced old url to new url at lyft. As per issue : https://github.com/tidbyt/community/issues/1793

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7dae1a6</samp>

### Summary
🚲🛠️🔗

<!--
1.  🚲 - This emoji represents the Bay Wheels bike-sharing service and the app that displays its information on the Tidbyt device. It can be used to indicate the topic or theme of the changes.
2.  🛠️ - This emoji represents the fixing or repairing of the broken URLs that were causing the app to fail. It can be used to indicate the purpose or goal of the changes.
3.  🔗 - This emoji represents the links or URLs that were updated to use the new domain and version. It can be used to indicate the content or scope of the changes.
-->
Updated the Bay Wheels app to use the new API endpoints from Lyft. Fixed the broken URLs in `bay_wheels.star` that caused the app to fail.

> _`Bay Wheels` app broke_
> _Lyft changed URLs and version_
> _Winter bike rides saved_

### Walkthrough
* Update the station information and status URLs to use the new Lyft domain and version ([link](https://github.com/tidbyt/community/pull/1804/files?diff=unified&w=0#diff-0689e1ef47607aaeb61af4e7c8fb3b8b48813dd18098c34eeae30b8f4cd1a8b1L16-R17))


