### PR TITLE
remove exception for ncaafscores

### DIFF
--- a/.github/scripts/check-apps.sh
+++ b/.github/scripts/check-apps.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Trim quotes in case any were introduced.
-TARGETS=$(echo ${TARGETS} | tr -d '"' | tr ' ' '\n' | grep -v ncaafscores | xargs | awk '{$1=$1};1')
+TARGETS=$(echo ${TARGETS} | tr -d '"' | awk '{$1=$1};1')
 
 # Check apps.
 if [ ! -z "${TARGETS}" ]; then


### PR DESCRIPTION
# Description
Replace this with a description of your changes.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2c1be98</samp>

### Summary
🗑️🧹🤝

<!--
1.  🗑️ - This emoji represents the deletion or removal of something, in this case the unnecessary part of the command.
2.  🧹 - This emoji represents the cleaning or tidying up of something, in this case the whitespace from the TARGETS variable.
3.  🤝 - This emoji represents the collaboration or partnership of something, in this case the ncaafscores app joining the community repository.
-->
Simplified the script for checking apps and fixed a bug that excluded the ncaafscores app. Updated `.github/scripts/check-apps.sh` to remove unnecessary filtering and whitespace trimming.

> _No more `grep -v`_
> _Simpler logic for `TARGETS`_
> _Autumn leaves fall fast_

### Walkthrough
*  Simplify the command to get the app names from the apps directory by removing the unnecessary filtering and keeping the whitespace trimming ([link](https://github.com/tidbyt/community/pull/1808/files?diff=unified&w=0#diff-8ea7ea4d13a64514921c4ccfa292b6c8eb683ac4763a5833513981c76e2d65feL6-R6))


