### PR TITLE
Roomba: Add caching to roomba ip (server)

### DIFF
--- a/apps/roomba/index.js
+++ b/apps/roomba/index.js
@@ -13,6 +13,7 @@ const API_KEY = 'ADD_YOUR_OWN_API_KEY_HERE';
 
 const HOST = '0.0.0.0';
 const PORT = '6565';
+let cachedIP;
 
 const server = http.createServer((req, res) => {
     if (req.method === "GET") {
@@ -41,9 +42,14 @@ const server = http.createServer((req, res) => {
                     }
                 } else {
                     dorita980.getRobotIP((ierr, ip) => {
-                        if (ierr) return console.log('error looking for robot IP');  
+                        if (ierr) return console.log('error looking for robot IP');
+                        if (ip) {
+                            cachedIP = ip;
+                        }
+                    });
+                    if (cachedIP) {
                         try {
-                            var myRobotViaLocal = new dorita980.Local(BLID, PASSWORD, ip);
+                            var myRobotViaLocal = new dorita980.Local(BLID, PASSWORD, cachedIP);
                             myRobotViaLocal.getRobotState(['batPct']).then((state) => {
                                 res.writeHead(200, {'Content-Type': 'application/json'});
                                 res.write(JSON.stringify(state));
@@ -55,8 +61,8 @@ const server = http.createServer((req, res) => {
                         } catch(e) {
                             res.writeHead(500);
                             res.end();
-                        }              
-                    });
+                        }  
+                    }            
                 }
                 break;
             default:


### PR DESCRIPTION
# Description
Saves roomba ip requests on the server. This fixes a bug I've encountered with the `getRobotIP` function not working sometimes and will update with the old IP even if the call fails.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fecd777</samp>

### Summary
🚀🛠️🤖

<!--
1.  🚀 - This emoji conveys the idea of speed and efficiency, which are the benefits of caching the IP address and avoiding unnecessary network requests.
2.  🛠️ - This emoji represents the idea of fixing or repairing something, which is what the syntax error correction does for the `/roomba` endpoint logic.
3.  🤖 - This emoji is a playful and relevant way to indicate that the changes are related to the `roomba` app and the robot itself.
-->
Improved `roomba` app by caching IP address and fixing syntax error. The app now communicates faster and more reliably with the robot and handles the `/roomba` endpoint correctly.

> _Sing, O Muse, of the cunning coder who devised_
> _A swift and sure way to command the `roomba` app,_
> _By storing in his mind the address of the robot,_
> _And reusing it for every call, like Zeus' thunderbolt._

### Walkthrough
* Cache the IP address of the robot to avoid unnecessary network calls ([link](https://github.com/tidbyt/community/pull/1809/files?diff=unified&w=0#diff-78ad8781d8c3fa1df204406e86ea930f35635115c6b206c3f3780d72d8851aa3R16), [link](https://github.com/tidbyt/community/pull/1809/files?diff=unified&w=0#diff-78ad8781d8c3fa1df204406e86ea930f35635115c6b206c3f3780d72d8851aa3L44-R52), [link](https://github.com/tidbyt/community/pull/1809/files?diff=unified&w=0#diff-78ad8781d8c3fa1df204406e86ea930f35635115c6b206c3f3780d72d8851aa3L58-R65)) in `apps/roomba/index.js`


