### PR TITLE
Update: AFL Scores

### DIFF
--- a/apps/aflscores/afl_scores.star
+++ b/apps/aflscores/afl_scores.star
@@ -26,9 +26,8 @@ Changed background color for Adelaide Crows
 v2.1 
 Removed W-D-L data during pre-game display for finals matches
 
-Ideas for next season
-- show ladder position as an option in pre-game
-
+v2.1a
+Removed W-D-L data during pre-game display for finals matches, when "Live Games" and "Specific Team" is selected
 """
 
 load("encoding/json.star", "json")
@@ -86,13 +85,10 @@ def main(config):
     # Get the Current Round, according to the API
     CurrentRound = str(MatchesJSON["matches"][0]["compSeason"]["currentRoundNumber"])
 
-    # CurrentRound = "25"
     if ViewSelection == "All" or ViewSelection == "Live":
         CURRENT_ROUND_URL = ROUND_URL + CurrentRound
     elif ViewSelection == "Team":
         CURRENT_ROUND_URL = ROUND_URL + CurrentRound + TEAM_SUFFIX + TeamListSelection
-
-    #print(CURRENT_ROUND_URL)
 
     # Cache match info for 1 min
     RoundData = get_cachable_data(CURRENT_ROUND_URL, ROUND_CACHE)
@@ -250,25 +246,31 @@ def main(config):
                     HomeFound = 0
                     AwayFound = 0
 
-                    # show the win-draw-loss record for teams
-                    for y in range(0, 18, 1):
-                        if HomeTeam == LadderJSON["ladders"][0]["entries"][y]["team"]["id"]:
-                            HomeWins = str(LadderJSON["ladders"][0]["entries"][y]["thisSeasonRecord"]["winLossRecord"]["wins"])
-                            HomeLosses = str(LadderJSON["ladders"][0]["entries"][y]["thisSeasonRecord"]["winLossRecord"]["losses"])
-                            HomeDraws = str(LadderJSON["ladders"][0]["entries"][y]["thisSeasonRecord"]["winLossRecord"]["draws"])
-                            HomeFound = 1
-                        if AwayTeam == LadderJSON["ladders"][0]["entries"][y]["team"]["id"]:
-                            AwayWins = str(LadderJSON["ladders"][0]["entries"][y]["thisSeasonRecord"]["winLossRecord"]["wins"])
-                            AwayLosses = str(LadderJSON["ladders"][0]["entries"][y]["thisSeasonRecord"]["winLossRecord"]["losses"])
-                            AwayDraws = str(LadderJSON["ladders"][0]["entries"][y]["thisSeasonRecord"]["winLossRecord"]["draws"])
-                            AwayFound = 1
+                    # if not finals, show W-D-L
+                    if MatchesJSON["matches"][0]["compSeason"]["currentRoundNumber"] < 25:
+                        # show the win-draw-loss record for teams
+                        for y in range(0, 18, 1):
+                            if HomeTeam == LadderJSON["ladders"][0]["entries"][y]["team"]["id"]:
+                                HomeWins = str(LadderJSON["ladders"][0]["entries"][y]["thisSeasonRecord"]["winLossRecord"]["wins"])
+                                HomeLosses = str(LadderJSON["ladders"][0]["entries"][y]["thisSeasonRecord"]["winLossRecord"]["losses"])
+                                HomeDraws = str(LadderJSON["ladders"][0]["entries"][y]["thisSeasonRecord"]["winLossRecord"]["draws"])
+                                HomeFound = 1
+                            if AwayTeam == LadderJSON["ladders"][0]["entries"][y]["team"]["id"]:
+                                AwayWins = str(LadderJSON["ladders"][0]["entries"][y]["thisSeasonRecord"]["winLossRecord"]["wins"])
+                                AwayLosses = str(LadderJSON["ladders"][0]["entries"][y]["thisSeasonRecord"]["winLossRecord"]["losses"])
+                                AwayDraws = str(LadderJSON["ladders"][0]["entries"][y]["thisSeasonRecord"]["winLossRecord"]["draws"])
+                                AwayFound = 1
 
-                        # We found both teams, so break out
-                        if HomeFound + AwayFound == 2:
-                            break
+                            # We found both teams, so break out
+                            if HomeFound + AwayFound == 2:
+                                break
 
-                    HomeRecord = HomeWins + "-" + HomeDraws + "-" + HomeLosses
-                    AwayRecord = AwayWins + "-" + AwayDraws + "-" + AwayLosses
+                        HomeRecord = HomeWins + "-" + HomeDraws + "-" + HomeLosses
+                        AwayRecord = AwayWins + "-" + AwayDraws + "-" + AwayLosses
+
+                    else:
+                        HomeRecord = ""
+                        AwayRecord = ""
 
                     # Render on the screen
                     SchedOutput = showScheduledGame(HomeRecord, AwayRecord, home_team_abb, away_team_abb, home_team_font, away_team_font, home_team_bkg, away_team_bkg, starttime)
@@ -350,23 +352,31 @@ def main(config):
                 HomeFound = 0
                 AwayFound = 0
 
-                # show the win-draw-loss record for teams
-                for y in range(0, 18, 1):
-                    if HomeTeam == LadderJSON["ladders"][0]["entries"][y]["team"]["id"]:
-                        HomeWins = str(LadderJSON["ladders"][0]["entries"][y]["thisSeasonRecord"]["winLossRecord"]["wins"])
-                        HomeLosses = str(LadderJSON["ladders"][0]["entries"][y]["thisSeasonRecord"]["winLossRecord"]["losses"])
-                        HomeDraws = str(LadderJSON["ladders"][0]["entries"][y]["thisSeasonRecord"]["winLossRecord"]["draws"])
-                    if AwayTeam == LadderJSON["ladders"][0]["entries"][y]["team"]["id"]:
-                        AwayWins = str(LadderJSON["ladders"][0]["entries"][y]["thisSeasonRecord"]["winLossRecord"]["wins"])
-                        AwayLosses = str(LadderJSON["ladders"][0]["entries"][y]["thisSeasonRecord"]["winLossRecord"]["losses"])
-                        AwayDraws = str(LadderJSON["ladders"][0]["entries"][y]["thisSeasonRecord"]["winLossRecord"]["draws"])
+                # if not finals, show W-D-L
+                if MatchesJSON["matches"][0]["compSeason"]["currentRoundNumber"] < 25:
+                    # show the win-draw-loss record for teams
+                    for y in range(0, 18, 1):
+                        if HomeTeam == LadderJSON["ladders"][0]["entries"][y]["team"]["id"]:
+                            HomeWins = str(LadderJSON["ladders"][0]["entries"][y]["thisSeasonRecord"]["winLossRecord"]["wins"])
+                            HomeLosses = str(LadderJSON["ladders"][0]["entries"][y]["thisSeasonRecord"]["winLossRecord"]["losses"])
+                            HomeDraws = str(LadderJSON["ladders"][0]["entries"][y]["thisSeasonRecord"]["winLossRecord"]["draws"])
+                            HomeFound = 1
+                        if AwayTeam == LadderJSON["ladders"][0]["entries"][y]["team"]["id"]:
+                            AwayWins = str(LadderJSON["ladders"][0]["entries"][y]["thisSeasonRecord"]["winLossRecord"]["wins"])
+                            AwayLosses = str(LadderJSON["ladders"][0]["entries"][y]["thisSeasonRecord"]["winLossRecord"]["losses"])
+                            AwayDraws = str(LadderJSON["ladders"][0]["entries"][y]["thisSeasonRecord"]["winLossRecord"]["draws"])
+                            AwayFound = 1
 
-                    # We found both teams, so break out
-                    if HomeFound + AwayFound == 2:
-                        break
+                        # We found both teams, so break out
+                        if HomeFound + AwayFound == 2:
+                            break
 
-                HomeRecord = HomeWins + "-" + HomeDraws + "-" + HomeLosses
-                AwayRecord = AwayWins + "-" + AwayDraws + "-" + AwayLosses
+                    HomeRecord = HomeWins + "-" + HomeDraws + "-" + HomeLosses
+                    AwayRecord = AwayWins + "-" + AwayDraws + "-" + AwayLosses
+
+                else:
+                    HomeRecord = ""
+                    AwayRecord = ""
 
                 # Render on the screen
                 SchedOutput = showScheduledGame(HomeRecord, AwayRecord, home_team_abb, away_team_abb, home_team_font, away_team_font, home_team_bkg, away_team_bkg, starttime)


### PR DESCRIPTION
# Description
Removed W-D-L data during pre-game display for finals matches, when "Live Games" and "Specific Team" is selected. Previous update was only for "All Matches"

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 666c266</samp>

### Summary
:sparkles::mute::wastebasket:

<!--
1.  :sparkles: - This emoji is often used to indicate the addition of a new feature or enhancement to an existing app or project. It conveys a sense of excitement and creativity, and suggests that the feature is something valuable or desirable for the users or stakeholders.
2.  :mute: - This emoji is used to indicate the removal or suppression of something, such as sound, speech, or noise. In this context, it could represent the hiding of the W-D-L record for teams in finals matches, as this information is not relevant or helpful for the users who want to focus on the outcome of the match. It could also imply that the feature is optional or configurable, and that the users can choose to mute or unmute the W-D-L record according to their preference.
3.  :wastebasket: - This emoji is used to indicate the deletion or disposal of something, such as trash, waste, or unwanted items. In this context, it could represent the removal of the commented-out code that was used for testing, as this code is no longer needed or useful for the app. It could also suggest that the code was cluttering or confusing the app, and that the removal improves the readability or quality of the code.
-->
This pull request improves the `aflscores` app by hiding irrelevant W-D-L records for finals matches and cleaning up unused code.

> _A user of `aflscores` app_
> _Did not like to see W-D-L stats_
> _So the coder complied_
> _And the records he hid_
> _And also cleaned up some old scraps_

### Walkthrough
*  Hide W-D-L record for finals matches when displaying pre-game information ([link](https://github.com/tidbyt/community/pull/1823/files?diff=unified&w=0#diff-d716ba70c74849eb9bd237328ea408adc40b5ac1f613b6bfa19810ec04bc029cL253-R274), [link](https://github.com/tidbyt/community/pull/1823/files?diff=unified&w=0#diff-d716ba70c74849eb9bd237328ea408adc40b5ac1f613b6bfa19810ec04bc029cL353-R380))
* Update version number and comment in `afl_scores.star` to reflect new feature ([link](https://github.com/tidbyt/community/pull/1823/files?diff=unified&w=0#diff-d716ba70c74849eb9bd237328ea408adc40b5ac1f613b6bfa19810ec04bc029cL29-R30))
* Remove commented-out lines in `afl_scores.star` that were used for testing and printing ([link](https://github.com/tidbyt/community/pull/1823/files?diff=unified&w=0#diff-d716ba70c74849eb9bd237328ea408adc40b5ac1f613b6bfa19810ec04bc029cL89), [link](https://github.com/tidbyt/community/pull/1823/files?diff=unified&w=0#diff-d716ba70c74849eb9bd237328ea408adc40b5ac1f613b6bfa19810ec04bc029cL95-L96))


