### PR TITLE
Fix: NRL Scores

### DIFF
--- a/apps/nrlscores/nrl_scores.star
+++ b/apps/nrlscores/nrl_scores.star
@@ -9,6 +9,9 @@ First release
 
 v1.1
 Updated abbreviations
+
+v1.2
+Updated round number determination
 """
 
 load("encoding/json.star", "json")
@@ -40,7 +43,8 @@ def main(config):
     LadderData = get_cachable_data(LADDER_URL, LADDER_CACHE)
     LadderJSON = json.decode(LadderData)
 
-    RoundNumber = str(MatchesJSON["selectedRoundId"])
+    RoundNumber = MatchesJSON["fixtures"][0]["roundTitle"]
+    RoundNumber = RoundNumber[6:]
 
     LIVE_URL = MATCHES_URL + "&round=" + RoundNumber
     LiveData = get_cachable_data(LIVE_URL, LIVE_CACHE)

--- a/apps/nrlscores/nrl_scores.star
+++ b/apps/nrlscores/nrl_scores.star
@@ -41,7 +41,7 @@ def main(config):
     LadderJSON = json.decode(LadderData)
 
     RoundNumber = str(MatchesJSON["selectedRoundId"])
-        
+
     LIVE_URL = MATCHES_URL + "&round=" + RoundNumber
     LiveData = get_cachable_data(LIVE_URL, LIVE_CACHE)
     LiveJSON = json.decode(LiveData)

--- a/apps/nrlscores/nrl_scores.star
+++ b/apps/nrlscores/nrl_scores.star
@@ -40,9 +40,8 @@ def main(config):
     LadderData = get_cachable_data(LADDER_URL, LADDER_CACHE)
     LadderJSON = json.decode(LadderData)
 
-    RoundNumber = MatchesJSON["fixtures"][0]["roundTitle"]
-    RoundNumber = RoundNumber[6:]
-
+    RoundNumber = str(MatchesJSON["selectedRoundId"])
+        
     LIVE_URL = MATCHES_URL + "&round=" + RoundNumber
     LiveData = get_cachable_data(LIVE_URL, LIVE_CACHE)
     LiveJSON = json.decode(LiveData)


### PR DESCRIPTION
# Description
Previous method of determining the round number was not working for finals, found alternate & better method

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 540a577</samp>

### Summary
🐛🔄🚀

<!--
1.  🐛 - This emoji represents a bug fix, as the app was not working as intended before the change.
2.  🔄 - This emoji represents a refactoring or improvement of the existing code, as the change makes the code more readable and maintainable.
3.  🚀 - This emoji represents a feature enhancement or performance improvement, as the change makes the app more responsive and accurate for the users.
-->
Fixed a bug in `nrl_scores.star` that caused incorrect live scores to be shown. Used a more reliable field to determine the current round and fixed a type mismatch.

> _`selectedRoundId`_
> _A reliable field to use_
> _No more parsing woes_

### Walkthrough
* Fix bug where app would not display correct live scores for current round by using `selectedRoundId` field instead of `roundTitle` field and converting `RoundNumber` to string ([link](https://github.com/tidbyt/community/pull/1824/files?diff=unified&w=0#diff-fcd53ccdb770ab4984779093f94d657d2180df9246c72b12206235ceb4169b0fL43-R44))


