### PR TITLE
Fix: NRL Scores

### DIFF
--- a/apps/nrlscores/nrl_scores.star
+++ b/apps/nrlscores/nrl_scores.star
@@ -9,6 +9,9 @@ First release
 
 v1.1
 Updated abbreviations
+
+v1.2
+Updated method of determining the round number, as the old method wasn't working for finals
 """
 
 load("encoding/json.star", "json")
@@ -40,8 +43,7 @@ def main(config):
     LadderData = get_cachable_data(LADDER_URL, LADDER_CACHE)
     LadderJSON = json.decode(LadderData)
 
-    RoundNumber = MatchesJSON["fixtures"][0]["roundTitle"]
-    RoundNumber = RoundNumber[6:]
+    RoundNumber = str(MatchesJSON["selectedRoundId"])
 
     LIVE_URL = MATCHES_URL + "&round=" + RoundNumber
     LiveData = get_cachable_data(LIVE_URL, LIVE_CACHE)


### PR DESCRIPTION
# Description
Updated method of determining the round number, as the old method wasn't working for finals

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c93102a</samp>

### Summary
🐛🏉🏆

<!--
1.  🐛 - This emoji represents a bug or an error, and can be used to indicate that the update fixed a bug with the round number detection.
2.  🏉 - This emoji represents a rugby ball, and can be used to indicate that the update is related to the NRL Scores applet, which shows the scores of the National Rugby League matches.
3.  🏆 - This emoji represents a trophy or an award, and can be used to indicate that the update improves the functionality for the finals rounds, which are the most important and competitive matches of the season.
-->
Fixed a bug in the `nrl_scores` applet that caused incorrect round numbers for the finals. Updated the applet to use a more reliable data field from the API.

> _Sing, O Muse, of the skillful coder who updated the applet_
> _That shows the glorious deeds of the rugby warriors in the NRL_
> _He fixed the cunning bug that plagued the round number detection_
> _By using a different field from the `MatchesJSON` source of information_

### Walkthrough
*  Update applet version and add comment for new feature ([link](https://github.com/tidbyt/community/pull/1827/files?diff=unified&w=0#diff-fcd53ccdb770ab4984779093f94d657d2180df9246c72b12206235ceb4169b0fL1-R16))
*  Change round number logic to use `selectedRoundId` field from MatchesJSON data ([link](https://github.com/tidbyt/community/pull/1827/files?diff=unified&w=0#diff-fcd53ccdb770ab4984779093f94d657d2180df9246c72b12206235ceb4169b0fL43-R46))
*  Update LIVE_URL variable to use new round number ([link](https://github.com/tidbyt/community/pull/1827/files?diff=unified&w=0#diff-fcd53ccdb770ab4984779093f94d657d2180df9246c72b12206235ceb4169b0fL43-R46))


