### PR TITLE
murphy_gas : fix station list get ttl

### DIFF
--- a/apps/murphyusagas/murphy_usa_gas.star
+++ b/apps/murphyusagas/murphy_usa_gas.star
@@ -133,7 +133,7 @@ def get_stations(location):
     lat = humanize.float("#.##", float(loc["lat"]))
     lng = humanize.float("#.##", float(loc["lng"]))
 
-    http_response = http.post(url = API_STATION_SEARCH, json_body = {"pagesize": API_STATION_SEARCH_PAGESIZE, "range": API_STATION_SEARCH_RANGE, "latitude": lat, "longitude": lng}, ttl_seconds = API_STATION_CACHE_KEY)
+    http_response = http.post(url = API_STATION_SEARCH, json_body = {"pagesize": API_STATION_SEARCH_PAGESIZE, "range": API_STATION_SEARCH_RANGE, "latitude": lat, "longitude": lng}, ttl_seconds = API_STATION_LIST_TTL)
     if http_response.status_code != 200:
         fail("Station list request failed with status {} and result {}".format(http_response.status_code, http_response.body()))
     stations = http_response.json()["data"]


### PR DESCRIPTION
# Description
cache_key was used instead of an integer TTL value.  replace with API_STATION_LIST_TTL. tested and working.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9f1a48f</samp>

### Summary
🐛🚀📡

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of this change.
2.  🚀 - This emoji represents a performance improvement, which is the secondary benefit of this change.
3.  📡 - This emoji represents a network or API related change, which is the domain of this change.
-->
Fixed a bug in `murphy_usa_gas.star` that caused the station list cache to expire too quickly. Used the correct constant for the `ttl_seconds` parameter of the `http.post` call.

> _`ttl_seconds`_
> _Fixed a bug in `http.post`_
> _Cache lasts longer now_

### Walkthrough
* Fix bug where station list cache key was used as time-to-live value ([link](https://github.com/tidbyt/community/pull/1831/files?diff=unified&w=0#diff-951cc7eb877c8007f7ce257fa6a83ec1e42eaca06b74788406a85b83a2d7de34L136-R136)). Use `API_STATION_LIST_TTL` constant instead of `API_STATION_CACHE_KEY` for `ttl_seconds` parameter of `http.post` call in `apps/murphyusagas/murphy_usa_gas.star`.


