### PR TITLE
New app: Nu.nl (Dutch news ticker)

### DIFF
--- a/apps/nunl/README.md
+++ b/apps/nunl/README.md
@@ -1,0 +1,5 @@
+# Nu.nl Applet for Tidbyt
+
+Shows random one of the latest news items from the Dutch website [nu.nl](https://www.nu.nl).
+
+Data provided by [Nu.nl](https://www.nu.nl).

--- a/apps/nunl/manifest.yaml
+++ b/apps/nunl/manifest.yaml
@@ -1,0 +1,8 @@
+---
+id: nunl
+name: Nu.nl
+summary: Latest news from nu.nl
+desc: Shows random one of the latest news items from the Dutch website nu.nl.
+author: PMK (@pmk)
+fileName: nunl.star
+packageName: nunl

--- a/apps/nunl/nunl.star
+++ b/apps/nunl/nunl.star
@@ -100,6 +100,7 @@ def get_schema():
         schema.Option(display = "Wetenschap", value = "Wetenschap"),
         schema.Option(display = "Tech", value = "Tech"),
         schema.Option(display = "Gezondheid", value = "Gezondheid"),
+        schema.Option(display = "Podcast", value = "Podcast"),
     ]
 
     return schema.Schema(

--- a/apps/nunl/nunl.star
+++ b/apps/nunl/nunl.star
@@ -1,0 +1,117 @@
+"""
+Applet: Nunl
+Summary: Latest news from nu.nl
+Description: Shows random one of the latest news items from the Dutch website nu.nl.
+Author: PMK (@pmk)
+"""
+
+load("encoding/base64.star", "base64")
+load("http.star", "http")
+load("random.star", "random")
+load("render.star", "render")
+load("schema.star", "schema")
+load("xpath.star", "xpath")
+
+DEFAULT_CATEGORY = "Algemeen"
+
+LOGO = base64.decode("""
+R0lGODlhCwALAJEDALUMFv///wIAUQAAACH5BAEAAAMALAAAAAALAAsAAAIfnCd5l63mIgxUBCsQvhyAxG0euGFZSV1Q1DDssmZHAQA7
+""")
+
+def get_news_feed(category = DEFAULT_CATEGORY, ttl_seconds = 60 * 5):
+    url = "https://www.nu.nl/rss/{}".format(category)
+    response = http.get(url = url, ttl_seconds = ttl_seconds)
+    if response.status_code != 200:
+        fail("Nu.nl request failed with status %d @ %s", response.status_code, url)
+    return response.body()
+
+def parse_news_feed(raw_xml):
+    result = []
+    for feed_item in xpath.loads(raw_xml).query_all_nodes("//rss/channel/item"):
+        result.append({
+            # "date": feed_item.query("/pubDate"), # no support for parsing time as RFC228
+            "title": feed_item.query("/title"),
+            "image": feed_item.query("/enclosure/@url"),
+        })
+    return result
+
+def get_image(image_url):
+    response = http.get(url = image_url.replace("sqr256.jpg", "wd854"), ttl_seconds = 60 * 60 * 24 * 7)
+    if response.status_code != 200:
+        fail("Image from nu.nl request failed with status %d @ %s", response.status_code, image_url)
+    return response.body()
+
+def main(config):
+    category = config.str("category", DEFAULT_CATEGORY)
+
+    news_item_list = parse_news_feed(get_news_feed(category))
+    random_index = random.number(0, len(news_item_list) - 1)
+
+    return render.Root(
+        show_full_animation = True,
+        max_age = 60 * 5,
+        child = render.Stack(
+            children = [
+                render.Image(
+                    src = get_image(news_item_list[random_index]["image"]),
+                    width = 64,
+                    height = 32,
+                ),
+                render.Column(
+                    main_align = "space_between",
+                    expanded = True,
+                    children = [
+                        render.Padding(
+                            pad = (1, 1, 1, 1),
+                            child = render.Image(
+                                src = LOGO,
+                                width = 11,
+                                height = 11,
+                            ),
+                        ),
+                        render.Box(
+                            width = 64,
+                            height = 9,
+                            color = "#0008",
+                            child = render.Marquee(
+                                width = 64,
+                                child = render.Text(
+                                    content = news_item_list[random_index]["title"],
+                                    font = "tb-8",
+                                    color = "#fff",
+                                ),
+                            ),
+                        ),
+                    ],
+                ),
+            ],
+        ),
+    )
+
+def get_schema():
+    categories = [
+        schema.Option(display = "Algemeen", value = "Algemeen"),
+        schema.Option(display = "Economie", value = "Economie"),
+        schema.Option(display = "Sport", value = "Sport"),
+        schema.Option(display = "Achterklap", value = "Achterklap"),
+        schema.Option(display = "Opmerkelijk", value = "Opmerkelijk"),
+        schema.Option(display = "Muziek", value = "Muziek"),
+        schema.Option(display = "Film", value = "Film"),
+        schema.Option(display = "Wetenschap", value = "Wetenschap"),
+        schema.Option(display = "Tech", value = "Tech"),
+        schema.Option(display = "Gezondheid", value = "Gezondheid"),
+    ]
+
+    return schema.Schema(
+        version = "1",
+        fields = [
+            schema.Dropdown(
+                id = "category",
+                name = "News category",
+                desc = "Choose a news category",
+                default = categories[0].value,
+                options = categories,
+                icon = "newspaper",
+            ),
+        ],
+    )

--- a/apps/nunl/nunl.star
+++ b/apps/nunl/nunl.star
@@ -33,7 +33,7 @@ def get_nth_item_from_raw_xml(raw_xml, nth = 1):
     }
 
 def get_image(image_url):
-    response = http.get(url = image_url.replace("sqr256.jpg", "wd854"), ttl_seconds = 60 * 60 * 24 * 7)
+    response = http.get(url = image_url.replace("sqr256.jpg", "std160"), ttl_seconds = 60 * 60 * 24 * 7)
     if response.status_code != 200:
         fail("Image from nu.nl request failed with status %d @ %s", response.status_code, image_url)
     return response.body()

--- a/apps/nunl/nunl.star
+++ b/apps/nunl/nunl.star
@@ -29,7 +29,6 @@ def parse_news_feed(raw_xml):
     result = []
     for feed_item in xpath.loads(raw_xml).query_all_nodes("//rss/channel/item"):
         result.append({
-            # "date": feed_item.query("/pubDate"), # no support for parsing time as RFC228
             "title": feed_item.query("/title"),
             "image": feed_item.query("/enclosure/@url"),
         })
@@ -75,6 +74,7 @@ def main(config):
                             color = "#0008",
                             child = render.Marquee(
                                 width = 64,
+                                offset_start = 64,
                                 child = render.Text(
                                     content = news_item_list[random_index]["title"],
                                     font = "tb-8",

--- a/apps/nunl/nunl.star
+++ b/apps/nunl/nunl.star
@@ -15,7 +15,7 @@ load("xpath.star", "xpath")
 DEFAULT_CATEGORY = "Algemeen"
 
 LOGO = base64.decode("""
-R0lGODlhCwALAJEDALUMFv///wIAUQAAACH5BAEAAAMALAAAAAALAAsAAAIfnCd5l63mIgxUBCsQvhyAxG0euGFZSV1Q1DDssmZHAQA7
+R0lGODlhCgAKAJEDALUMFv///wIAUQAAACH5BAEAAAMALAAAAAAKAAoAAAIanIWmyDkNX5giVCGvDQBo3X2T9UDMYSoophQAOw==
 """)
 
 def get_news_feed(category = DEFAULT_CATEGORY, ttl_seconds = 60 * 5):
@@ -65,8 +65,8 @@ def main(config):
                             pad = (1, 1, 1, 1),
                             child = render.Image(
                                 src = LOGO,
-                                width = 11,
-                                height = 11,
+                                width = 10,
+                                height = 10,
                             ),
                         ),
                         render.Box(


### PR DESCRIPTION
# Description
This new app shows random one of the latest news items from the Dutch website [nu.nl](https://www.nu.nl). This will show as a news ticker in Dutch. You can also optionally specify a news category.

Data provided by [Nu.nl](https://www.nu.nl).

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b1a93a2</samp>

### Summary
📰🇳🇱🌟

<!--
1.  📰 - This emoji represents the news theme of the applet and the data source.
2.  🇳🇱 - This emoji represents the Dutch origin and language of the applet and the data source.
3.  🌟 - This emoji represents the Starlark programming language used to write the applet code.
-->
This pull request adds a new applet for the Tidbyt community that shows the latest news from nu.nl. It includes the applet code in `nunl.star`, the metadata and configuration in `manifest.yaml`, and the documentation in `README.md`.

> _`Nu.nl` applet code_
> _News from the Netherlands on Tidbyt_
> _Autumn leaves fall_

### Walkthrough
* Create a new applet for displaying news from nu.nl ([link](https://github.com/tidbyt/community/pull/1837/files?diff=unified&w=0#diff-8447706bfce1b253ad2b5d9ececc14fe196fa0d9217198e3e545e02dcb019fddR1-R8), [link](https://github.com/tidbyt/community/pull/1837/files?diff=unified&w=0#diff-b4fb946dc5069fee79975181eb2548fd65768febf191d9972721e082cfaa6741R1-R117), [link](https://github.com/tidbyt/community/pull/1837/files?diff=unified&w=0#diff-802da93a6645969d910d913290c8d6125fb08eee9db5b95812ef6628c3ff289eR1-R5))
  * Add a `manifest.yaml` file to define the applet metadata and configuration ([link](https://github.com/tidbyt/community/pull/1837/files?diff=unified&w=0#diff-8447706bfce1b253ad2b5d9ececc14fe196fa0d9217198e3e545e02dcb019fddR1-R8))
  * Add a `nunl.star` file to implement the applet logic using Starlark modules ([link](https://github.com/tidbyt/community/pull/1837/files?diff=unified&w=0#diff-b4fb946dc5069fee79975181eb2548fd65768febf191d9972721e082cfaa6741R1-R117))
    * Load and parse the news feed from nu.nl using `http` and `json` modules ([link](https://github.com/tidbyt/community/pull/1837/files?diff=unified&w=0#diff-b4fb946dc5069fee79975181eb2548fd65768febf191d9972721e082cfaa6741R1-R117))
    * Render a random news item with its image and title using `render` and `image` modules ([link](https://github.com/tidbyt/community/pull/1837/files?diff=unified&w=0#diff-b4fb946dc5069fee79975181eb2548fd65768febf191d9972721e082cfaa6741R1-R117))
    * Define a schema for the user to choose a news category using `config` module ([link](https://github.com/tidbyt/community/pull/1837/files?diff=unified&w=0#diff-b4fb946dc5069fee79975181eb2548fd65768febf191d9972721e082cfaa6741R1-R117))
  * Add a `README.md` file to provide a brief introduction and a link to the data source ([link](https://github.com/tidbyt/community/pull/1837/files?diff=unified&w=0#diff-802da93a6645969d910d913290c8d6125fb08eee9db5b95812ef6628c3ff289eR1-R5))


