### PR TITLE
New app: Buienradar (rain radar)

### DIFF
--- a/apps/buienradar/README.md
+++ b/apps/buienradar/README.md
@@ -1,0 +1,6 @@
+# Buienradar Applet for Tidbyt
+
+Shows the rain radar of Belgium or The Netherlands.
+
+Data provided by [Buienradar](https://buienradar.nl).
+Buienradar is a brand of RTL Nederland.

--- a/apps/buienradar/buienradar.star
+++ b/apps/buienradar/buienradar.star
@@ -1,0 +1,74 @@
+"""
+Applet: Buienradar
+Summary: Buienradar (BE/NL)
+Description: Shows the buienradar of Belgium or The Netherlands.
+Author: PMK (@pmk)
+"""
+
+load("http.star", "http")
+load("render.star", "render")
+load("schema.star", "schema")
+
+DEFAULT_COUNTRY = "NL"
+
+def get_radar(country = DEFAULT_COUNTRY, ttl_seconds = 60 * 15):
+    url = "https://image.buienradar.nl/2.0/image/animation/RadarMapRainWebMercator{}?width=64&height=64&renderBackground=True&renderBranding=False&renderText=False".format(country)
+    response = http.get(url = url, ttl_seconds = ttl_seconds)
+    if response.status_code != 200:
+        fail("Buienradar request failed with status %d @ %s", response.status_code, url)
+    return response.body()
+
+def main(config):
+    country = config.str("country", DEFAULT_COUNTRY)
+
+    radar = get_radar(country)
+
+    return render.Root(
+        child = render.Stack(
+            children = [
+                render.Box(
+                    child = render.Image(
+                        src = radar,
+                        width = 64,
+                        height = 64,
+                    ),
+                ),
+                render.Padding(
+                    pad = (1, 1, 1, 1),
+                    child = render.WrappedText(
+                        width = 24,
+                        linespacing = 1,
+                        content = "Buien- radar",
+                        color = "#fff",
+                        font = "CG-pixel-3x5-mono",
+                    ),
+                ),
+            ],
+        ),
+    )
+
+def get_schema():
+    options = [
+        schema.Option(
+            display = "Nederland",
+            value = "NL",
+        ),
+        schema.Option(
+            display = "België",
+            value = "BE",
+        ),
+    ]
+
+    return schema.Schema(
+        version = "1",
+        fields = [
+            schema.Dropdown(
+                id = "country",
+                name = "Land",
+                desc = "Welk land weergegeven moet worden.",
+                icon = "globe",
+                default = options[0].value,
+                options = options,
+            ),
+        ],
+    )

--- a/apps/buienradar/buienradar.star
+++ b/apps/buienradar/buienradar.star
@@ -1,7 +1,7 @@
 """
 Applet: Buienradar
 Summary: Buienradar (BE/NL)
-Description: Shows the buienradar of Belgium or The Netherlands.
+Description: Shows the rain radar of Belgium or The Netherlands.
 Author: PMK (@pmk)
 """
 

--- a/apps/buienradar/buienradar.star
+++ b/apps/buienradar/buienradar.star
@@ -22,16 +22,18 @@ def main(config):
     country = config.str("country", DEFAULT_COUNTRY)
 
     radar = get_radar(country)
+    radar_image = render.Image(
+        src = radar,
+        width = 64,
+        height = 64,
+    )
 
     return render.Root(
+        delay = radar_image.delay,
         child = render.Stack(
             children = [
                 render.Box(
-                    child = render.Image(
-                        src = radar,
-                        width = 64,
-                        height = 64,
-                    ),
+                    child = radar_image,
                 ),
                 render.Padding(
                     pad = (1, 1, 1, 1),

--- a/apps/buienradar/manifest.yaml
+++ b/apps/buienradar/manifest.yaml
@@ -1,0 +1,8 @@
+---
+id: buienradar
+name: Buienradar
+summary: Buienradar (BE/NL)
+desc: Shows the buienradar of Belgium or The Netherlands.
+author: PMK (@pmk)
+fileName: buienradar.star
+packageName: buienradar

--- a/apps/buienradar/manifest.yaml
+++ b/apps/buienradar/manifest.yaml
@@ -2,7 +2,7 @@
 id: buienradar
 name: Buienradar
 summary: Buienradar (BE/NL)
-desc: Shows the buienradar of Belgium or The Netherlands.
+desc: Shows the rain radar of Belgium or The Netherlands.
 author: PMK (@pmk)
 fileName: buienradar.star
 packageName: buienradar


### PR DESCRIPTION
# Description
This new app shows the rain radar of Belgium or The Netherlands. The data is provided by [Buienradar.nl](https://buienradar.nl), a brand of RTL Nederland.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9bba2b6</samp>

### Summary
🌧️🌍📝

<!--
1.  🌧️ - This emoji represents the rain radar feature of the applet, which is the main functionality and appeal of the applet. It also matches the name of the applet, Buienradar, which means rain radar in Dutch.
2.  🌍 - This emoji represents the country selection option of the applet, which allows the user to choose between Belgium and The Netherlands. It also indicates that the applet is based on a geographic data source and that it may be useful for users in those regions.
3.  📝 - This emoji represents the documentation and metadata of the applet, which includes the manifest.yaml file, the README.md file, and the schema function. It also suggests that the applet is well-documented and follows the applet development guidelines.
-->
This pull request adds a new applet called Buienradar, which shows the rain radar of Belgium or The Netherlands on the Tidbyt device. It includes the applet code in `buienradar.star`, the manifest file in `manifest.yaml`, and the documentation file in `README.md`.

> _`Buienradar` app_
> _Shows the rain on Tidbyt_
> _Autumn is coming_

### Walkthrough
* Create a new applet for displaying the rain radar of Belgium or The Netherlands using the Buienradar API ([link](https://github.com/tidbyt/community/pull/1840/files?diff=unified&w=0#diff-94395b75776a70047a31d469c0fe95b7a0287a787709dbe8392a198b2e7ee575R1-R74), [link](https://github.com/tidbyt/community/pull/1840/files?diff=unified&w=0#diff-19768fa9ad75c679aeecb87f3f6f1eace00c4f12b821ccfb4dbc2c0d3a5e6e8cR1-R8), [link](https://github.com/tidbyt/community/pull/1840/files?diff=unified&w=0#diff-08f8c7389091472b7f45383fcb2e8de8e7a079b6e9adcc1a65a942b05a93668cR1-R6))


