### PR TITLE
fix:  racing apps - handle end of season better

### DIFF
--- a/apps/formula1/formula_1.star
+++ b/apps/formula1/formula_1.star
@@ -12,7 +12,7 @@ load("render.star", "render")
 load("schema.star", "schema")
 load("time.star", "time")
 
-VERSION = 23247
+VERSION = 23254
 
 # ############################
 # Mods - jvivona - 2023-02-04
@@ -37,6 +37,7 @@ VERSION = 23247
 # - fix trunc of am/pm - to not trunc when we're in 24 hour format
 # jvivona - 20230904
 # - fix date display - remove leading 0
+# jvivona - 20230911 - handle end of season calendar - no upcoming races
 # ############################
 
 DEFAULTS = {
@@ -132,8 +133,11 @@ def main(config):
     # return data is already at MRData
 
     if display == "NRI":
-        #Next Race
-        next_race = f1_cached["RaceTable"]["Races"][0]
+        if len(f1_cached["RaceTable"]["Races"]) == 0:
+            return []
+        else:
+            #Next Race
+            next_race = f1_cached["RaceTable"]["Races"][0]
 
         #code from @whyamihere to automatically adjust the date time sting from the API
         date_and_time = next_race["date"] + "T" + next_race["time"]

--- a/apps/indycar/indy_car.star
+++ b/apps/indycar/indy_car.star
@@ -13,6 +13,7 @@ Author: jvivona
 #  add display of qualifing date/time on app
 # 20230904 jvivona
 #  fix date display remove leading 0
+# 20230911 - jvivona - update code and API to better handle end of season with not upcoming race
 
 load("encoding/base64.star", "base64")
 load("encoding/json.star", "json")
@@ -21,7 +22,7 @@ load("render.star", "render")
 load("schema.star", "schema")
 load("time.star", "time")
 
-VERSION = 23247
+VERSION = 23254
 
 IMAGES = {
     #Indycar track type logos
@@ -80,8 +81,12 @@ def main(config):
     series = config.get("series", DEFAULTS["series"])
     displaytype = config.get("datadisplay", DEFAULTS["display"])
     data = json.decode(get_cachable_data(DEFAULTS["api"].format(series, displaytype)))
+
     if displaytype == "nri":
-        displayrow = nextrace(config, data)
+        if data.get("start", "") == "":
+            return []
+        else:
+            displayrow = nextrace(config, data)
     else:
         displayrow = standings(config, data)
 

--- a/apps/nascarnextrace/nascarnextrace.star
+++ b/apps/nascarnextrace/nascarnextrace.star
@@ -8,6 +8,7 @@ Author: jvivona
 # 20230904 - jvivona - fix date display
 # 20230828 - jvivona - with Kurt Busch officially retiring, changed driver names to only have 1 char for 1st name - will eval in future if necessary
 #                    - change text color to be schema.Color instead of drop down
+# 20230911 - jvivona - update code and API to better handle end of season with not upcoming race
 
 load("animation.star", "animation")
 load("encoding/json.star", "json")
@@ -17,7 +18,7 @@ load("render.star", "render")
 load("schema.star", "schema")
 load("time.star", "time")
 
-VERSION = 23247
+VERSION = 23254
 
 # cache data for 15 minutes - cycle through with cache on the API side
 CACHE_TTL_SECONDS = 900
@@ -71,7 +72,10 @@ def main(config):
 
     if data_display == "nri":
         NASCAR_DATA = json.decode(get_cachable_data(NASCAR_API + series))
-        text = nextrace(NASCAR_DATA, config)
+        if NASCAR_DATA.get("Race_Date", "") == "":
+            return []
+        else:
+            text = nextrace(NASCAR_DATA, config)
     else:
         NASCAR_DATA = json.decode(get_cachable_data(NASCAR_API + series + data_display))
         text = standings(NASCAR_DATA, config, data_display)


### PR DESCRIPTION
# Description
Fix Indycar, NASCAR and SailGP to better handle end of season with no upcoming race
move SailGP data to Github to reduce load on our datacenter

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at bbec414</samp>

### Summary
📝🆙🏁

<!--
1.  📝 - This emoji represents documentation, and can be used for the first and second pull requests, which both add documentation to their respective apps.
2.  🆙 - This emoji represents an update or upgrade, and can be used for all three pull requests, which all update the version number and the data source of their apps.
3.  🏁 - This emoji represents a finish line or the end of a race, and can be used for all three pull requests, which all handle the end of season scenario for their apps.
-->
This pull request improves and updates three sports-related apps for the tidbyt device: `indycar`, `nascarnextrace`, and `sailgp`. It adds documentation, handles the end of season cases, and switches to more reliable data sources for each app. It also increments the version numbers of the app files.

> _Oh, we're the crew of the `indycar` app_
> _And we document and update with a snap_
> _We handle the end of season well_
> _And we switch to a new API as well_

### Walkthrough
*  Add comments, update version numbers, and improve end of season handling for three apps: `indy_car.star`, `nascarnextrace.star`, and `sailgp.star` ([link](https://github.com/tidbyt/community/pull/1841/files?diff=unified&w=0#diff-cfe68139033f465b97af504645c809b9f97f1075ef7bb1436e6ca51e8af36f63R16), [link](https://github.com/tidbyt/community/pull/1841/files?diff=unified&w=0#diff-cfe68139033f465b97af504645c809b9f97f1075ef7bb1436e6ca51e8af36f63L24-R25), [link](https://github.com/tidbyt/community/pull/1841/files?diff=unified&w=0#diff-cfe68139033f465b97af504645c809b9f97f1075ef7bb1436e6ca51e8af36f63L83-R89), [link](https://github.com/tidbyt/community/pull/1841/files?diff=unified&w=0#diff-b1c40f21af46b32ce867ca5487d2de7ca7fb741c7fe133f2fe2a2ddf06ea4ff2R11), [link](https://github.com/tidbyt/community/pull/1841/files?diff=unified&w=0#diff-b1c40f21af46b32ce867ca5487d2de7ca7fb741c7fe133f2fe2a2ddf06ea4ff2L20-R21), [link](https://github.com/tidbyt/community/pull/1841/files?diff=unified&w=0#diff-b1c40f21af46b32ce867ca5487d2de7ca7fb741c7fe133f2fe2a2ddf06ea4ff2L74-R78), [link](https://github.com/tidbyt/community/pull/1841/files?diff=unified&w=0#diff-2399292d6aefa701a3b6039085581cb5dd858a3ced689775d60cf2fc425c87d8R12-R13), [link](https://github.com/tidbyt/community/pull/1841/files?diff=unified&w=0#diff-2399292d6aefa701a3b6039085581cb5dd858a3ced689775d60cf2fc425c87d8L21-R23), [link](https://github.com/tidbyt/community/pull/1841/files?diff=unified&w=0#diff-2399292d6aefa701a3b6039085581cb5dd858a3ced689775d60cf2fc425c87d8L66-R58))
*  Change API source and remove hard-coded flags for `sailgp.star` app ([link](https://github.com/tidbyt/community/pull/1841/files?diff=unified&w=0#diff-2399292d6aefa701a3b6039085581cb5dd858a3ced689775d60cf2fc425c87d8L27-R29), [link](https://github.com/tidbyt/community/pull/1841/files?diff=unified&w=0#diff-2399292d6aefa701a3b6039085581cb5dd858a3ced689775d60cf2fc425c87d8L42-L54), [link](https://github.com/tidbyt/community/pull/1841/files?diff=unified&w=0#diff-2399292d6aefa701a3b6039085581cb5dd858a3ced689775d60cf2fc425c87d8R112-R114))


