### PR TITLE
MLB magic number: fix clinching logic to focus on division

### DIFF
--- a/apps/mlbmagicnumber/mlb_magic_number.star
+++ b/apps/mlbmagicnumber/mlb_magic_number.star
@@ -384,6 +384,7 @@ def http_get_number(team_id):
                         clinched = team_record.get("clinched")
                         if clinched:
                             indicator = team_record.get("clinchIndicator")
+
                             # indicator of y means division
                             # indicator of z means best record in league
                             # an indicator of x means we have clinched a wild card
@@ -401,12 +402,13 @@ def http_get_number(team_id):
                                 eliminated = True if number == "E" else False
                             else:
                                 magic = True
+
                                 # if we have not clinched yet our magic number is a dash
                                 # it means we need the elimination number of the team right after us
                                 # MLB API stops displaying magic number for division leader after they clinch wild card
                                 if number == "-":
                                     number = record.get("teamRecords")[index].get("eliminationNumberDivision")
-                    
+
                         break  # we found our team
                 break  # we found our division
     else:


### PR DESCRIPTION
# Description
The MLB API stops reporting the division magic number once a team clinches a wild card berth, as in the case of the Atlanta Braves this weekend. Since we want this number to be the true division winner magic number, we need to look at the second place team _division elimination number_ if the first place team has the wild card clinched and reports a "-" magic number.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b6e7fa2</samp>

### Summary
🆕📊⚾

<!--
1.  🆕 - This emoji can be used to indicate that a new parameter (divisionMagicNumber) was added to the API request, which allows the app to access the most updated information on the team's magic number.
2.  📊 - This emoji can be used to indicate that the logic for calculating and displaying the magic number was updated, which improves the accuracy and clarity of the app by using the correct formula and showing the relevant indicators (e.g., E for eliminated, X for clinched, etc.).
3.  ⚾ - This emoji can be used to indicate that the changes are related to the MLB domain and the app's functionality, which enhances the user experience and the app's value.
-->
This pull request enhances the `mlbmagicnumber` app by adding a new parameter to the MLB API request and refining the magic number calculation and display. The changes use the latest data and indicators from the MLB API to improve the app's accuracy and clarity.

> _`MLB API` changed_
> _New parameter and logic_
> _Magic number shines_

### Walkthrough
*  Add `clinchIndicator` parameter to MLB API request to get division clinch status ([link](https://github.com/tidbyt/community/pull/1842/files?diff=unified&w=0#diff-e5749a7f35e4fa2bfdec809e54032a332a3296a284390a4125865f537ab78ae0L353-R353))
*  Update logic for determining division winner to use `clinchIndicator` instead of `clinched` ([link](https://github.com/tidbyt/community/pull/1842/files?diff=unified&w=0#diff-e5749a7f35e4fa2bfdec809e54032a332a3296a284390a4125865f537ab78ae0L380-R391))
*  Handle case where magic number is a dash by using elimination number of next team in standings ([link](https://github.com/tidbyt/community/pull/1842/files?diff=unified&w=0#diff-e5749a7f35e4fa2bfdec809e54032a332a3296a284390a4125865f537ab78ae0R404-R409))
*  Initialize and increment `index` variable to keep track of team position in division records ([link](https://github.com/tidbyt/community/pull/1842/files?diff=unified&w=0#diff-e5749a7f35e4fa2bfdec809e54032a332a3296a284390a4125865f537ab78ae0R370-R371), [link](https://github.com/tidbyt/community/pull/1842/files?diff=unified&w=0#diff-e5749a7f35e4fa2bfdec809e54032a332a3296a284390a4125865f537ab78ae0R377))


