### PR TITLE
Octoprint: Fix stuck on last print

### DIFF
--- a/apps/octoprint/octoprint.star
+++ b/apps/octoprint/octoprint.star
@@ -140,6 +140,9 @@ def renderProgress(label, progress_value, padding):
     )
 
 def main(config):
+    name = None
+    printTimeLeft = None
+    completion = None
     serverIP = config.str("serverIP")
     serverPort = config.str("serverPort", "5000")
     apiKey = config.str("apiKey")

--- a/apps/octoprint/octoprint.star
+++ b/apps/octoprint/octoprint.star
@@ -154,11 +154,12 @@ def main(config):
         job = request("/api/job", serverIP, serverPort, apiKey)
         printer = request("/api/printer", serverIP, serverPort, apiKey)
 
-    completion = math.round(job["progress"]["completion"])
-    name = job["job"]["file"]["display"].removesuffix(".gcode")
+    if job["progress"]["completion"] != None:
+        completion = math.round(job["progress"]["completion"])
+        name = job["job"]["file"]["display"].removesuffix(".gcode")
 
-    # printTime = str(math.round(job["progress"]["printTime"] / 360) / 10)
-    printTimeLeft = str(math.round(job["progress"]["printTimeLeft"] / 360) / 10)
+        # printTime = str(math.round(job["progress"]["printTime"] / 360) / 10)
+        printTimeLeft = str(math.round(job["progress"]["printTimeLeft"] / 360) / 10)
 
     state = printer["state"]["text"]
     bed = int(printer["temperature"]["bed"]["actual"])


### PR DESCRIPTION
# Description
Fixes a bug which would keep it rendered at 100% completion until a new print is initiated. Now will revert to `Octoprint Operational` after a print is finished.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 91bde9d</samp>

### Summary
🐛🛠️🖨️

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the change.
2.  🛠️ - This emoji represents a tool or a repair, which is what the change does by adding a condition to avoid errors.
3.  🖨️ - This emoji represents a printer, which is the device that the Octoprint app for Tidbyt interacts with.
-->
Fix a bug in the `Octoprint` app that caused errors when no job was running or completed. Add a check for `job.progress.completion` before accessing other job attributes.

> _`job_progress` checked_
> _None means no job or done job_
> _Fixes bug in fall_

### Walkthrough
*  Prevent errors when job progress is None ([link](https://github.com/tidbyt/community/pull/1855/files?diff=unified&w=0#diff-679c3cf8c79e9af7bfe3aa3dcc9d711434c13777f02dc419ea42e126871e5783L157-R162))


