### PR TITLE
fix: NASCAR - sync marquee for playoff drivers when in round of 8 and 4

### DIFF
--- a/apps/nascarnextrace/nascarnextrace.star
+++ b/apps/nascarnextrace/nascarnextrace.star
@@ -9,6 +9,7 @@ Author: jvivona
 # 20230828 - jvivona - with Kurt Busch officially retiring, changed driver names to only have 1 char for 1st name - will eval in future if necessary
 #                    - change text color to be schema.Color instead of drop down
 # 20230911 - jvivona - update code and API to better handle end of season with not upcoming race
+# 20230918 - jvivona - fixed marquee spacing for playoff drivers / points as we go through rounds and # of drivers drops below 9
 
 load("animation.star", "animation")
 load("encoding/json.star", "json")
@@ -18,7 +19,7 @@ load("render.star", "render")
 load("schema.star", "schema")
 load("time.star", "time")
 
-VERSION = 23254
+VERSION = 23261
 
 # cache data for 15 minutes - cycle through with cache on the API side
 CACHE_TTL_SECONDS = 900
@@ -253,6 +254,14 @@ def playoff(data):
 
     for i in range(0, positions):
         text[int(math.mod(i, 3))] = text[int(math.mod(i, 3))] + "{} {} {} {} / {}    ".format(data[i]["playoff_rank"], data[i]["driver_first_name"][0:1], text_justify_trunc(10, data[i]["driver_last_name"], "left"), text_justify_trunc(4, str(data[i]["playoff_points"]), "right"), text_justify_trunc(2, str(data[i]["playoff_race_wins"]), "right"))
+
+    # during playoffs - each round cuts people out - 16 in 1st, 12 in 2nd, 8 in 3rd, 4 in final - the api call will handle the number of drivers - so we need to handle spacing to make the scrolls work
+    # we only need to worry about 3rd round and final round - since we only display 9 drivers (for time) anyway
+    spacer = "                            "
+    if positions < 9:
+        if positions < 5:
+            text[1] = text[1] + spacer
+        text[2] = text[2] + spacer
 
     return text
 


### PR DESCRIPTION
each round eliminates drivers, once we drop to 8 - the marquees get wonky in their display - handle this better and sync marquees

# Description
Replace this with a description of your changes.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4be5f8d</samp>

### Summary
🏁🛠️🔢

<!--
1.  🏁 This emoji represents the racing theme of the app and the fact that the changes are related to the playoff drivers and points, which are important aspects of the NASCAR season.
2.  🛠️ This emoji represents the fixing of a bug or issue with the marquee spacing, which could affect the appearance and readability of the app.
3.  🔢 This emoji represents the updating of the version number, which indicates that the app has been improved or modified in some way.
-->
Improved display of NASCAR playoff information in the `nascarnextrace` app. Fixed a bug with marquee spacing and updated the app version to 1.0.1.

> _Sing, O Muse, of the skillful coder who refined_
> _The `nascarnextrace` app, a marvel of design,_
> _And fixed the marquee spacing for the playoff drivers bold_
> _And their hard-earned points, as precious as the finest gold._

### Walkthrough
* Fix marquee spacing for playoff drivers and points in NASCAR app ([link](https://github.com/tidbyt/community/pull/1862/files?diff=unified&w=0#diff-b1c40f21af46b32ce867ca5487d2de7ca7fb741c7fe133f2fe2a2ddf06ea4ff2R12), [link](https://github.com/tidbyt/community/pull/1862/files?diff=unified&w=0#diff-b1c40f21af46b32ce867ca5487d2de7ca7fb741c7fe133f2fe2a2ddf06ea4ff2R258-R265))
* Update version number of NASCAR app ([link](https://github.com/tidbyt/community/pull/1862/files?diff=unified&w=0#diff-b1c40f21af46b32ce867ca5487d2de7ca7fb741c7fe133f2fe2a2ddf06ea4ff2L21-R22))


