### PR TITLE
Braemarscreen: Adding schema to allow selection of colour and ttl …

### DIFF
--- a/apps/braemarscreen/braemar_screen.star
+++ b/apps/braemarscreen/braemar_screen.star
@@ -136,7 +136,7 @@ def main(config):
     rep = http.post(
         BRAEMAR_PRICES_URL,
         body = BRAEMAR_QUERY,
-        ttl_seconds = int(config.get("ttl", "60"))  ,
+        ttl_seconds = int(config.get("ttl", "60")),
         headers = {
             "content-type": "application/json",
         },
@@ -165,53 +165,52 @@ def main(config):
     )
 
 def get_schema():
-  options = [
-    schema.Option(
-        display = "10 seconds",
-        value = "10",
-    ),
-    schema.Option(
-        display = "20 seconds",
-        value = "20",
-    ),
-    schema.Option(
-        display = "30 seconds",
-        value = "30",
-    ),
-    schema.Option(
-        display = "60 seconds",
-        value = "60",
-    ),
-  ]
+    options = [
+        schema.Option(
+            display = "10 seconds",
+            value = "10",
+        ),
+        schema.Option(
+            display = "20 seconds",
+            value = "20",
+        ),
+        schema.Option(
+            display = "30 seconds",
+            value = "30",
+        ),
+        schema.Option(
+            display = "60 seconds",
+            value = "60",
+        ),
+    ]
 
-
-  return schema.Schema(
-      version = "1",
-      fields = [
-          schema.Color(
-              id = "price_color",
-              name = "Price Colour",
-              desc = "Colour for the prices",
-              icon = "palette",
-              default = "#0000FF",
-              palette = [
-                  "#0000FF",
-                  "#FF0000",
-                  "#FFFF00",
-                  "#00FF00",
-                  "#FFAA00",
-                  "#00FFFF",
-                  "#FF00FF",
-                  "#FFFFFF",
-              ],
-          ),
-          schema.Dropdown(
+    return schema.Schema(
+        version = "1",
+        fields = [
+            schema.Color(
+                id = "price_color",
+                name = "Price Colour",
+                desc = "Colour for the prices",
+                icon = "palette",
+                default = "#0000FF",
+                palette = [
+                    "#0000FF",
+                    "#FF0000",
+                    "#FFFF00",
+                    "#00FF00",
+                    "#FFAA00",
+                    "#00FFFF",
+                    "#FF00FF",
+                    "#FFFFFF",
+                ],
+            ),
+            schema.Dropdown(
                 id = "ttl",
                 name = "Refresh",
                 desc = "How often to refresh the values",
                 icon = "arrowsRotate",
                 default = options[0].value,
                 options = options,
-            )
-      ],
-  )
+            ),
+        ],
+    )


### PR DESCRIPTION
…for cache

# Description
Adding some schema items to allow users to select the colour of the prices and also the TTL of the cache

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3875789</samp>

### Summary
🎨🔄⚙️

<!--
1.  🎨 - This emoji can be used to indicate that the pull request adds or changes the color options for the app, as color is often associated with art and design.
2.  🔄 - This emoji can be used to indicate that the pull request adds or changes the refresh interval for the data, as this implies updating or reloading the information periodically.
3.  ⚙️ - This emoji can be used to indicate that the pull request adds or changes the configuration options for the app, as this implies setting or adjusting the preferences or settings of the app.
-->
This pull request enhances the `braemar_screen` app with user-configurable settings for color and refresh rate. It uses the `schema` module to define and validate the config options, and passes them to the rendering functions in `braemar_screen.star`.

> _Sing, O Muse, of the braemar_screen app, the work of skillful coders_
> _Who added options for the users, to customize their colors and timers_
> _Using the `schema` module, the source of order and structure_
> _And passing the `config` parameter, the bearer of their choices_

### Walkthrough
*  Add configuration options for price color and refresh interval ([link](https://github.com/tidbyt/community/pull/1863/files?diff=unified&w=0#diff-5efaf53a138898ef976e199e2947f56539d8beaa247659742855bd7ac0a6f704R12), [link](https://github.com/tidbyt/community/pull/1863/files?diff=unified&w=0#diff-5efaf53a138898ef976e199e2947f56539d8beaa247659742855bd7ac0a6f704L58-R65), [link](https://github.com/tidbyt/community/pull/1863/files?diff=unified&w=0#diff-5efaf53a138898ef976e199e2947f56539d8beaa247659742855bd7ac0a6f704L79-R81), [link](https://github.com/tidbyt/community/pull/1863/files?diff=unified&w=0#diff-5efaf53a138898ef976e199e2947f56539d8beaa247659742855bd7ac0a6f704L96-R98), [link](https://github.com/tidbyt/community/pull/1863/files?diff=unified&w=0#diff-5efaf53a138898ef976e199e2947f56539d8beaa247659742855bd7ac0a6f704L105-R107), [link](https://github.com/tidbyt/community/pull/1863/files?diff=unified&w=0#diff-5efaf53a138898ef976e199e2947f56539d8beaa247659742855bd7ac0a6f704L113-R115), [link](https://github.com/tidbyt/community/pull/1863/files?diff=unified&w=0#diff-5efaf53a138898ef976e199e2947f56539d8beaa247659742855bd7ac0a6f704L125-R127), [link](https://github.com/tidbyt/community/pull/1863/files?diff=unified&w=0#diff-5efaf53a138898ef976e199e2947f56539d8beaa247659742855bd7ac0a6f704L133-R139), [link](https://github.com/tidbyt/community/pull/1863/files?diff=unified&w=0#diff-5efaf53a138898ef976e199e2947f56539d8beaa247659742855bd7ac0a6f704L148-R150), [link](https://github.com/tidbyt/community/pull/1863/files?diff=unified&w=0#diff-5efaf53a138898ef976e199e2947f56539d8beaa247659742855bd7ac0a6f704R166-R217))
*  Remove hardcoded BLUE color variable from `braemar_screen.star` ([link](https://github.com/tidbyt/community/pull/1863/files?diff=unified&w=0#diff-5efaf53a138898ef976e199e2947f56539d8beaa247659742855bd7ac0a6f704L25))
*  Use `ttl` option from config to set HTTP request time to live in `main` function ([link](https://github.com/tidbyt/community/pull/1863/files?diff=unified&w=0#diff-5efaf53a138898ef976e199e2947f56539d8beaa247659742855bd7ac0a6f704L133-R139))


