### PR TITLE
New App: Boulder BCycle

### DIFF
--- a/apps/boulderbcycle/boulder_bcycle.star
+++ b/apps/boulderbcycle/boulder_bcycle.star
@@ -1,0 +1,162 @@
+"""
+Applet: Boulder BCycle
+Summary: Boulder Bcycle availability
+Description: Display how many BCycles are available for a given BCycle station in Boulder, Colorado. The user can choose which station they want to see bike availability for.
+Author: MauricioZambrano
+"""
+
+load("render.star", "render")
+load("http.star", "http")
+load("schema.star", "schema")
+load("encoding/base64.star", "base64")
+
+API_STATION_STATUS_URL = "https://gbfs.bcycle.com/bcycle_boulder/station_status.json"
+API_STATION_INFORMATION_URL = "https://gbfs.bcycle.com/bcycle_boulder/station_information.json"
+
+STRING_SEPARATOR = "/$*$/"
+DEFAULT_STATION = "bcycle_boulder_4091" + STRING_SEPARATOR + "Timber Ridge @ Adams Circle"
+COLORS = {
+    "green": "#00FF00",
+    "red": "#FF0000",
+    "white": "#FFF",
+    "black": "#000",
+    "yellow": "#FFFF00",
+    "aquamarine": "#7FFFD4",
+}
+ERROR_STRING = "ERR"
+
+def getStationInfo():
+    res = http.get(API_STATION_INFORMATION_URL, ttl_seconds = 12000)
+
+    if res.status_code != 200:
+        fail("API call failed with status %d", res.status_code)
+
+    stations = res.json()["data"]["stations"]
+
+    return stations
+
+def getNumberBikes(station_id):
+    res = http.get(API_STATION_STATUS_URL, ttl_seconds = 60)
+
+    if res.status_code != 200:
+        fail("API call failed with status %d", res.status_code)
+
+    stations = res.json()["data"]["stations"]
+
+    for station in stations:
+        if station["station_id"] == station_id:
+            return station["num_bikes_available"]
+
+    return ERROR_STRING
+
+def getTextColor(number):
+    if number == ERROR_STRING:
+        # In case number of bikes is not found, so ERR is printed
+        return COLORS["white"]
+
+    number = int(number)
+    if number < 3:
+        return COLORS["red"]
+    elif number < 8:
+        return COLORS["yellow"]
+    else:
+        return COLORS["green"]
+
+def getIdAndName(config_string):
+    return config_string.split(STRING_SEPARATOR)
+
+def main(config):
+    station_id, station_name = getIdAndName(config.get("station", DEFAULT_STATION))
+
+    if not station_id or not station_name:
+        fail("No station ID or station name found")
+        return
+
+    # Type parsing is a bit weird here so this is a quick hack
+    available_bikes = str(int(getNumberBikes(station_id)))
+
+    if not available_bikes:
+        available_bikes = ERROR_STRING
+
+    return render.Root(
+        child = render.Row(
+            expanded = True,
+            children = [
+                render.Column(
+                    expanded = True,
+                    children = [
+                        render.Box(
+                            width = 35,
+                            color = COLORS["black"],
+                            child = render.WrappedText(
+                                content = station_name,
+                                font = "tom-thumb",
+                                color = COLORS["white"],
+                            ),
+                        ),
+                    ],
+                ),
+                render.Column(
+                    expanded = True,
+                    main_align = "center",
+                    cross_align = "center",
+                    children = [
+                        render.Box(
+                            width = 30,
+                            color = config.get("color") or COLORS["aquamarine"],
+                            child = render.Column(
+                                main_align = "center",
+                                cross_align = "center",
+                                expanded = True,
+                                children = [
+                                    render.Circle(
+                                        color = COLORS["black"],
+                                        diameter = 14,
+                                        child = render.Text(
+                                            available_bikes,
+                                            color = getTextColor(available_bikes),
+                                        ),
+                                    ),
+                                ],
+                            ),
+                        ),
+                    ],
+                ),
+            ],
+        ),
+    )
+
+def get_schema():
+    station_info = getStationInfo()
+
+    options = []
+
+    for station in station_info:
+        string_value = station["station_id"] + STRING_SEPARATOR + station["name"]
+        options.append(
+            schema.Option(
+                display = station["name"],
+                value = string_value,
+            ),
+        )
+
+    return schema.Schema(
+        version = "1",
+        fields = [
+            schema.Dropdown(
+                id = "station",
+                name = "Station Name",
+                desc = "Name of the BCycle Station you want to track.",
+                icon = "usersCog",
+                default = DEFAULT_STATION,
+                options = options,
+            ),
+            schema.Color(
+                id = "color",
+                name = "Background Color",
+                desc = "Background color of the screen",
+                icon = "brush",
+                default = COLORS["aquamarine"],
+            ),
+        ],
+    )

--- a/apps/boulderbcycle/manifest.yaml
+++ b/apps/boulderbcycle/manifest.yaml
@@ -1,0 +1,8 @@
+---
+id: boulder-bcycle
+name: Boulder BCycle
+summary: Boulder Bcycle availability
+desc: Display how many BCycles are available for a given BCycle station in Boulder, Colorado. The user can choose which station they want to see bike availability for.
+author: MauricioZambrano
+fileName: boulder_bcycle.star
+packageName: boulderbcycle


### PR DESCRIPTION
# Description
Created an app that checks the bike availability of BCycle stations in Boulder, Colorado. The user can choose any station in Boulder and their Tidbyt will display the amount of available bikes. 

Note: This app is not affiliated with BCycle or BCycle Boulder.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fd35fef</samp>

### Summary
🚲🌄🎨

<!--
1.  🚲 - This emoji represents the main theme of the applet, which is bike sharing and cycling. It also matches the logo of BCycle, the bike sharing service that the applet uses.
2.  🌄 - This emoji represents the location of the applet, which is Boulder, Colorado, a city known for its scenic views and outdoor activities. It also suggests the idea of biking in nature and enjoying the landscape.
3.  🎨 - This emoji represents the customization feature of the applet, which allows the user to choose a background color for the applet display. It also implies the creativity and diversity of the applet and its users.
-->
This pull request adds a new applet for the tidbyt device that shows the number of available bikes for a selected station in Boulder BCycle, a bike-sharing service in Boulder, Colorado. The applet consists of a `.star` file that contains the code for fetching and rendering the data from the BCycle API, and a `manifest.yaml` file that contains the metadata for the applet. The applet allows the user to configure the station and the background color of the applet.

> _`Boulder BCycle`_
> _Shows bikes for chosen station_
> _Autumn leaves in `render`_

### Walkthrough
* Create and register a new applet for displaying Boulder BCycle station data ([link](https://github.com/tidbyt/community/pull/1866/files?diff=unified&w=0#diff-7665d95c2261196b471ef1e117556c3e7da7cbf6d5b68b9a1142a365e8544560R1-R162), [link](https://github.com/tidbyt/community/pull/1866/files?diff=unified&w=0#diff-eb87f8b004b82083c703a3ca15c46b6e512a6df185b267f2b0c38d4c28c04008R1-R8))
  - Define the applet logic and configuration schema in `boulder_bcycle.star` ([link](https://github.com/tidbyt/community/pull/1866/files?diff=unified&w=0#diff-7665d95c2261196b471ef1e117556c3e7da7cbf6d5b68b9a1142a365e8544560R1-R162))
  - Use the BCycle API to fetch and parse the station status and availability ([link](https://github.com/tidbyt/community/pull/1866/files?diff=unified&w=0#diff-7665d95c2261196b471ef1e117556c3e7da7cbf6d5b68b9a1142a365e8544560R1-R162))
  - Render the applet with a custom background color and station name ([link](https://github.com/tidbyt/community/pull/1866/files?diff=unified&w=0#diff-7665d95c2261196b471ef1e117556c3e7da7cbf6d5b68b9a1142a365e8544560R1-R162))
  - Add the applet metadata in `manifest.yaml` ([link](https://github.com/tidbyt/community/pull/1866/files?diff=unified&w=0#diff-eb87f8b004b82083c703a3ca15c46b6e512a6df185b267f2b0c38d4c28c04008R1-R8))


