### PR TITLE
Roomba: Update states and remove Roomba IP config

### DIFF
--- a/apps/roomba/index.js
+++ b/apps/roomba/index.js
@@ -9,11 +9,15 @@ var url = require('url');
 
 const BLID = '_BLID_HERE_';
 const PASSWORD = '_PASSWORD_HERE_';
-const API_KEY = 'ADD_YOUR_OWN_API_KEY_HERE';
+const API_KEY = 'ADD_YOUR_OWN_API_KEY_HERE_AND_ADD_IN_TIDBYT_CONFIG';
 
 const HOST = '0.0.0.0';
 const PORT = '6565';
-let cachedIP;
+
+var myRobotViaLocal;
+dorita980.getRobotIP((ierr, ip) => {
+    myRobotViaLocal = new dorita980.Local(BLID, PASSWORD, ip);
+});
 
 const server = http.createServer((req, res) => {
     if (req.method === "GET") {
@@ -25,45 +29,15 @@ const server = http.createServer((req, res) => {
         var _req = url.parse(req.url, true);
         switch (_req.pathname) {
             case '/status':
-                if (_req.query.ip) {
-                    try {
-                        var myRobotViaLocal = new dorita980.Local(BLID, PASSWORD, _req.query.ip);
-                        myRobotViaLocal.getRobotState(['batPct']).then((state) => {
-                            res.writeHead(200, {'Content-Type': 'application/json'});
-                            res.write(JSON.stringify(state))
-                            res.end();
-                            myRobotViaLocal.end();
-                        }).catch((err) => {
-                            console.error(err);
-                        });
-                    } catch(e) {
-                        res.writeHead(500);
-                        res.end();
-                    }
-                } else {
-                    dorita980.getRobotIP((ierr, ip) => {
-                        if (ierr) return console.log('error looking for robot IP');
-                        if (ip) {
-                            cachedIP = ip;
-                        }
-                    });
-                    if (cachedIP) {
-                        try {
-                            var myRobotViaLocal = new dorita980.Local(BLID, PASSWORD, cachedIP);
-                            myRobotViaLocal.getRobotState(['batPct']).then((state) => {
-                                res.writeHead(200, {'Content-Type': 'application/json'});
-                                res.write(JSON.stringify(state));
-                                res.end();
-                                myRobotViaLocal.end();
-                            }).catch((err) => {
-                                console.error(err);
-                            });
-                        } catch(e) {
-                            res.writeHead(500);
-                            res.end();
-                        }  
-                    }            
-                }
+                myRobotViaLocal.getRobotState(['batPct']).then((state) => {
+                    res.writeHead(200, {'Content-Type': 'application/json'});
+                    res.write(JSON.stringify(state));
+                    res.end();
+                    console.log(`request made to roomba at ${Date()}`);
+                    // myRobotViaLocal.end();
+                }).catch((err) => {
+                    console.error(err);
+                });
                 break;
             default:
                 res.writeHead(404);

--- a/apps/roomba/roomba.star
+++ b/apps/roomba/roomba.star
@@ -9,6 +9,7 @@ load("encoding/base64.star", "base64")
 load("http.star", "http")
 load("render.star", "render")
 load("schema.star", "schema")
+load("random.star", "random")
 
 REFRESH_TIME = 180  # every few minutes
 
@@ -19,6 +20,7 @@ GREEN = "#00ff00"
 ORANGE = "#db8f00"
 
 rIcon = "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAIAAAACUFjqAAAACXBIWXMAAAsTAAALEwEAmpwYAAAJnGlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPD94cGFja2V0IGJlZ2luPSLvu78iIGlkPSJXNU0wTXBDZWhpSHpyZVN6TlRjemtjOWQiPz4gPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iQWRvYmUgWE1QIENvcmUgNS42LWMxNDUgNzkuMTYzNDk5LCAyMDE4LzA4LzEzLTE2OjQwOjIyICAgICAgICAiPiA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPiA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIiB4bWxuczp4bXA9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC8iIHhtbG5zOmRjPSJodHRwOi8vcHVybC5vcmcvZGMvZWxlbWVudHMvMS4xLyIgeG1sbnM6eG1wTU09Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9tbS8iIHhtbG5zOnN0RXZ0PSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvc1R5cGUvUmVzb3VyY2VFdmVudCMiIHhtbG5zOnN0UmVmPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvc1R5cGUvUmVzb3VyY2VSZWYjIiB4bWxuczpwaG90b3Nob3A9Imh0dHA6Ly9ucy5hZG9iZS5jb20vcGhvdG9zaG9wLzEuMC8iIHhtbG5zOnRpZmY9Imh0dHA6Ly9ucy5hZG9iZS5jb20vdGlmZi8xLjAvIiB4bWxuczpleGlmPSJodHRwOi8vbnMuYWRvYmUuY29tL2V4aWYvMS4wLyIgeG1wOkNyZWF0b3JUb29sPSJBZG9iZSBQaG90b3Nob3AgQ0MgMjAxOSAoV2luZG93cykiIHhtcDpDcmVhdGVEYXRlPSIyMDIzLTA1LTI0VDE1OjIyOjU4LTA0OjAwIiB4bXA6TWV0YWRhdGFEYXRlPSIyMDIzLTA1LTI1VDE4OjAwOjMzLTA0OjAwIiB4bXA6TW9kaWZ5RGF0ZT0iMjAyMy0wNS0yNVQxODowMDozMy0wNDowMCIgZGM6Zm9ybWF0PSJpbWFnZS9wbmciIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6MTMzNmZiZmItZGYxNi1hYjRmLTg4YzktMTk3NzMxZThmZTNjIiB4bXBNTTpEb2N1bWVudElEPSJ4bXAuZGlkOmI0MTJlYTI4LWQ1NDQtYWE0Yy1iNjBmLTgyNThhMmQzYzVhMCIgeG1wTU06T3JpZ2luYWxEb2N1bWVudElEPSJ4bXAuZGlkOjUxNDRjNzkxLThjYmYtMjQ0ZS05ODhlLTk0ZTk1NDUxOGVhMSIgcGhvdG9zaG9wOkNvbG9yTW9kZT0iMyIgdGlmZjpPcmllbnRhdGlvbj0iMSIgdGlmZjpYUmVzb2x1dGlvbj0iNzIwMDAwLzEwMDAwIiB0aWZmOllSZXNvbHV0aW9uPSI3MjAwMDAvMTAwMDAiIHRpZmY6UmVzb2x1dGlvblVuaXQ9IjIiIGV4aWY6Q29sb3JTcGFjZT0iNjU1MzUiIGV4aWY6UGl4ZWxYRGltZW5zaW9uPSIxMCIgZXhpZjpQaXhlbFlEaW1lbnNpb249IjEwIj4gPHhtcE1NOkhpc3Rvcnk+IDxyZGY6U2VxPiA8cmRmOmxpIHN0RXZ0OmFjdGlvbj0iY3JlYXRlZCIgc3RFdnQ6aW5zdGFuY2VJRD0ieG1wLmlpZDo1MTQ0Yzc5MS04Y2JmLTI0NGUtOTg4ZS05NGU5NTQ1MThlYTEiIHN0RXZ0OndoZW49IjIwMjMtMDUtMjRUMTU6MjI6NTgtMDQ6MDAiIHN0RXZ0OnNvZnR3YXJlQWdlbnQ9IkFkb2JlIFBob3Rvc2hvcCBDQyAyMDE5IChXaW5kb3dzKSIvPiA8cmRmOmxpIHN0RXZ0OmFjdGlvbj0iZGVyaXZlZCIgc3RFdnQ6cGFyYW1ldGVycz0iY29udmVydGVkIGZyb20gaW1hZ2UvcG5nIHRvIGFwcGxpY2F0aW9uL3ZuZC5hZG9iZS5waG90b3Nob3AiLz4gPHJkZjpsaSBzdEV2dDphY3Rpb249InNhdmVkIiBzdEV2dDppbnN0YW5jZUlEPSJ4bXAuaWlkOmI0MTJlYTI4LWQ1NDQtYWE0Yy1iNjBmLTgyNThhMmQzYzVhMCIgc3RFdnQ6d2hlbj0iMjAyMy0wNS0yNFQxNToyOTowOC0wNDowMCIgc3RFdnQ6c29mdHdhcmVBZ2VudD0iQWRvYmUgUGhvdG9zaG9wIENDIDIwMTkgKFdpbmRvd3MpIiBzdEV2dDpjaGFuZ2VkPSIvIi8+IDxyZGY6bGkgc3RFdnQ6YWN0aW9uPSJkZXJpdmVkIiBzdEV2dDpwYXJhbWV0ZXJzPSJjb252ZXJ0ZWQgZnJvbSBhcHBsaWNhdGlvbi92bmQuYWRvYmUucGhvdG9zaG9wIHRvIGltYWdlL3BuZyIvPiA8cmRmOmxpIHN0RXZ0OmFjdGlvbj0ic2F2ZWQiIHN0RXZ0Omluc3RhbmNlSUQ9InhtcC5paWQ6MTMzNmZiZmItZGYxNi1hYjRmLTg4YzktMTk3NzMxZThmZTNjIiBzdEV2dDp3aGVuPSIyMDIzLTA1LTI1VDE4OjAwOjMzLTA0OjAwIiBzdEV2dDpzb2Z0d2FyZUFnZW50PSJBZG9iZSBQaG90b3Nob3AgQ0MgMjAxOSAoV2luZG93cykiIHN0RXZ0OmNoYW5nZWQ9Ii8iLz4gPC9yZGY6U2VxPiA8L3htcE1NOkhpc3Rvcnk+IDx4bXBNTTpEZXJpdmVkRnJvbSBzdFJlZjppbnN0YW5jZUlEPSJ4bXAuaWlkOmI0MTJlYTI4LWQ1NDQtYWE0Yy1iNjBmLTgyNThhMmQzYzVhMCIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDpiNDEyZWEyOC1kNTQ0LWFhNGMtYjYwZi04MjU4YTJkM2M1YTAiIHN0UmVmOm9yaWdpbmFsRG9jdW1lbnRJRD0ieG1wLmRpZDo1MTQ0Yzc5MS04Y2JmLTI0NGUtOTg4ZS05NGU5NTQ1MThlYTEiLz4gPC9yZGY6RGVzY3JpcHRpb24+IDwvcmRmOlJERj4gPC94OnhtcG1ldGE+IDw/eHBhY2tldCBlbmQ9InIiPz4mXzX0AAAAWUlEQVQYlXWOwQ3AIAwDL4hXYUAGgKkYgAzYvumDtqoi4peVcyxLHQe+IgjQywk0zcsATRMQvL9eLkDqSDu2ylI0J6Pgsab5wb852Zhg4qbMLv9CK7Ff/mrejqcePdD1Ft0AAAAASUVORK5CYII="
+
 SAMPLE_DATA = {
     "batPct": 84,
     "name": "MyRoomba",
@@ -27,7 +29,7 @@ SAMPLE_DATA = {
         "error": 0,
         "expireTm": 0,
         "mssnStrtTm": 1689100000,
-        "phase": "run",
+        "phase": "error",
         "mssnM": 0,
         "cycle": "null",
         "condNotReady": [],
@@ -40,6 +42,107 @@ SAMPLE_DATA = {
         "missionId": "82348DVK9CV9CM212K23CM",
     },
 }
+
+ROOMBA_STATES = {
+    "charge": "Charging",
+    "new": "Starting",
+    "run": "Cleaning",
+    "resume": "Cleaning",
+    "hmMidMsn": "Recharging",
+    "recharge": "Recharging",
+    "stuck": "Stuck",
+    "hmUsrDock": "Docking",
+    "dock": "Docking",
+    "dockend": "Docking",
+    "cancelled": "Cancelled",
+    "stop": "Stopped",
+    "pause": "Paused",
+    "hmPostMsn": "Ending",
+    "evac": "Emptying",
+    "chargeerror": "Error Charging",
+    "error": "Error",
+    "": "Other",
+}
+
+ROOMBA_STATE_COLORS = {
+    "charge": GREEN,
+    "new": WHITE,
+    "run": GREEN,
+    "resume": GREEN,
+    "hmMidMsn": ORANGE,
+    "recharge": GREEN,
+    "stuck": RED,
+    "hmUsrDock": WHITE,
+    "dock": WHITE,
+    "dockend": WHITE,
+    "cancelled": RED,
+    "stop": RED,
+    "pause": ORANGE,
+    "hmPostMsn": GREEN,
+    "evac": WHITE,
+    "chargeerror": RED,
+    "error": RED,
+    "": WHITE,
+}
+
+ERROR_CODES = [
+    "None",
+    "Left wheel off floor",
+    "Main Brushes stuck",
+    "Right wheel off floor",
+    "Left wheel stuck",
+    "Right wheel stuck",
+    "Stuck near a cliff",
+    "Left wheel error",
+    "Bin error",
+    "Bumper stuck",
+    "Right wheel error",
+    "Bin error",
+    "Cliff sensor issue",
+    "Both wheels off floor",
+    "Bin missing",
+    "Reboot required",
+    "Bumped unexpectedly",
+    "Path blocked",
+    "Docking issue",
+    "Undocking issue",
+    "Docking issue",
+    "Navigation problem",
+    "Navigation problem",
+    "Battery issue",
+    "Navigation problem",
+    "Reboot required",
+    "Vacuum problem",
+    "Vacuum problem",
+    "Sftwr Update needed",
+    "Vacuum problem",
+    "Reboot required",
+    "Smart map problem",
+    "Path blocked",
+    "Reboot required",
+    "Unrecognized cleaning pad",
+    "Bin full",
+    "Tank needed refilling",
+    "Vacuum problem",
+    "Reboot required",
+    "Navigation problem",
+    "Timed out",
+    "Localization problem",
+    "Navigation problem",
+    "Pump issue",
+    "Lid open",
+    "Low battery",
+    "Reboot required",
+    "Path blocked",
+    "Pad required attention",
+    "Hardware problem",
+    "Low memory",
+    "Hardware problem",
+    "Pad type changed",
+    "Max area reached",
+    "Navigation problem",
+    "Hardware problem"
+]
 
 BATTERY_OUTLINE = [
     [0, 0, 1, 1, 1, 1, 0, 0],
@@ -102,11 +205,8 @@ WIDTH = 8
 HEIGHT = 16
 HEIGHT_ADJ = 2
 
-def requestStatus(serverIP, serverPort, apiKey, roombaIP):
-    if roombaIP:
-        res = http.get("http://%s:%d/status?ip=%s" % (serverIP, serverPort, roombaIP), headers = {"x-api-key": apiKey}, ttl_seconds = REFRESH_TIME)
-    else:
-        res = http.get("http://%s:%d/status" % (serverIP, serverPort), headers = {"x-api-key": apiKey}, ttl_seconds = REFRESH_TIME)
+def requestStatus(serverIP, serverPort, apiKey):
+    res = http.get("http://%s:%d/status" % (serverIP, serverPort), headers = {"x-api-key": apiKey}, ttl_seconds = REFRESH_TIME)
     if res.status_code != 200:
         fail("request failed with status %d", res.status_code)
     res = res.json()
@@ -141,56 +241,44 @@ def main(config):
 
     serverIP = config.str("serverIP")
     serverPort = config.str("serverPort")
-    roombaIP = config.str("roombaIP")
     apiKey = config.str("apiKey")
 
     if not serverIP or type(int(serverPort)) != "int":
         data = SAMPLE_DATA
+        batPct = random.number(0, 100)
+        name = data["name"]
+        # phase = data["cleanMissionStatus"]["phase"]
+        phase = ["charge", "run", "new", "resume", "stuck", "dock", "stop", "evac"][random.number(0, 7)]
+    
     else:
         serverPort = int(serverPort)
-        data = requestStatus(serverIP, serverPort, apiKey, roombaIP)
-
-    # print(data)
-    if data and data["batPct"]:
-        batPct = data["batPct"]
-        name = data["name"]
-        phase = data["cleanMissionStatus"]["phase"]
-        # addr = data["netinfo"]["addr"]
-
-    else:
-        fail("Server did not respond correctly")
+        data = requestStatus(serverIP, serverPort, apiKey)
+        if data and data["batPct"]:
+            batPct = data["batPct"]
+            name = data["name"]
+            phase = data["cleanMissionStatus"]["phase"]
+        else:
+            fail("Server did not respond correctly")
 
     batLabel = ""
     phaseLabel = ""
     phaseLabelColor = WHITE
     statusOffset = 7
-    if phase == "charge":
+    phaseLabel = ROOMBA_STATES[phase]
+    if phase != "chargeerror":
         batLabel = "%d%%" % batPct
-        phaseLabel = "charging"
-        phaseLabelColor = GREEN
-        if batPct == 100:
-            batLabel = "%d%%" % batPct
-            phaseLabel = "ready"
-    elif phase == "chargeerror":
-        phaseLabel = "error charging"
+    else:
+        statusOffset = 0
+
+    phaseLabelColor = ROOMBA_STATE_COLORS[phase]
+
+    if batPct <= 5 and phase not in ["charge", "hmMidMsn", "recharge", "hmUsrDock", "dock", "dockend", "hmPostMsn"]:
+        phaseLabel = "Please Charge"
         statusOffset = 0
         phaseLabelColor = RED
-    elif phase == "run":
-        batLabel = "%d%%" % batPct
-        phaseLabel = "cleaning"
-        phaseLabelColor = GREEN
-    elif phase == "error":
-        batLabel = "%d%%" % batPct
-        phaseLabel = "error"
-        phaseLabelColor = RED
-    elif phase != "charge" and batPct <= 5:
-        phaseLabel = "please charge"
-        statusOffset = 0
-        phaseLabelColor = RED
-    elif phase == "stop":
-        batLabel = "%d%%" % batPct
-        phaseLabel = "stopped"
-        phaseLabelColor = RED
+        batLabel = ""
+    
+    error = data["cleanMissionStatus"]["error"]
 
     #render battery icon
     # why not just use separate images for batteries? - it's NOT AS FUN
@@ -220,7 +308,7 @@ def main(config):
                 if x != 0 and x < WIDTH - 1 and y > 2 and y < HEIGHT - 1:
                     #draw filled up battery depending on batPct
                     #green
-                    if batPct >= 70 and y - HEIGHT_ADJ >= ((HEIGHT - HEIGHT_ADJ) * (1 - batPct / 100)):
+                    if batPct >= 65 and y - HEIGHT_ADJ >= ((HEIGHT - HEIGHT_ADJ) * (1 - batPct / 100)):
                         row.append(green_pixel)
                         #orange
 
@@ -274,7 +362,7 @@ def main(config):
                             ],
                         ),
                         render.Padding(
-                            pad = 1,
+                            pad = (1, 1, 0, 0),
                             child = render.Row(
                                 main_align = "space_around",
                                 cross_align = "center",
@@ -308,6 +396,20 @@ def main(config):
                                         ],
                                     ),
                                 ],
+                            ) if not error else render.Row(
+                                main_align = "space_around",
+                                cross_align = "center",
+                                expanded = True,
+                                children = [
+                                    render.Stack(
+                                        children = [
+                                            render.Padding(
+                                                pad = 0,
+                                                child = render.WrappedText(ERROR_CODES[error], font = "5x8", color = RED),
+                                            ),
+                                        ],
+                                    ),
+                                ],
                             ),
                         ),
                     ],
@@ -337,12 +439,6 @@ def get_schema():
                 name = "API Key (optional)",
                 desc = "API Key setup in index.js",
                 icon = "gear",
-            ),
-            schema.Text(
-                id = "roombaIP",
-                name = "Roomba IP (optional)",
-                desc = "Ex: (192.168.1.123)",
-                icon = "gear",
-            ),
+            )
         ],
     )

--- a/apps/roomba/roomba.star
+++ b/apps/roomba/roomba.star
@@ -279,7 +279,7 @@ def main(config):
         phaseLabelColor = RED
         batLabel = ""
 
-    error = data["cleanMissionStatus"]["error"]
+    error = int(data["cleanMissionStatus"]["error"])
 
     #render battery icon
     # why not just use separate images for batteries? - it's NOT AS FUN
@@ -334,6 +334,8 @@ def main(config):
                 else:
                     row.append(black_pixel)
             batteryIconRows.append(row)
+    if error > 55: # if some other untested error, default to 'navigation problem'
+        error = 21
 
     return render.Root(
         child = render.Row(

--- a/apps/roomba/roomba.star
+++ b/apps/roomba/roomba.star
@@ -7,9 +7,9 @@ Author: noahpodgurski
 
 load("encoding/base64.star", "base64")
 load("http.star", "http")
+load("random.star", "random")
 load("render.star", "render")
 load("schema.star", "schema")
-load("random.star", "random")
 
 REFRESH_TIME = 180  # every few minutes
 
@@ -141,7 +141,7 @@ ERROR_CODES = [
     "Pad type changed",
     "Max area reached",
     "Navigation problem",
-    "Hardware problem"
+    "Hardware problem",
 ]
 
 BATTERY_OUTLINE = [
@@ -247,9 +247,10 @@ def main(config):
         data = SAMPLE_DATA
         batPct = random.number(0, 100)
         name = data["name"]
+
         # phase = data["cleanMissionStatus"]["phase"]
         phase = ["charge", "run", "new", "resume", "stuck", "dock", "stop", "evac"][random.number(0, 7)]
-    
+
     else:
         serverPort = int(serverPort)
         data = requestStatus(serverIP, serverPort, apiKey)
@@ -277,7 +278,7 @@ def main(config):
         statusOffset = 0
         phaseLabelColor = RED
         batLabel = ""
-    
+
     error = data["cleanMissionStatus"]["error"]
 
     #render battery icon
@@ -439,6 +440,6 @@ def get_schema():
                 name = "API Key (optional)",
                 desc = "API Key setup in index.js",
                 icon = "gear",
-            )
+            ),
         ],
     )

--- a/apps/roomba/roomba.star
+++ b/apps/roomba/roomba.star
@@ -334,7 +334,7 @@ def main(config):
                 else:
                     row.append(black_pixel)
             batteryIconRows.append(row)
-    if error > 55: # if some other untested error, default to 'navigation problem'
+    if error > 55:  # if some other untested error, default to 'navigation problem'
         error = 21
 
     return render.Root(


### PR DESCRIPTION
# Description
Tidbyt: Add error code messages, add exact states, remove `roombaIP` config, make sample render dynamic

Server: Move `getRobotIP` logic, remove `roombaIP` query logic, log requests

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5f19c00</samp>

### Summary
🔌📊🎲

<!--
1.  🔌 - This emoji represents the change from using a Roomba IP to a server IP and port, which implies a different connection method and protocol for the app. The plug emoji can also suggest the idea of plugging into a network or a power source, which are both relevant for the Roomba app.
2.  📊 - This emoji represents the improvement of the Roomba status, battery, and error information display, which involves using charts, graphs, and indicators to show the data in a more visual and clear way. The chart emoji can also suggest the idea of monitoring, analyzing, and comparing the Roomba's performance and status.
3.  🎲 - This emoji represents the addition of some random data generation for testing purposes, which involves using dice, numbers, and randomness to simulate different scenarios and outcomes for the app. The dice emoji can also suggest the idea of experimenting, playing, and having fun with the app.
-->
This pull request enhances the `roomba` app for the tidbyt device by enabling automatic IP detection, simplifying the code logic, and improving the user interface. It also modifies the `roomba.star` app to use a server proxy and to add some mock data for testing.

> _No more manual IP, the app will find the way_
> _To connect to the server and control the Roomba's fate_
> _Display the status, battery, and error code_
> _Generate some random data, unleash the testing mode_

### Walkthrough
*  Simplify the configuration and discovery of the Roomba IP address by using the `dorita980.getRobotIP` function in `index.js` ([link](https://github.com/tidbyt/community/pull/1874/files?diff=unified&w=0#diff-78ad8781d8c3fa1df204406e86ea930f35635115c6b206c3f3780d72d8851aa3L12-R21), [link](https://github.com/tidbyt/community/pull/1874/files?diff=unified&w=0#diff-78ad8781d8c3fa1df204406e86ea930f35635115c6b206c3f3780d72d8851aa3L28-R40))
* Remove the `roombaIP` parameter and variable from the `requestStatus` function and the schema in `roomba.star`, since they are no longer needed ([link](https://github.com/tidbyt/community/pull/1874/files?diff=unified&w=0#diff-e30ae99e3ce331353e74da47892999add51030b44eb57b6beab2815ac34b9187L105-R209), [link](https://github.com/tidbyt/community/pull/1874/files?diff=unified&w=0#diff-e30ae99e3ce331353e74da47892999add51030b44eb57b6beab2815ac34b9187L144-R281), [link](https://github.com/tidbyt/community/pull/1874/files?diff=unified&w=0#diff-e30ae99e3ce331353e74da47892999add51030b44eb57b6beab2815ac34b9187L340-R442))
* Add the `random` module to generate random values for the battery percentage and the phase of the Roomba when the server IP or port are not configured, for testing purposes ([link](https://github.com/tidbyt/community/pull/1874/files?diff=unified&w=0#diff-e30ae99e3ce331353e74da47892999add51030b44eb57b6beab2815ac34b9187R12))
* Define dictionaries and a list to map the possible phases and error codes of the Roomba to human-readable labels, colors, and messages in `roomba.star` ([link](https://github.com/tidbyt/community/pull/1874/files?diff=unified&w=0#diff-e30ae99e3ce331353e74da47892999add51030b44eb57b6beab2815ac34b9187R46-R146))
* Use the dictionaries to get the phase label and color, instead of multiple if-else statements, in the `render` function in `roomba.star` ([link](https://github.com/tidbyt/community/pull/1874/files?diff=unified&w=0#diff-e30ae99e3ce331353e74da47892999add51030b44eb57b6beab2815ac34b9187L144-R281))
* Handle the case when the battery percentage is low and the phase is not charging, and show a "Please Charge" message in red in the `render` function in `roomba.star` ([link](https://github.com/tidbyt/community/pull/1874/files?diff=unified&w=0#diff-e30ae99e3ce331353e74da47892999add51030b44eb57b6beab2815ac34b9187L144-R281))
* Handle the case when there is an error, and show the error message corresponding to the error code, in red, instead of the phase label and the battery icon, in the `render` function in `roomba.star` ([link](https://github.com/tidbyt/community/pull/1874/files?diff=unified&w=0#diff-e30ae99e3ce331353e74da47892999add51030b44eb57b6beab2815ac34b9187R399-R412))
* Change the threshold for the green color of the battery icon from 70% to 65%, to make it more consistent with the standard battery indicator in the `render` function in `roomba.star` ([link](https://github.com/tidbyt/community/pull/1874/files?diff=unified&w=0#diff-e30ae99e3ce331353e74da47892999add51030b44eb57b6beab2815ac34b9187L223-R311))
* Change the padding of the row that contains the phase label and the battery icon, to remove the bottom and right padding and make it more aligned with the name label in the `render` function in `roomba.star` ([link](https://github.com/tidbyt/community/pull/1874/files?diff=unified&w=0#diff-e30ae99e3ce331353e74da47892999add51030b44eb57b6beab2815ac34b9187L277-R365))
* Change the phase of the sample data from `run` to `error`, to simulate an error state for testing purposes in `roomba.star` ([link](https://github.com/tidbyt/community/pull/1874/files?diff=unified&w=0#diff-e30ae99e3ce331353e74da47892999add51030b44eb57b6beab2815ac34b9187L30-R32))
* Remove an empty line that was not needed in `roomba.star` ([link](https://github.com/tidbyt/community/pull/1874/files?diff=unified&w=0#diff-e30ae99e3ce331353e74da47892999add51030b44eb57b6beab2815ac34b9187R23))


