### PR TITLE
Update ncaaf_standings.star

### DIFF
--- a/apps/ncaafstandings/ncaaf_standings.star
+++ b/apps/ncaafstandings/ncaaf_standings.star
@@ -443,8 +443,8 @@ def get_team(x, s, entriesToDisplay, displayType):
                 teamName = s[i + x]["team"]["abbreviation"]
                 teamColor = get_team_color(teamID)
                 teamLogo = get_logoType(teamName, s[i + x]["team"]["logos"][0]["href"])
-                teamRecord = s[i + x]["stats"][11]["displayValue"]
-                teamGB = s[i + x]["stats"][2]["displayValue"]
+                teamRecord = s[i + x]["stats"][12]["displayValue"]
+                teamGB = s[i + x]["stats"][1]["displayValue"]
 
                 team = render.Column(
                     children = [

--- a/apps/ncaafstandings/ncaaf_standings.star
+++ b/apps/ncaafstandings/ncaaf_standings.star
@@ -51,7 +51,9 @@ ALT_COLOR = """
     "UNC" : "#13294B",
     "COLO" : "#000000",
     "IOWA" : "#000000",
-    "RICE" : "#00205B"
+    "RICE" : "#00205B",
+    "HP": "#330072",
+    "MIZ": "#000000"
 }
 """
 ALT_LOGO = """
@@ -114,7 +116,10 @@ ALT_LOGO = """
     "NORF" : "https://b.fssta.com/uploads/application/college/team-logos/NorfolkState.vresize.50.50.medium.0.png",
     "UNC" : "https://b.fssta.com/uploads/application/college/team-logos/NorthCarolina.vresize.50.50.medium.0.png",
     "BAY" : "https://b.fssta.com/uploads/application/college/team-logos/Baylor-alternate.vresize.50.50.medium.0.png",
-    "ALA" : "https://b.fssta.com/uploads/application/college/team-logos/Alabama-alternate.vresize.50.50.medium.0.png"
+    "ALA" : "https://b.fssta.com/uploads/application/college/team-logos/Alabama-alternate.vresize.50.50.medium.0.png",
+    "TLSA": "https://b.fssta.com/uploads/application/college/team-logos/Tulsa-alternate.vresize.50.50.medium.0.png",
+    "HP": "https://b.fssta.com/uploads/application/college/team-logos/HighPoint.vresize.50.50.medium.0.png",
+    "OSU": "https://b.fssta.com/uploads/application/college/team-logos/OhioState.vresize.50.50.medium.0.png"
 }
 """
 
@@ -491,9 +496,8 @@ def get_logoType(team, logo):
     if usealt != "NO":
         logo = get_cachable_data(usealt, 36000)
     else:
-        logo = logo.replace("500/scoreboard", "500-dark/scoreboard")
-        logo = logo.replace("https://a.espncdn.com/", "https://a.espncdn.com/combiner/i?img=", 36000)
-        logo = get_cachable_data(logo + "&h=50&w=50")
+        logo = logo.replace("500", "500-dark")
+        logo = get_cachable_data(logo + "?h=50&w=50")
     return logo
 
 def get_top_column(displayTop, now, timeColor, divisionName, renderCategory):


### PR DESCRIPTION
Updated colors/logos as in the Scores app

# Description
Replace this with a description of your changes.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 200b403</samp>

### Summary
:football::sparkles::bug:

<!--
1.  :football: - This emoji represents the sport of NCAAF and the main topic of the app.
2.  :sparkles: - This emoji represents the addition of new features or enhancements, such as more teams and logos.
3.  :bug: - This emoji represents the fixing of a bug or error, such as the logo display issue.
-->
This pull request enhances the NCAAF standings app by adding more teams and logos and fixing a logo display bug. It modifies the `apps/ncaafstandings/ncaaf_standings.star` file to update the data and logic for the app.

> _We're adding more teams to the NCAAF app_
> _`team_colors` and `team_logos` we'll update_
> _And when we see a logo bug we'll fix it in a snap_
> _Heave away, me hearties, heave away_

### Walkthrough
* Add more teams to the NCAAF standings app by updating the `team_colors` and `team_logos` dictionaries with the hex codes and logos for High Point, Missouri, Tulsa, and Ohio State ([link](https://github.com/tidbyt/community/pull/1876/files?diff=unified&w=0#diff-c54cfae0e86a414aa212fa528bf93af1041e12ce71d5bbbdb0afa646b3c31f89L54-R56), [link](https://github.com/tidbyt/community/pull/1876/files?diff=unified&w=0#diff-c54cfae0e86a414aa212fa528bf93af1041e12ce71d5bbbdb0afa646b3c31f89L117-R122))
* Fix a bug in the `get_logo` function that caused some logos to not display correctly on the Tidbyt device by simplifying the URL replacement logic and ensuring the correct dimensions for the ESPN logo API ([link](https://github.com/tidbyt/community/pull/1876/files?diff=unified&w=0#diff-c54cfae0e86a414aa212fa528bf93af1041e12ce71d5bbbdb0afa646b3c31f89L494-R500))


