### PR TITLE
Progressclock: Fixes duration logic

### DIFF
--- a/apps/progressclock/.gitignore
+++ b/apps/progressclock/.gitignore
@@ -1,1 +1,2 @@
 .env
+!progressclock.webp

--- a/apps/progressclock/README.md
+++ b/apps/progressclock/README.md
@@ -4,6 +4,8 @@
 
 See the time displayed & how much of the day has passed, as represented by a graph.
 
+https://github.com/Meandmybadself/community/assets/433643/45cfe034-2d0f-4f0b-9bae-c5d68c6ef559
+
 ## Development
 
 ### In-browser development

--- a/apps/progressclock/progressclock.star
+++ b/apps/progressclock/progressclock.star
@@ -28,11 +28,8 @@ def main(config):
     # Create a new time object representing the start of the day
     start_of_day = time.time(hour = 0, minute = 0, second = 0, year = current_time.year, month = current_time.month, day = current_time.day, location = timezone)
 
-    # Calculate the duration between the current time and the start of the day
-    duration = current_time - start_of_day
-
-    # Extract the total number of seconds from the duration
-    elapsed_seconds = duration.seconds
+    # Calculate the total number of seconds
+    elapsed_seconds = now.hour * 3600 + now.minute * 60 + now.second
 
     # Calculate the total number of seconds in a day
     total_seconds_in_day = 24 * 60 * 60

--- a/apps/progressclock/progressclock.star
+++ b/apps/progressclock/progressclock.star
@@ -19,14 +19,8 @@ def main(config):
     # Get the current time in the specified timezone
     now = time.now().in_location(timezone)
 
-    # Get the current local time
-    current_time = time.now()
-
     # For creating screenshots
     # mock_time = time.time(hour = 17, minute = 1, second = 1, year = current_time.year, month = current_time.month, day = current_time.day, location = timezone)
-
-    # Create a new time object representing the start of the day
-    start_of_day = time.time(hour = 0, minute = 0, second = 0, year = current_time.year, month = current_time.month, day = current_time.day, location = timezone)
 
     # Calculate the total number of seconds
     elapsed_seconds = now.hour * 3600 + now.minute * 60 + now.second


### PR DESCRIPTION
# Description

- Updates duration logic per @jmanske 's [wonderful advice](https://github.com/tidbyt/community/issues/1779#issuecomment-1727515992).
- Adds preview graphic.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 64ebc6d</samp>

### Summary
🕒🛠️🧹

<!--
1.  🕒 - This emoji represents the progress clock app and the icon file that was added to the repository. It also suggests the concept of time, which is relevant for both changes.
2.  🛠️ - This emoji represents the improvement or simplification of the code logic for calculating the elapsed seconds. It suggests the idea of fixing or refining something.
3.  🧹 - This emoji represents the removal of unnecessary or redundant code, such as the import of the `time` module and the subtraction of two `time.time` objects. It suggests the idea of cleaning or tidying up something.
-->
Added an icon and improved the time calculation for the progress clock app. Modified the `.gitignore` file to allow the `progressclock.webp` file and the `progressclock.star` file to use the `now` variable instead of the `time` module.

> _`progressclock.star`_
> _Simpler time calculation_
> _Autumn leaves falling_

### Walkthrough
*  Simplify calculation of elapsed seconds since start of day in `progressclock.star` ([link](https://github.com/tidbyt/community/pull/1879/files?diff=unified&w=0#diff-9c49603344aefe7ab184792fcb9a7cdd2a619dc57d458b09e45e0fe244091fe0L31-R33))
*  Allow `progressclock.webp` file to be committed in `.gitignore` ([link](https://github.com/tidbyt/community/pull/1879/files?diff=unified&w=0#diff-ec6db343746a4ca3605d81824c8b228b006461195bb74c74b6205a40a2d45944L1-R2))


