### PR TITLE
MLB Magic Number: override clinched flag if second place team is eliminated

### DIFF
--- a/apps/mlbmagicnumber/mlb_magic_number.star
+++ b/apps/mlbmagicnumber/mlb_magic_number.star
@@ -409,6 +409,12 @@ def http_get_number(team_id):
                                 if number == "-":
                                     number = record.get("teamRecords")[index].get("eliminationNumberDivision")
 
+                                    # if the second place team is eliminated, it means we have indeed clinched the division
+                                    # there is a short window of time where the clinch indicator has yet to be updated
+                                    # we can override the clinched flag here
+                                    if number == "E":
+                                        clinched = True
+
                         break  # we found our team
                 break  # we found our division
     else:


### PR DESCRIPTION
# Description
In the moment that a team wins the division, they will not be flagged as division winners before the second place team is flagged as eliminated. There is a brief window of time where we report a magic number of "E" (meaning "eliminated") which of course makes no sense. Instead, if the second place team is eliminated, override the clinched flag because it means we won the division.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c9ca688</samp>

### Summary
🐛🏆🖼️

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the pull request. It also conveys that the app had some issues that needed to be resolved.
2.  🏆 - This emoji represents a division clinch, which is the specific scenario that the change handles. It also conveys that the app is related to sports and achievements.
3.  🖼️ - This emoji represents a display or UI improvement, which is another aspect of the pull request. It also conveys that the app has a visual component and that the change affects how the app looks.
-->
Fix bugs and improve display of `mlb_magic_number` app. Add condition to handle division clinch scenario.

> _`clinch` condition_
> _fixes bugs in magic app_
> _autumn baseball joy_

### Walkthrough
*  Add condition to handle division clinch scenario ([link](https://github.com/tidbyt/community/pull/1891/files?diff=unified&w=0#diff-e5749a7f35e4fa2bfdec809e54032a332a3296a284390a4125865f537ab78ae0R412-R417))


