### PR TITLE
New App: Live on Twitch

### DIFF
--- a/apps/liveontwitch/live_on_twitch.star
+++ b/apps/liveontwitch/live_on_twitch.star
@@ -5,13 +5,13 @@ Description: This app fetches and displays the streamers you follow who are live
 Author: daltonclaybrook
 """
 
-load("render.star", "render")
-load("schema.star", "schema")
+load("cache.star", "cache")
 load("encoding/json.star", "json")
 load("http.star", "http")
-load("cache.star", "cache")
-load("time.star", "time")
+load("render.star", "render")
+load("schema.star", "schema")
 load("secret.star", "secret")
+load("time.star", "time")
 
 TWITCH_CLIENT_ID = "h980fr8jmfwp9gkcdo0sc1m251qlw9"
 TWITCH_CLIENT_SECRET = secret.decrypt("AV6+xWcEQV17TbSvb4u35Ir6ac/CuqEVYoo+XRIDH/FftFQhjn+VSh3oqchdz1hAbco3PsD5BAqyoL7hQHpT7iS0l5KIpYfcP84rBJOhp6or2SS38OfqjglBPcKQHSV9kAZEcgU7wIVBpJzO7I9R1d57YxDLhEpOB1O60OYLuc/8gsEI")

--- a/apps/liveontwitch/live_on_twitch.star
+++ b/apps/liveontwitch/live_on_twitch.star
@@ -13,8 +13,8 @@ load("schema.star", "schema")
 load("secret.star", "secret")
 load("time.star", "time")
 
-TWITCH_CLIENT_ID = "h980fr8jmfwp9gkcdo0sc1m251qlw9"
-TWITCH_CLIENT_SECRET = secret.decrypt("AV6+xWcEQV17TbSvb4u35Ir6ac/CuqEVYoo+XRIDH/FftFQhjn+VSh3oqchdz1hAbco3PsD5BAqyoL7hQHpT7iS0l5KIpYfcP84rBJOhp6or2SS38OfqjglBPcKQHSV9kAZEcgU7wIVBpJzO7I9R1d57YxDLhEpOB1O60OYLuc/8gsEI")
+TWITCH_CLIENT_ID = secret.decrypt("AV6+xWcE/aYwEfmThAFhVm8NJrh/c9tjxuvENfNesy1lUWIqQo9GGq90ENm/UDJwJ+1zpnJvESzP/GxVAt7+YoHiUJfJ2mCleNpdFsMJ0ix58jEEvdWH6H6MJ8dI0nSOKl5uCsXSkXpGGvh5UgI8pxlMfvKHg59D5FOeX62GB/2PqSaJ")
+TWITCH_CLIENT_SECRET = secret.decrypt("AV6+xWcEaGyyQ31L8I3zSauUNqXvLAsuS4H/WZuX8qSFM0pGA8/l6xqPnAhvzHOMvKpmwus3e3bLBFxP2evfLsCA1CJKZ+52BCAyvhPTyZBBRfDAlp+J16Ebk5JOLezMlX7pcZ3OyLgB8UB+WuMkZBLuFVHbPzQTYRjdYl/GYNoJCXBi")
 NO_DATA_IN_CACHE = ""
 
 # If a streamer went live less than 2 minutes ago, show them in an isolated widget. Otherwise, show the full list.

--- a/apps/liveontwitch/live_on_twitch.star
+++ b/apps/liveontwitch/live_on_twitch.star
@@ -13,7 +13,7 @@ load("schema.star", "schema")
 load("secret.star", "secret")
 load("time.star", "time")
 
-TWITCH_CLIENT_ID = secret.decrypt("t7n82ips6t16w5hmf27abea5ypqa2a")
+TWITCH_CLIENT_ID = "t7n82ips6t16w5hmf27abea5ypqa2a"
 TWITCH_CLIENT_SECRET = secret.decrypt("AV6+xWcEaGyyQ31L8I3zSauUNqXvLAsuS4H/WZuX8qSFM0pGA8/l6xqPnAhvzHOMvKpmwus3e3bLBFxP2evfLsCA1CJKZ+52BCAyvhPTyZBBRfDAlp+J16Ebk5JOLezMlX7pcZ3OyLgB8UB+WuMkZBLuFVHbPzQTYRjdYl/GYNoJCXBi")
 NO_DATA_IN_CACHE = ""
 

--- a/apps/liveontwitch/live_on_twitch.star
+++ b/apps/liveontwitch/live_on_twitch.star
@@ -16,6 +16,7 @@ load("secret.star", "secret")
 TWITCH_CLIENT_ID = "h980fr8jmfwp9gkcdo0sc1m251qlw9"
 TWITCH_CLIENT_SECRET = secret.decrypt("AV6+xWcEQV17TbSvb4u35Ir6ac/CuqEVYoo+XRIDH/FftFQhjn+VSh3oqchdz1hAbco3PsD5BAqyoL7hQHpT7iS0l5KIpYfcP84rBJOhp6or2SS38OfqjglBPcKQHSV9kAZEcgU7wIVBpJzO7I9R1d57YxDLhEpOB1O60OYLuc/8gsEI")
 NO_DATA_IN_CACHE = ""
+
 # If a streamer went live less than 2 minutes ago, show them in an isolated widget. Otherwise, show the full list.
 RECENTLY_LIVE_THRESHOLD = 120
 
@@ -103,7 +104,7 @@ def render_recently_live(stream):
                                         child = render.Circle(
                                             color = RED,
                                             diameter = 6,
-                                        )
+                                        ),
                                     ),
                                     render.Marquee(
                                         width = 49,
@@ -123,7 +124,7 @@ def render_recently_live(stream):
                         color = TWITCH_PURPLE,
                     ),
                 ],
-            )
+            ),
         ),
     )
 
@@ -156,10 +157,10 @@ def render_stream_list(followed_streams):
                 scroll_direction = "vertical",
                 offset_start = 6,
                 child = render.Column(
-                    children = streamer_widgets
+                    children = streamer_widgets,
                 ),
             ),
-        )
+        ),
     ]
     return render.Root(
         delay = 200,

--- a/apps/liveontwitch/live_on_twitch.star
+++ b/apps/liveontwitch/live_on_twitch.star
@@ -13,7 +13,7 @@ load("schema.star", "schema")
 load("secret.star", "secret")
 load("time.star", "time")
 
-TWITCH_CLIENT_ID = secret.decrypt("AV6+xWcE/aYwEfmThAFhVm8NJrh/c9tjxuvENfNesy1lUWIqQo9GGq90ENm/UDJwJ+1zpnJvESzP/GxVAt7+YoHiUJfJ2mCleNpdFsMJ0ix58jEEvdWH6H6MJ8dI0nSOKl5uCsXSkXpGGvh5UgI8pxlMfvKHg59D5FOeX62GB/2PqSaJ")
+TWITCH_CLIENT_ID = secret.decrypt("t7n82ips6t16w5hmf27abea5ypqa2a")
 TWITCH_CLIENT_SECRET = secret.decrypt("AV6+xWcEaGyyQ31L8I3zSauUNqXvLAsuS4H/WZuX8qSFM0pGA8/l6xqPnAhvzHOMvKpmwus3e3bLBFxP2evfLsCA1CJKZ+52BCAyvhPTyZBBRfDAlp+J16Ebk5JOLezMlX7pcZ3OyLgB8UB+WuMkZBLuFVHbPzQTYRjdYl/GYNoJCXBi")
 NO_DATA_IN_CACHE = ""
 

--- a/apps/liveontwitch/live_on_twitch.star
+++ b/apps/liveontwitch/live_on_twitch.star
@@ -1,0 +1,282 @@
+"""
+Applet: Live on Twitch
+Summary: See who's live on Twitch
+Description: This app fetches and displays the streamers you follow who are live.
+Author: daltonclaybrook
+"""
+
+load("render.star", "render")
+load("schema.star", "schema")
+load("encoding/json.star", "json")
+load("http.star", "http")
+load("cache.star", "cache")
+load("time.star", "time")
+load("secret.star", "secret")
+
+TWITCH_CLIENT_ID = "h980fr8jmfwp9gkcdo0sc1m251qlw9"
+TWITCH_CLIENT_SECRET = secret.decrypt("AV6+xWcEQV17TbSvb4u35Ir6ac/CuqEVYoo+XRIDH/FftFQhjn+VSh3oqchdz1hAbco3PsD5BAqyoL7hQHpT7iS0l5KIpYfcP84rBJOhp6or2SS38OfqjglBPcKQHSV9kAZEcgU7wIVBpJzO7I9R1d57YxDLhEpOB1O60OYLuc/8gsEI")
+NO_DATA_IN_CACHE = ""
+# If a streamer went live less than 2 minutes ago, show them in an isolated widget. Otherwise, show the full list.
+RECENTLY_LIVE_THRESHOLD = 120
+
+TWITCH_PURPLE = "#a970ff"
+WHITE = "#ffffff"
+BLACK = "#000000"
+RED = "#ff0000"
+
+def main(config):
+    refresh_token = config.get("auth")
+    if refresh_token == None:
+        return render_message("Login to Twitch")
+
+    user_id = get_current_user_id(refresh_token)
+    if user_id == None:
+        return render_message("Failed to fetch user")
+
+    followed_streams = get_followed_streams(refresh_token, user_id)
+    if followed_streams == None:
+        return render_message("Failed to fetch followed streams")
+
+    # Don't show the app at all if no one is live
+    if len(followed_streams) == 0:
+        return []
+
+    (stream, seconds_since_start) = most_recently_live_stream(followed_streams)
+    if stream != None and (seconds_since_start <= RECENTLY_LIVE_THRESHOLD or len(followed_streams) == 1):
+        return render_recently_live(stream)
+    else:
+        return render_stream_list(followed_streams)
+
+def get_schema():
+    return schema.Schema(
+        version = "1",
+        fields = [
+            schema.OAuth2(
+                id = "auth",
+                name = "Twitch",
+                desc = "Connect your Twitch account",
+                icon = "twitch",
+                handler = oauth_handler,
+                client_id = TWITCH_CLIENT_ID,
+                authorization_endpoint = "https://id.twitch.tv/oauth2/authorize",
+                scopes = [
+                    "user:read:follows",
+                ],
+            ),
+        ],
+    )
+
+# Render a message instead of displaying streamers
+def render_message(message):
+    return render.Root(
+        delay = 200,
+        child = render.Box(
+            child = render.Marquee(
+                width = 64,
+                offset_start = 20,
+                child = render.Text(message),
+            ),
+        ),
+    )
+
+# Render the provided streamer in a special "recently live" widget
+def render_recently_live(stream):
+    return render.Root(
+        delay = 100,
+        child = render.Box(
+            child = render.Column(
+                expanded = True,
+                main_align = "space_evenly",
+                cross_align = "center",
+                children = [
+                    render.Padding(
+                        color = RED,
+                        pad = 1,
+                        child = render.Padding(
+                            color = BLACK,
+                            pad = (1, 2, 1, 2),
+                            child = render.Row(
+                                cross_align = "center",
+                                children = [
+                                    render.Padding(
+                                        pad = (1, 0, 2, 0),
+                                        child = render.Circle(
+                                            color = RED,
+                                            diameter = 6,
+                                        )
+                                    ),
+                                    render.Marquee(
+                                        width = 49,
+                                        offset_start = 24,
+                                        align = "center",
+                                        child = render.Text(
+                                            content = stream["user_name"],
+                                        ),
+                                    ),
+                                ],
+                            ),
+                        ),
+                    ),
+                    render.Text(
+                        content = "Live on Twitch",
+                        font = "tom-thumb",
+                        color = TWITCH_PURPLE,
+                    ),
+                ],
+            )
+        ),
+    )
+
+# Render the provided list of live streamers
+def render_stream_list(followed_streams):
+    streamer_widgets = [
+        render.Text(
+            color = WHITE if index % 2 == 0 else TWITCH_PURPLE,
+            content = followed_streams[index]["user_name"],
+        )
+        for index in range(len(followed_streams))
+    ]
+    column_widgets = [
+        render.Padding(
+            pad = 1,
+            color = RED,
+            child = render.Padding(
+                pad = (1, 1, 3, 0),
+                color = BLACK,
+                child = render.Text(
+                    content = "Live on Twitch",
+                    font = "tom-thumb",
+                ),
+            ),
+        ),
+        render.Padding(
+            pad = (0, 1, 0, 0),
+            child = render.Marquee(
+                height = 21,
+                scroll_direction = "vertical",
+                offset_start = 6,
+                child = render.Column(
+                    children = streamer_widgets
+                ),
+            ),
+        )
+    ]
+    return render.Root(
+        delay = 200,
+        child = render.Padding(
+            pad = 1,
+            child = render.Column(
+                children = column_widgets,
+            ),
+        ),
+    )
+
+# Given a list of streams, returns the stream that went live most recently
+def most_recently_live_stream(followed_streams):
+    shortest_delta = None
+    recent_stream = None
+    now = time.now()
+    for stream in followed_streams:
+        started_at = time.parse_time(stream["started_at"])
+        delta = (now - started_at).seconds
+        if shortest_delta == None or delta < shortest_delta:
+            shortest_delta = delta
+            recent_stream = stream
+    return (recent_stream, shortest_delta)
+
+# The OAuth2 handler function provided to `schema.OAuth2`
+def oauth_handler(params):
+    params = json.decode(params)
+    res = http.post(
+        url = "https://id.twitch.tv/oauth2/token",
+        headers = {
+            "Accept": "application/json",
+        },
+        form_encoding = "application/x-www-form-urlencoded",
+        form_body = dict(
+            params,
+            client_secret = TWITCH_CLIENT_SECRET,
+        ),
+    )
+
+    if res.status_code != 200:
+        fail("auth failed with status %d: %s", res.status_code, res.body())
+
+    token = res.json()
+    refresh_token = token["refresh_token"]
+    access_token = token["access_token"]
+    expires_in = token["expires_in"]
+    cache.set(refresh_token, access_token, ttl_seconds = int(expires_in))
+    return refresh_token
+
+# Retrieve an access token from cache, or fetch one from the Twitch API
+def get_access_token(refresh_token, force_refresh = False):
+    access_token = cache.get(refresh_token)
+    if access_token != None and access_token != NO_DATA_IN_CACHE and force_refresh == False:
+        # Return early if we have a cached access token
+        print("Found cached access token")
+        return access_token
+
+    print("Fetching new access token...")
+    params = {
+        "client_id": TWITCH_CLIENT_ID,
+        "client_secret": TWITCH_CLIENT_SECRET,
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token,
+    }
+    res = http.post(
+        url = "https://id.twitch.tv/oauth2/token",
+        headers = {
+            "Accept": "application/json",
+        },
+        form_encoding = "application/x-www-form-urlencoded",
+        form_body = params,
+    )
+
+    if res.status_code != 200:
+        fail("auth refresh failed with status %d: %s", res.status_code, res.body())
+
+    token = res.json()
+    access_token = token["access_token"]
+    expires_in = token["expires_in"]
+    cache.set(refresh_token, access_token, ttl_seconds = int(expires_in))
+    return access_token
+
+# Clear the access token from cache by setting it to an empty string
+def clear_access_token(refresh_token):
+    cache.set(refresh_token, NO_DATA_IN_CACHE, ttl_seconds = 30)
+
+# Fetch the logged-in user's ID on Twitch
+def get_current_user_id(refresh_token):
+    access_token = get_access_token(refresh_token)
+    res = http.get(
+        url = "https://api.twitch.tv/helix/users",
+        headers = {
+            "Client-Id": TWITCH_CLIENT_ID,
+            "Authorization": "Bearer %s" % access_token,
+        },
+    )
+    if res.status_code == 200:
+        return res.json()["data"][0]["id"]
+    else:
+        clear_access_token(refresh_token)
+        return None
+
+# Fetch the provided user's list of followers
+def get_followed_streams(refresh_token, user_id):
+    access_token = get_access_token(refresh_token)
+    res = http.get(
+        url = "https://api.twitch.tv/helix/streams/followed",
+        headers = {
+            "Client-Id": TWITCH_CLIENT_ID,
+            "Authorization": "Bearer %s" % access_token,
+        },
+        params = {
+            "user_id": user_id,
+        },
+    )
+    if res.status_code == 200:
+        return res.json()["data"]
+    else:
+        clear_access_token(refresh_token)
+        return None

--- a/apps/liveontwitch/manifest.yaml
+++ b/apps/liveontwitch/manifest.yaml
@@ -1,0 +1,8 @@
+---
+id: live-on-twitch
+name: Live on Twitch
+summary: See who's live on Twitch
+desc: This app fetches and displays the streamers you follow who are live.
+author: daltonclaybrook
+fileName: live_on_twitch.star
+packageName: liveontwitch


### PR DESCRIPTION
# Description
This PR adds a new app called "Live on Twitch." After configuring the app with your Twitch account via OAuth2, the app shows a list of the streamers you follow who are currently live. If only one streamer is live, or if a streamer has gone live in the last two minutes, that streamer is shown in a special "recently live" widget. If none of your followed streamers are live, the app does not appear in the rotation.

## When multiple followed streamers are live

![live_list](https://github.com/tidbyt/community/assets/1727803/8702aa46-ebe6-49aa-ba06-a1dfad0c766f)

## When only one followed streamer is live, or when a streamer has just gone live minutes ago

![recently_live](https://github.com/tidbyt/community/assets/1727803/bc8c0d4a-5e47-403a-b230-e6d7ec7acd53)

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ad0590a</samp>

### Summary
🎮📺🟣

<!--
1.  🎮 - This emoji represents gaming, which is the main category of content on Twitch. It also conveys the idea of entertainment and fun, which are the goals of the applet.
2.  📺 - This emoji represents streaming, which is the core feature of Twitch and the applet. It also suggests the visual aspect of the applet, which shows the streamers' thumbnails and names on the Tidbyt device.
3.  🟣 - This emoji represents the color purple, which is the dominant color of the Twitch brand and logo. It also helps to distinguish the applet from other applets that might use similar emojis.
-->
This pull request adds a new applet called Live on Twitch, which shows the user's followed streamers who are live on Twitch. The pull request includes the applet code in `live_on_twitch.star` and the applet manifest in `manifest.yaml`. The applet code uses various modules and features to interact with the Twitch API and display the streamer information on the Tidbyt device.

> _`Live on Twitch` applet_
> _Shows streamers in the fall_
> _Code uses `Twitch API`_

### Walkthrough
* Create a new applet called Live on Twitch that shows the user's followed streamers who are live on Twitch ([link](https://github.com/tidbyt/community/pull/1894/files?diff=unified&w=0#diff-7230e91031664febc4723c0557b54bf7f537a0383896bb62dd62051a6a5531caR1-R283), [link](https://github.com/tidbyt/community/pull/1894/files?diff=unified&w=0#diff-021633cd08b710cf60220c28f06dffa37eece64f6708c3c5c9a5dd14984dfdaaR1-R8))
  * Use the Twitch API and OAuth2 module to authenticate the user and fetch the live streamers data ([link](https://github.com/tidbyt/community/pull/1894/files?diff=unified&w=0#diff-7230e91031664febc4723c0557b54bf7f537a0383896bb62dd62051a6a5531caR1-R283))
  * Use the caching module to store and update the data periodically ([link](https://github.com/tidbyt/community/pull/1894/files?diff=unified&w=0#diff-7230e91031664febc4723c0557b54bf7f537a0383896bb62dd62051a6a5531caR1-R283))
  * Use the rendering module to display the streamers' names, titles, and logos on the Tidbyt device ([link](https://github.com/tidbyt/community/pull/1894/files?diff=unified&w=0#diff-7230e91031664febc4723c0557b54bf7f537a0383896bb62dd62051a6a5531caR1-R283))
  * Use the schema module to define the applet settings and inputs, such as the refresh interval and the OAuth2 token ([link](https://github.com/tidbyt/community/pull/1894/files?diff=unified&w=0#diff-7230e91031664febc4723c0557b54bf7f537a0383896bb62dd62051a6a5531caR1-R283))
  * Use constants and comments to document and configure the applet behavior and parameters ([link](https://github.com/tidbyt/community/pull/1894/files?diff=unified&w=0#diff-7230e91031664febc4723c0557b54bf7f537a0383896bb62dd62051a6a5531caR1-R283))
  * Add the `live_on_twitch.star` file that contains the applet code ([link](https://github.com/tidbyt/community/pull/1894/files?diff=unified&w=0#diff-7230e91031664febc4723c0557b54bf7f537a0383896bb62dd62051a6a5531caR1-R283))
  * Add the `manifest.yaml` file that contains the applet metadata for the Tidbyt app store ([link](https://github.com/tidbyt/community/pull/1894/files?diff=unified&w=0#diff-021633cd08b710cf60220c28f06dffa37eece64f6708c3c5c9a5dd14984dfdaaR1-R8))


