### PR TITLE
Update API Secret and API for Opensea

### DIFF
--- a/apps/nft/nft.star
+++ b/apps/nft/nft.star
@@ -5,29 +5,27 @@ Description: Displays a random NFT associated with an Ethereum public address.
 Author: nipterink
 """
 
-load("cache.star", "cache")
-load("encoding/base64.star", "base64")
-load("encoding/json.star", "json")
 load("http.star", "http")
+load("random.star", "random")
 load("render.star", "render")
 load("schema.star", "schema")
 load("secret.star", "secret")
-load("time.star", "time")
 
-ASSETS_URL = "https://api.opensea.io/api/v1/assets?format=json&owner={}"
-COLLECTION_URL = "https://api.opensea.io/api/v1/collection/{}/"
+NFTS_URL = "https://api.opensea.io/v2/chain/ethereum/account/{}/nfts"
+COLLECTION_STATS_URL = "https://api.opensea.io/api/v1/collection/{}/stats"
 
 def main(config):
-    api_key = secret.decrypt("AV6+xWcEgyom3axWmveQsUXTRbQOZS5J+86SzzjX6xzGZdxe3TCmX1whv2nacbrV87OVvRLL2W9KC6+fN2Sikz4cKFxYPBth3Pv5I8on/9znxCWkyNyYxnfoK33i+f2Jwmn2Ffmdt2qdGm907dtB7pInMKLPIr+ikDYteSXA7FtQUUslxws=") or config.get("opensea-api-key") or ""
-    public_address = config.get("public_address") or "0xd6a984153acb6c9e2d788f08c2465a1358bb89a7"
-    nfts = fetch_opensea_assets(public_address, api_key)
-    nft = nfts[random(len(nfts))]
+    api_key = secret.decrypt("AV6+xWcE6aY6fd81YrVzBfapeIGfdHtBrvi3x5uhwn+APhh3N8foO4a7CpW55B0ZKsZ6Ut1CR5F0y1QG3UTlj/pD5tGToAoCoVYMsxPCyDyVu1tFX1MK1w5DX2yDKFR6lYnYrV5djtLUx1VFs9iPVBbpx26IelzoG8Nc1KghjlnPmPlIdVM=") or config.get("opensea-api-key") or ""
+    public_address = config.get("public_address")
+
+    nfts = fetch_opensea_nfts(public_address, api_key)
+    nft = nfts[random.number(0, len(nfts) - 1)]
     (nft_name, nft_thumbnail) = fetch_nft_thumbnail(nft)
 
     floor_price = None
     display_floor = config.bool("display_floor", False)
     if display_floor:
-        collection_stats = fetch_collection_stats(nft)
+        collection_stats = fetch_collection_stats(nft, api_key)
         floor_price = str(collection_stats["floor_price"])[:4] if collection_stats["floor_price"] else None
 
     return render.Root(
@@ -56,70 +54,44 @@ def main(config):
         ),
     )
 
-def fetch_opensea_assets(public_address, api_key):
-    cached_nfts = cache.get("public_address=%s" % public_address)
-    if cached_nfts != None:
-        print("Hit! Using cached Opensea response for", public_address)
-        nfts = json.decode(cached_nfts)
-    else:
-        fetch_url = ASSETS_URL.format(public_address)
-        print("Miss! Fetching OpenSea Assets for", public_address)
-        assets_resp = http.get(fetch_url, headers = {"X-API-KEY": api_key})
-        if (assets_resp.status_code != 200):
-            fail("OpenSea request failed with status", assets_resp.status_code)
+def fetch_opensea_nfts(public_address, api_key):
+    fetch_url = NFTS_URL.format(public_address)
+    print("Fetch URL:", fetch_url)
 
-        nfts = assets_resp.json()["assets"]
+    nfts_resp = http.get(fetch_url, headers = {"X-API-KEY": api_key}, ttl_seconds = 3600)
+    if (nfts_resp.status_code != 200):
+        fail("OpenSea request failed with status", nfts_resp.status_code)
 
-        # TODO: Determine if this cache call can be converted to the new HTTP cache.
-        cache.set("public_address=%s" % public_address, json.encode(nfts), ttl_seconds = 3600)
-
+    nfts = nfts_resp.json()["nfts"]
     return nfts
 
 def fetch_nft_thumbnail(nft):
     nft_name = nft["name"] if nft["name"] else ""
-    thumbnail_url = nft["image_thumbnail_url"]
+    thumbnail_url = nft["image_url"]
     if not thumbnail_url:
         fail("NFT has no image to display")
 
     # request a much smaller thumbnail than the default
     thumbnail_url = thumbnail_url.replace("?w=500", "?w=64")
+    print("Thumbnail URL for {}:".format(nft_name), thumbnail_url)
 
-    cached_thumbnail = cache.get("thumbnail=%s" % thumbnail_url)
-    if cached_thumbnail != None:
-        print("Hit! Using cached thumbnail for", nft_name)
-        return (nft_name, base64.decode(cached_thumbnail))
-    else:
-        print("Miss! Fetching image thumbnail for", nft_name)
-        thumbnail_resp = http.get(thumbnail_url)
-        if (thumbnail_resp.status_code != 200):
-            fail("Failed to fetch thumbnail with status", thumbnail_resp.status_code)
+    thumbnail_resp = http.get(thumbnail_url, ttl_seconds = 3600)
+    if (thumbnail_resp.status_code != 200):
+        fail("Failed to fetch thumbnail with status", thumbnail_resp.status_code)
 
-        # TODO: Determine if this cache call can be converted to the new HTTP cache.
-        cache.set("thumbnail=%s" % thumbnail_url, base64.encode(thumbnail_resp.body()), ttl_seconds = 3600)
-        return (nft_name, thumbnail_resp.body())
+    return (nft_name, thumbnail_resp.body())
 
-def fetch_collection_stats(nft):
-    collection_slug = nft["collection"]["slug"]
-    cached_collection_stats = cache.get("collection=%s" % collection_slug)
-    if cached_collection_stats != None:
-        print("Hit! Using cached collection stats for", collection_slug)
-        return json.decode(cached_collection_stats)
-    else:
-        collection_url = COLLECTION_URL.format(collection_slug)
-        print("Fetching OpenSea stats for", collection_slug)
-        collection_resp = http.get(collection_url)
-        if (collection_resp.status_code != 200):
-            fail("OpenSea request failed with status", collection_resp.status_code)
+def fetch_collection_stats(nft, api_key):
+    collection_slug = nft["collection"]
+    collection_url = COLLECTION_STATS_URL.format(collection_slug)
+    print("Collection Stats URL for {}:".format(collection_slug), collection_url)
 
-        collection_stats = collection_resp.json()["collection"]["stats"]
+    collection_resp = http.get(collection_url, headers = {"X-API-KEY": api_key}, ttl_seconds = 3600)
+    if (collection_resp.status_code != 200):
+        fail("OpenSea request failed with status", collection_resp.status_code)
 
-        # TODO: Determine if this cache call can be converted to the new HTTP cache.
-        cache.set("collection=%s" % collection_slug, json.encode(collection_stats), ttl_seconds = 3600)
-        return collection_stats
-
-def random(max):
-    """Return a pseudo-random number in [0, max)"""
-    return int(time.now().nanosecond % max)
+    collection_stats = collection_resp.json()["stats"]
+    return collection_stats
 
 def get_schema():
     return schema.Schema(


### PR DESCRIPTION
# Description
Opensea is rolling secrets. This updates the app with the new secret and also upgrades to newer versions of their api. Caching is updated to use ttl with http requests and the random util is now being used.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 418e656</samp>

### Summary
🆕🚀🧹

<!--
1.  🆕 - This emoji conveys the idea of something new or updated, and can be used to highlight the use of the new OpenSea API v2 and the new HTTP cache feature.
2.  🚀 - This emoji conveys the idea of speed, performance, or launching something, and can be used to highlight the improved performance and reliability of the nft app after the changes.
3.  🧹 - This emoji conveys the idea of cleaning, tidying, or simplifying something, and can be used to highlight the simplification and renaming of some functions and variables in the nft app.
-->
Improved the nft app by switching to a newer API, using HTTP caching, and refactoring some code.

> _The nft app had a makeover_
> _To use OpenSea API v2 and cache over_
> _The old fetching way_
> _That was slow and less stable_
> _And some names and functions got better_

### Walkthrough
*  Update OpenSea API calls to use v2 endpoint and HTTP cache feature ([link](https://github.com/tidbyt/community/pull/1897/files?diff=unified&w=0#diff-93cbe87d464fe3e8ed151c9909c15d03c16b782d28beeee89ea4916fef7ca4d4L8-R23), [link](https://github.com/tidbyt/community/pull/1897/files?diff=unified&w=0#diff-93cbe87d464fe3e8ed151c9909c15d03c16b782d28beeee89ea4916fef7ca4d4L30-R29), [link](https://github.com/tidbyt/community/pull/1897/files?diff=unified&w=0#diff-93cbe87d464fe3e8ed151c9909c15d03c16b782d28beeee89ea4916fef7ca4d4L59-R71), [link](https://github.com/tidbyt/community/pull/1897/files?diff=unified&w=0#diff-93cbe87d464fe3e8ed151c9909c15d03c16b782d28beeee89ea4916fef7ca4d4L86-R96))
  - Use `random.number` function from `random.star` module instead of custom random function ([link](https://github.com/tidbyt/community/pull/1897/files?diff=unified&w=0#diff-93cbe87d464fe3e8ed151c9909c15d03c16b782d28beeee89ea4916fef7ca4d4L8-R23))
  - Pass `api_key` parameter to `fetch_collection_stats` function for authentication ([link](https://github.com/tidbyt/community/pull/1897/files?diff=unified&w=0#diff-93cbe87d464fe3e8ed151c9909c15d03c16b782d28beeee89ea4916fef7ca4d4L30-R29))
  - Rename `fetch_opensea_assets` function to `fetch_opensea_nfts` and simplify logic to return a list of NFTs without pagination or extra fields ([link](https://github.com/tidbyt/community/pull/1897/files?diff=unified&w=0#diff-93cbe87d464fe3e8ed151c9909c15d03c16b782d28beeee89ea4916fef7ca4d4L59-R71))
  - Remove cache calls from `fetch_opensea_nfts` function and use `image_url` field instead of `image_thumbnail_url` field for `fetch_nft_thumbnail` function ([link](https://github.com/tidbyt/community/pull/1897/files?diff=unified&w=0#diff-93cbe87d464fe3e8ed151c9909c15d03c16b782d28beeee89ea4916fef7ca4d4L59-R71), [link](https://github.com/tidbyt/community/pull/1897/files?diff=unified&w=0#diff-93cbe87d464fe3e8ed151c9909c15d03c16b782d28beeee89ea4916fef7ca4d4L86-R96))
  - Simplify `fetch_nft_thumbnail` function to use HTTP cache feature instead of cache module and base64 encoding, and print `thumbnail_url` for debugging ([link](https://github.com/tidbyt/community/pull/1897/files?diff=unified&w=0#diff-93cbe87d464fe3e8ed151c9909c15d03c16b782d28beeee89ea4916fef7ca4d4L86-R96))
  - Update `fetch_collection_stats` function to return a stats object without extra fields, and change `collection_slug` to `collection` to match API response ([link](https://github.com/tidbyt/community/pull/1897/files?diff=unified&w=0#diff-93cbe87d464fe3e8ed151c9909c15d03c16b782d28beeee89ea4916fef7ca4d4L86-R96))


