### PR TITLE
Update Sunrise & Sunset - Use Set Timezone When Retrieving Current Date

### DIFF
--- a/apps/sunrisesunset/sunrise_sunset.star
+++ b/apps/sunrisesunset/sunrise_sunset.star
@@ -61,7 +61,7 @@ def main(config):
     lng = float(location["lng"])
 
     # Get sunset and sunrise times
-    now = time.now()
+    now = time.now().in_location(location["timezone"])
     sunriseTime = sunrise.sunrise(lat, lng, now).in_location(location["timezone"])
     sunsetTime = sunrise.sunset(lat, lng, now).in_location(location["timezone"])
 


### PR DESCRIPTION
# Description
To retrieve the current date and time, this app uses `time.now()`, which grabs the local time of the machine. However, I've noticed in EST that the sunrise and sunset times change at 8:00 PM; midnight UTC. Because of that, I assume the Tidbyt servers are running on UTC, which could give incorrect sunrise and sunset times for people that are a day ahead or behind that timezone.

This one-liner ensures that we get the local time according to the user's timezone, thus getting the correct date and thus the correct sunrise and sunset times.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f666a0d</samp>

### Summary
🕒🌅🌇

<!--
1.  🕒 - This emoji represents a clock or time, and can be used to indicate that the `now` variable was changed to use the location's timezone instead of UTC.
2.  🌅 - This emoji represents a sunrise, and can be used to indicate that the sunrise time was calculated and displayed correctly for the location.
3.  🌇 - This emoji represents a sunset, and can be used to indicate that the sunset time was calculated and displayed correctly for the location.
-->
Fixed a timezone bug in the `sunrise_sunset` app that caused incorrect sunrise and sunset times for some locations. Updated the app to use the location's timezone for calculating and displaying the times.

> _`now` uses timezone_
> _sunrise and sunset correct_
> _a winter bug fixed_

### Walkthrough
* Fix sunrise and sunset time calculation and display by using location's timezone instead of UTC ([link](https://github.com/tidbyt/community/pull/1898/files?diff=unified&w=0#diff-5c35c0000b31bcfe6a9e41b1e917af117e775d78f9799c3d7f90ca23b5c16d80L64-R64))


