### PR TITLE
App that shows tv static and a channel number in the top right corner

### DIFF
--- a/apps/tvstatic/manifest.yaml
+++ b/apps/tvstatic/manifest.yaml
@@ -1,0 +1,8 @@
+---
+id: tv-static
+name: TV Static
+summary: Show static on an old TV
+desc: Make your Tidbyt look like it is showing static on an old TV that is turned to Channel 3.
+author: Snuckey
+fileName: tv_static.star
+packageName: tvstatic

--- a/apps/tvstatic/tv_static.star
+++ b/apps/tvstatic/tv_static.star
@@ -1,0 +1,59 @@
+"""
+Applet: TV Static
+Summary: Show static on an old TV
+Description: Make your Tidbyt look like it is showing static on an old TV that is turned to Channel 3.
+Author: Snuckey
+"""
+
+load("random.star", "random")
+load("render.star", "render")
+
+STATIC_DIM = 2
+
+def main():
+    return render.Root(
+        child = render.Stack(
+            children = [
+                render.Animation(
+                    children = staticFrames(),
+                ),
+                render.Row(
+                    children = [
+                        render.Text(content = "03", color = "#00ff00", font = "10x20"),
+                    ],
+                    main_align = "end",
+                    expanded = True,
+                ),
+            ],
+        ),
+    )
+
+def staticFrames():
+    frames = []
+    for _ in range(200):
+        frames.append(staticScreen())
+    return frames
+
+def staticScreen():
+    static = []
+
+    for _ in range(int(32 / STATIC_DIM)):
+        static.append(render.Row(children = staticRow()))
+
+    return render.Column(children = static)
+
+def staticRow():
+    static = []
+    color = ""
+
+    for _ in range(int(64 / STATIC_DIM)):
+        num = random.number(0, 2)
+
+        if num == 0:
+            color = "#000000"
+        else:
+            color = "#ffffff"
+
+        static.append(render.Box(width = STATIC_DIM, height = STATIC_DIM, color = color))
+
+    return static


### PR DESCRIPTION
# Description
Created a simple app that makes the Tidbyt look like it is showing static on channel 3 of an old TV.
![tv_static](https://github.com/tidbyt/community/assets/47194400/4a38ec25-155b-455f-a1d5-82760ad529fe)

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 060b4e6</samp>

### Summary
📺🌩️📡

<!--
1.  📺 - This emoji represents a television, which is the main theme of the applet and the device that the applet runs on.
2.  🌩️ - This emoji represents lightning, which is a possible source of static interference on a TV and also suggests the random and noisy nature of the static animation.
3.  📡 - This emoji represents a satellite dish, which is a symbol of broadcasting and receiving TV signals and also relates to the channel number that the applet displays.
-->
This pull request adds a new applet called TV Static, which simulates the look of an old TV showing static on channel 3. It consists of two files: `manifest.yaml` for the applet metadata and `tv_static.star` for the applet logic.

> _`TV Static` applet_
> _Starlark code and manifest_
> _Winter nostalgia_

### Walkthrough
* Create and register a new applet for TV Static ([link](https://github.com/tidbyt/community/pull/1899/files?diff=unified&w=0#diff-530a0175b9d820bb41f863ad0c3a7159668ff22efdd6cda128eb2fb7be735dacR1-R8))
* Define the main function to generate and render the static animation and the channel number using the Tidbyt API ([link](https://github.com/tidbyt/community/pull/1899/files?diff=unified&w=0#diff-7410f9862dcc792e935f28959f1e030506a16f0be9d388434b8afbef651bcfeaR1-R59))


