### PR TITLE
Trharris/tvstaticrenderspeed

### DIFF
--- a/apps/tvstatic/tv_static.star
+++ b/apps/tvstatic/tv_static.star
@@ -30,7 +30,7 @@ def main():
 
 def staticFrames():
     frames = []
-    for _ in range(200):
+    for _ in range(100):
         frames.append(staticScreen())
     return frames
 

--- a/apps/tvstatic/tv_static.star
+++ b/apps/tvstatic/tv_static.star
@@ -9,6 +9,7 @@ load("random.star", "random")
 load("render.star", "render")
 
 STATIC_DIM = 2
+STATIC_FRAME_COUNT = 100
 
 def main():
     return render.Root(
@@ -30,7 +31,7 @@ def main():
 
 def staticFrames():
     frames = []
-    for _ in range(100):
+    for _ in range(STATIC_FRAME_COUNT):
         frames.append(staticScreen())
     return frames
 


### PR DESCRIPTION
# Description
Generate fewer frames of static so that the app renders in <500ms

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at bf8ce5e</samp>

### Summary
📺🔢♻️

<!--
1.  📺 - This emoji represents the TV static app and the visual effect of changing the number of static frames.
2.  🔢 - This emoji represents the introduction of a new constant and the use of a numeric value to control the app behavior.
3.  ♻️ - This emoji represents the refactoring of the `staticFrames` function to use the constant instead of a literal value, implying a cleaner and more reusable code.
-->
This pull request adds a new constant `STATIC_FRAME_COUNT` to the `tv_static.star` app, and uses it to generate the static frames. This makes the app more configurable and maintainable.

> _No more random noise, we control the static_
> _`STATIC_FRAME_COUNT` is our law, we set the limit_
> _Refactor the code, make it clean and tight_
> _`staticFrames` function, obey our might_

### Walkthrough
* Introduce a constant `STATIC_FRAME_COUNT` to store the number of static frames to generate ([link](https://github.com/tidbyt/community/pull/1906/files?diff=unified&w=0#diff-7410f9862dcc792e935f28959f1e030506a16f0be9d388434b8afbef651bcfeaR12))
* Use `STATIC_FRAME_COUNT` in `staticFrames` function instead of hard-coded value ([link](https://github.com/tidbyt/community/pull/1906/files?diff=unified&w=0#diff-7410f9862dcc792e935f28959f1e030506a16f0be9d388434b8afbef651bcfeaL33-R34))


