### PR TITLE
Remove test code that picked gold everytime.

### DIFF
--- a/apps/chemicalelements/chemical_elements.star
+++ b/apps/chemicalelements/chemical_elements.star
@@ -1614,18 +1614,16 @@ def main(config):
         The display inforamtion for the Tidbyt
     """
 
-    #default is random element
-    current_element = elements[random.number(0, len(elements) - 1)]
-
     #instead can choose one element per day based on day of year..
     #it'll cycle through a new element each day and restart on the 119th day
     if (config.get("display", "OncePerDay") == "OncePerDay"):
         now = config.get("time")
         now = (time.parse_time(now) if now else time.now())
         current_element = elements[day_of_year(now, DEFAULT_TIMEZONE) % len(elements)]
-
-    current_element = elements[78]
-
+    else:
+        #default is random element
+        current_element = elements[random.number(0, len(elements) - 1)]
+        
     row1 = current_element["Name"]
     row2 = getMainCommentary(current_element)
     row3 = getSecondaryCommentary(current_element)

--- a/apps/chemicalelements/chemical_elements.star
+++ b/apps/chemicalelements/chemical_elements.star
@@ -1623,7 +1623,7 @@ def main(config):
     else:
         #default is random element
         current_element = elements[random.number(0, len(elements) - 1)]
-        
+
     row1 = current_element["Name"]
     row2 = getMainCommentary(current_element)
     row3 = getSecondaryCommentary(current_element)


### PR DESCRIPTION
# Description
Removed a line of code that was there for testing and picked "Gold" everytime.

Now it'll work as expected based on the settings selected by the user.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c10f9a5</samp>

### Summary
🎲🔬🌟

<!--
1.  🎲 - This emoji represents the random element selection feature, as it suggests the idea of rolling a dice or generating a random outcome.
2.  🔬 - This emoji represents the chemicalelements app and its theme of science and chemistry, as it depicts a microscope, a common tool for scientific research and analysis.
3.  🌟 - This emoji represents the improvement and enhancement of the app's functionality and user experience, as it suggests the idea of excellence, quality, and achievement.
-->
The `chemicalelements` app now randomly selects an element to display instead of using a fixed value. This change enhances the app's variety and interactivity.

> _`chemicalelements`_
> _No more fixed value, but random_
> _A fresh surprise each time_

### Walkthrough
* Remove hard-coded element value and add random element selection for unspecified date ([link](https://github.com/tidbyt/community/pull/1908/files?diff=unified&w=0#diff-5da8c083b24b1699807775f0915551164d320cc193d93ae6ab9e201f490783b3L1617-L1619), [link](https://github.com/tidbyt/community/pull/1908/files?diff=unified&w=0#diff-5da8c083b24b1699807775f0915551164d320cc193d93ae6ab9e201f490783b3L1626-R1626)) in `chemical_elements.star`


