### PR TITLE
Plex recently added: update refresh time

### DIFF
--- a/apps/plexrecentlyadded/plex_recently_added.star
+++ b/apps/plexrecentlyadded/plex_recently_added.star
@@ -11,7 +11,7 @@ load("http.star", "http")
 load("render.star", "render")
 load("schema.star", "schema")
 
-REFRESH_TIME = 600  #every 10 minutes
+REFRESH_TIME = 86400 # twice a day
 
 SAMPLE_DATA = {
     "MediaContainer": {

--- a/apps/plexrecentlyadded/plex_recently_added.star
+++ b/apps/plexrecentlyadded/plex_recently_added.star
@@ -77,6 +77,7 @@ def main(config):
     plexToken = config.str("plexToken")
     apiKey = config.str("apiKey", "")
     showTitleCard = config.bool("showTitleCard", True)
+    title = ""
 
     if not serverIP or type(int(serverPort)) != "int":
         usingSampleData = True
@@ -91,6 +92,7 @@ def main(config):
             newData["MediaContainer"]["Metadata"].append({})
             newData["MediaContainer"]["Metadata"][i]["title"] = SAMPLE_DATA["MediaContainer"]["Metadata"][i]["title"]
             newData["MediaContainer"]["Metadata"][i]["thumb"] = SAMPLE_IMAGES[i]
+            title = newData["MediaContainer"]["Metadata"][i]["title"]
         data = newData
     else:
         serverPort = int(serverPort)
@@ -106,6 +108,11 @@ def main(config):
         else:
             thumbnailURL = entry["thumb"]
 
+        if entry.get("parentTitle"):
+            title = entry["parentTitle"]
+        else:
+            title = entry["title"]
+
         if not usingSampleData:
             thumbnail = requestThumb(serverIP, serverPort, plexToken, apiKey, thumbnailURL)
         else:
@@ -118,7 +125,7 @@ def main(config):
                     render.Marquee(
                         width = 21,
                         offset_start = 60 if showTitleCard else 0,  #offset to wait to slide in
-                        child = render.Text(entry["title"], font = "CG-pixel-3x5-mono"),
+                        child = render.Text(title, font = "CG-pixel-3x5-mono"),
                     ),
                 ],
             ),

--- a/apps/plexrecentlyadded/plex_recently_added.star
+++ b/apps/plexrecentlyadded/plex_recently_added.star
@@ -11,7 +11,7 @@ load("http.star", "http")
 load("render.star", "render")
 load("schema.star", "schema")
 
-REFRESH_TIME = 86400 # twice a day
+REFRESH_TIME = 86400  # twice a day
 
 SAMPLE_DATA = {
     "MediaContainer": {


### PR DESCRIPTION
# Description
Update to refresh twice a day

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6b845e2</samp>

### Summary
🕒📉🛑

<!--
1.  🕒 - This emoji represents the concept of time and can be used to indicate that the refresh time was modified.
2.  📉 - This emoji represents the idea of decreasing or lowering something and can be used to show that the refresh rate was reduced.
3.  🛑 - This emoji represents the notion of stopping or limiting something and can be used to suggest that the goal of the change was to avoid hitting the rate limit.
-->
Reduced the default refresh time for the `plex_recently_added` app from 10 minutes to 24 hours. This change aims to prevent the app from exceeding the Plex API rate limit.

> _`REFRESH_TIME` changed_
> _Less API calls to Plex_
> _Winter of waiting_

### Walkthrough
* Reduce the default refresh time from 10 minutes to 24 hours to avoid hitting the Plex API rate limit ([link](https://github.com/tidbyt/community/pull/1911/files?diff=unified&w=0#diff-ce209ddca3ff8e90241038ee61e7c5ec19c0da3b9f0cdf839dd3688f491afbe3L14-R14))


