### PR TITLE
Jacket: Lower refresh rate

### DIFF
--- a/apps/jacket/jacket.star
+++ b/apps/jacket/jacket.star
@@ -5,7 +5,7 @@ load("math.star", "math")
 load("render.star", "render")
 load("schema.star", "schema")
 
-REFRESH_RATE = 43200  #twice a day
+REFRESH_RATE = 3600
 OPEN_WEATHER_URL = "https://api.openweathermap.org/data/2.5/onecall"
 ADVERBS = [
     "damn cold",


### PR DESCRIPTION
# Description
Update rate to do once an hour, I've found that late at night it will still say jacket if the day was warm but got colder at night..

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2a66809</samp>

### Summary
🕒🌤️🧥

<!--
1.  🕒 - This emoji represents the clock or time aspect of the change, as the refresh rate was reduced by a factor of 12.
2.  🌤️ - This emoji represents the weather or climate aspect of the change, as the jacket app is based on the weather data and forecast.
3.  🧥 - This emoji represents the jacket or clothing aspect of the change, as the jacket app advises the user whether or not to wear a jacket based on the weather.
-->
Reduced the refresh rate of the `jacket` app to improve its accuracy. The app now updates the temperature and jacket recommendation every hour instead of every 12 hours.

> _`REFRESH_RATE` shrinks_
> _Jacket app needs latest data_
> _Winter is coming_

### Walkthrough
* Reduce the refresh rate of the jacket app from 12 hours to 1 hour to get more frequent weather updates ([link](https://github.com/tidbyt/community/pull/1915/files?diff=unified&w=0#diff-d06671f05ad7cc2a2e0e666d7cd24ea413131151e3471527049cbdfdeae86a36L8-R8))


