### PR TITLE
fixed reference to wrong weather API in options

### DIFF
--- a/apps/clockwithseconds/clockwithseconds.star
+++ b/apps/clockwithseconds/clockwithseconds.star
@@ -118,6 +118,26 @@ def main(config):
 
 time_offset_options = [
     schema.Option(
+        display = "-10",
+        value = "-10",
+    ),
+    schema.Option(
+        display = "-9",
+        value = "-9",
+    ),
+    schema.Option(
+        display = "-8",
+        value = "-8",
+    ),
+    schema.Option(
+        display = "-7",
+        value = "-7",
+    ),
+    schema.Option(
+        display = "-6",
+        value = "-6",
+    ),
+    schema.Option(
         display = "-5",
         value = "-5",
     ),
@@ -160,6 +180,26 @@ time_offset_options = [
     schema.Option(
         display = "+5",
         value = "5",
+    ),
+    schema.Option(
+        display = "+6",
+        value = "6",
+    ),
+    schema.Option(
+        display = "+7",
+        value = "7",
+    ),
+    schema.Option(
+        display = "+8",
+        value = "8",
+    ),
+    schema.Option(
+        display = "+9",
+        value = "9",
+    ),
+    schema.Option(
+        display = "+10",
+        value = "10",
     ),
 ]
 

--- a/apps/tempgraph/tempgraph.star
+++ b/apps/tempgraph/tempgraph.star
@@ -81,9 +81,8 @@ def main(config):
         Pixlet Root element
     """
     api_key = config.get("api_key", API_KEY)
-    # api_key = "0f21fd8fc8e54c84b9a13812232004"
 
-    if api_key == None:
+    if api_key == '':
         return render.Root(
             render.Padding(
                 pad = (0, 20, 0, 0),

--- a/apps/tempgraph/tempgraph.star
+++ b/apps/tempgraph/tempgraph.star
@@ -81,7 +81,7 @@ def main(config):
         Pixlet Root element
     """
     api_key = config.get("api_key", API_KEY)
-    api_key = "0f21fd8fc8e54c84b9a13812232004"
+    # api_key = "0f21fd8fc8e54c84b9a13812232004"
 
     if api_key == None:
         return render.Root(

--- a/apps/tempgraph/tempgraph.star
+++ b/apps/tempgraph/tempgraph.star
@@ -82,7 +82,7 @@ def main(config):
     """
     api_key = config.get("api_key", API_KEY)
 
-    if api_key == '':
+    if api_key == "":
         return render.Root(
             render.Padding(
                 pad = (0, 20, 0, 0),

--- a/apps/tempgraph/tempgraph.star
+++ b/apps/tempgraph/tempgraph.star
@@ -389,8 +389,8 @@ def get_schema():
         fields = [
             schema.Text(
                 id = "api_key",
-                name = "OpenWeather API Key",
-                desc = "API Key for OpenWeathermap",
+                name = "WeatherAPI.com API Key",
+                desc = "API Key for WeatherAPI.com",
                 icon = "user",
             ),
             schema.Location(


### PR DESCRIPTION
# Description
Fixed a reference to the wrong weather API in options

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 910a5d3</samp>

### Summary
:recycle::cloud::key:

<!--
1.  :recycle: - This emoji can be used to indicate that something was reused or recycled, such as switching to a different API provider that offers similar functionality. It can also imply that some code or logic was refactored or improved to work with the new service.
2.  :cloud: - This emoji can be used to represent the weather or the cloud-based service that provides the weather data. It can also suggest that the app is dealing with different types of weather conditions or forecasts from the new API.
3.  :key: - This emoji can be used to highlight the change in the API key schema field, which is a crucial piece of information for accessing the weather data. It can also imply that the app is more secure or reliable with the new key.
-->
Switched weather data source for `tempgraph` app from OpenWeathermap to WeatherAPI.com. Updated `api_key` schema field in `apps/tempgraph/tempgraph.star` to match the new service.

> _`api_key` changes_
> _WeatherAPI.com is new_
> _Autumn wind blows cold_

### Walkthrough
* Switch weather data source from OpenWeathermap to WeatherAPI.com for the tempgraph app ([link](https://github.com/tidbyt/community/pull/1931/files?diff=unified&w=0#diff-8e07f265c2c8a56d8b75b74e4886bd6ac30c6d53b50e26431cc56074d5b128e6L392-R393),                            


