### PR TITLE
more time offset options added

### DIFF
--- a/apps/clockwithseconds/clockwithseconds.star
+++ b/apps/clockwithseconds/clockwithseconds.star
@@ -118,6 +118,26 @@ def main(config):
 
 time_offset_options = [
     schema.Option(
+        display = "-10",
+        value = "-10",
+    ),
+    schema.Option(
+        display = "-9",
+        value = "-9",
+    ),
+    schema.Option(
+        display = "-8",
+        value = "-8",
+    ),
+    schema.Option(
+        display = "-7",
+        value = "-7",
+    ),
+    schema.Option(
+        display = "-6",
+        value = "-6",
+    ),
+    schema.Option(
         display = "-5",
         value = "-5",
     ),
@@ -160,6 +180,26 @@ time_offset_options = [
     schema.Option(
         display = "+5",
         value = "5",
+    ),
+    schema.Option(
+        display = "+6",
+        value = "6",
+    ),
+    schema.Option(
+        display = "+7",
+        value = "7",
+    ),
+    schema.Option(
+        display = "+8",
+        value = "8",
+    ),
+    schema.Option(
+        display = "+9",
+        value = "9",
+    ),
+    schema.Option(
+        display = "+10",
+        value = "10",
     ),
 ]
 


### PR DESCRIPTION
# Description
Added more time offset options to account for network delays in pushing and displaying the clock on local TidByts.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a70c9af</samp>

### Summary
🕒🌎🌏

<!--
1.  🕒 - This emoji represents a clock face showing three o'clock, which could be used to indicate the addition of more time zones and the ability to display different times on the clock.
2.  🌎 - This emoji represents the Earth as seen from the Western hemisphere, which could be used to indicate the inclusion of more regions in the Americas and the Pacific.
3.  🌏 - This emoji represents the Earth as seen from the Eastern hemisphere, which could be used to indicate the inclusion of more regions in Asia, Africa, and Australia.
-->
This pull request adds more timezone options to the `clockwithseconds` app, so that users can display the time in different parts of the world. It modifies the `apps/clockwithseconds/clockwithseconds.star` file to include more offset values and labels.

> _Sing, O Muse, of the skillful coder who devised_
> _A wondrous `clockwithseconds` app, that shows the time_
> _In many lands, both east and west, where mortals dwell_
> _And gods observe their deeds, with favor or with wrath._

### Walkthrough
* Add more timezone offset options for the clock with seconds app ([link](https://github.com/tidbyt/community/pull/1933/files?diff=unified&w=0#diff-84bfdd54467d4fe3330afdd48c3edf0b235e5fd4b0d06dd56c5e6de804e0e5e5R121-R140), [link](https://github.com/tidbyt/community/pull/1933/files?diff=unified&w=0#diff-84bfdd54467d4fe3330afdd48c3edf0b235e5fd4b0d06dd56c5e6de804e0e5e5R184-R203)) in `clockwithseconds.star`


