### PR TITLE
Lord of the Rings quote generator: Use http cache

### DIFF
--- a/apps/lordoftherings/lordoftherings.star
+++ b/apps/lordoftherings/lordoftherings.star
@@ -44,7 +44,7 @@ def main(config):
             "Content-Type": "application/json",
             "Authorization": "Bearer {0}".format(api_key),
         }
-        resp = http.get("https://the-one-api.dev/v2/character/{0}/quote".format(char_id), headers = headers)
+        resp = http.get("https://the-one-api.dev/v2/character/{0}/quote".format(char_id), headers = headers, ttl_seconds = CACHE_TIMEOUT)
 
         # check the HTTP response code
         # if we fail, send back "shall not pass"

--- a/apps/lordoftherings/lordoftherings.star
+++ b/apps/lordoftherings/lordoftherings.star
@@ -15,7 +15,8 @@ load("secret.star", "secret")
 load("time.star", "time")
 
 # using "lordoftherings"
-ENCRYPTED_API_KEY = "AV6+xWcE4VltFa9T2uqMvHJJvQmY+pl+upIgaFFPddIeaqFrJOg8lTPlzBnd4jN+EFw9k+ixYNjfzmJSCjYl4NLIw3NTUq96cWO0erM1BTMMh5SsurAc+4R2LZQ2iI+YHAlP5Go0Y5oe1WtMAfv3Zc47AaCh5Xl61QM="
+API_KEY = secret.decrypt("AV6+xWcE4VltFa9T2uqMvHJJvQmY+pl+upIgaFFPddIeaqFrJOg8lTPlzBnd4jN+EFw9k+ixYNjfzmJSCjYl4NLIw3NTUq96cWO0erM1BTMMh5SsurAc+4R2LZQ2iI+YHAlP5Go0Y5oe1WtMAfv3Zc47AaCh5Xl61QM=")
+
 
 MOVIE_FONT = "CG-pixel-3x5-mono"
 MOVIE_COLOR = "#701010"
@@ -39,10 +40,9 @@ def main(config):
 
     # if there is no quote info in the cache, get it via API
     if quote_info == None:
-        api_key = secret.decrypt(ENCRYPTED_API_KEY)
         headers = {
             "Content-Type": "application/json",
-            "Authorization": "Bearer {0}".format(api_key),
+            "Authorization": "Bearer {0}".format(API_KEY),
         }
         resp = http.get("https://the-one-api.dev/v2/character/{0}/quote".format(char_id), headers = headers, ttl_seconds = CACHE_TIMEOUT)
 


### PR DESCRIPTION
# Description
Use http cache instead of cache module and clean some stuff up. 

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8a9d63b</samp>

### Summary
🌐🔒🧹

<!--
1.  🌐 - This emoji represents the use of the new HTTP cache feature, which improves the performance and reliability of the app by caching the responses from the API and serving them faster and more consistently.
2.  🔒 - This emoji represents the use of the new secret management feature, which enhances the security and maintainability of the app by storing the API key in a secure and encrypted way, and avoiding exposing it in the code or the environment variables.
3.  🧹 - This emoji represents the simplification of the code by removing unnecessary modules and variables, and using constants for the font and API key. This emoji conveys the idea of cleaning up and refactoring the code to make it more readable and concise.
-->
The lordoftherings app is improved by using new features and refactoring the code. It now uses the `http_cache` module to cache API responses, and the `secret` module to store the API key securely. It also defines `FONT` and `API_KEY` as constants, and removes unused imports and variables.

> _We are the lords of the rings, we wield the power of the cache_
> _We guard our secrets in the dark, we don't need modules or trash_
> _We write our code with constants, we keep our font and key_
> _We face the doom of HTTP, we resist and we are free_

### Walkthrough
*  Decrypt the encrypted API key at runtime using the `secret.decrypt` function and the `API_KEY` constant ([link](https://github.com/tidbyt/community/pull/1938/files?diff=unified&w=0#diff-e77fa22f29fe6049291791d0df967114420b95607cb23db736b9b2dd72c1226eL18-R16))
* Simplify the caching and retrieval of the quote info by using the `ttl_seconds` parameter of the `http.get` function and removing the `cache` module and the `quote_info` variable ([link](https://github.com/tidbyt/community/pull/1938/files?diff=unified&w=0#diff-e77fa22f29fe6049291791d0df967114420b95607cb23db736b9b2dd72c1226eL37-R63))
* Store the quote text and the movie name in separate variables (`quote` and `movie`) and use them to render the text on the display, along with the `MOVIE_FONT` constant for the font ([link](https://github.com/tidbyt/community/pull/1938/files?diff=unified&w=0#diff-e77fa22f29fe6049291791d0df967114420b95607cb23db736b9b2dd72c1226eL99-R79), [link](https://github.com/tidbyt/community/pull/1938/files?diff=unified&w=0#diff-e77fa22f29fe6049291791d0df967114420b95607cb23db736b9b2dd72c1226eL125-R104))
* Remove the unused imports of the `cache.star` and `json.star` modules from the `lordoftherings.star` file ([link](https://github.com/tidbyt/community/pull/1938/files?diff=unified&w=0#diff-e77fa22f29fe6049291791d0df967114420b95607cb23db736b9b2dd72c1226eL8-R8))


