### PR TITLE
moretransit: Fix schema and add missing icons

### DIFF
--- a/apps/moretransit/moretransit.star
+++ b/apps/moretransit/moretransit.star
@@ -157,7 +157,7 @@ def main(config):
     root_cols.append(render.Row(children = [render.Text("    " + title, font = "tom-thumb")], main_align = "center"))
     return render.Root(render.Column(root_cols))
 
-def getSchema():
+def get_schema():
     return schema.Schema(
         version = "1",
         fields = [
@@ -190,18 +190,21 @@ def getSchema():
                 name = "Minimum ETA",
                 desc = "Omit vehicles closer than this ETA (in minutes), if that would make you sad that you couldn't walk to the station in time.",
                 default = "9",
+                icon = "hourglass",
             ),
             schema.Toggle(
                 id = "disableStation2",
                 name = "Disable second station",
                 default = False,
                 desc = "Disable the second station, only show one line.",
+                icon = "xmark",
             ),
             schema.Toggle(
                 id = "useStacked",
                 name = "Stack Times",
                 default = False,
                 desc = "Stack the arrival times under the line instead of overlaying them",
+                icon = "list",
             ),
         ],
     )


### PR DESCRIPTION
# Description
This app does not show any configurable settings in the Tidbyt app. The culprit appears to be that `get_schema` is incorrectly declared as `getSchema`. This PR fixes that, and also adds missing icons to pass schema validation.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a224e25</samp>

### Summary
🐍📝🚀

<!--
1.  🐍 This emoji represents the snake_case naming convention and can be used to highlight the change from camelCase to snake_case.
2.  📝 This emoji represents the documentation or code quality aspect of the change, as renaming functions can help make the code more readable and consistent.
3.  🚀 This emoji represents the improvement or enhancement of the app, as following the Python naming convention can help avoid potential errors or confusion and make the code more maintainable and compatible.
-->
Renamed `getSchema` to `get_schema` in `moretransit.star` to follow Python naming convention. This is part of a code quality improvement for the moretransit app.

> _`getSchema` no more_
> _`get_schema` follows Python_
> _a winter cleaning_

### Walkthrough
*  Rename `getSchema` function to `get_schema` for consistency with Python naming convention ([link](https://github.com/tidbyt/community/pull/1942/files?diff=unified&w=0#diff-f1335583fff712b973dbcd2c6c237a0ec25d777d20d277cb80225c547db0cbd1L160-R160))


