### PR TITLE
Updated Big Brother News app

### DIFF
--- a/apps/bigbrothernews/big_brother_news.star
+++ b/apps/bigbrothernews/big_brother_news.star
@@ -68,6 +68,7 @@ def render_article_larger(news):
     for article in news:
         news_text.append(render.Image(width = 64, height = 32, src = NEWS_ICON))
         news_text.append(render.WrappedText("%s" % article[0], color = "#FAE24C", font = "tb-8", linespacing = 1, width = 64, align = "left"))
+
         # news_text.append(render.Box(width = 64, height = 2))
         # news_text.append(render.WrappedText("%s" % article[1], font = "tb-8", color = "#ffffff", linespacing = 1, width = 64, align = "left"))
         news_text.append(render.Box(width = 64, height = 2))
@@ -82,6 +83,7 @@ def render_article_smaller(news):
     for article in news:
         news_text.append(render.Image(width = 64, height = 32, src = NEWS_ICON))
         news_text.append(render.WrappedText("%s" % article[0], color = "#FAE24C", font = "tom-thumb", linespacing = 1, width = 64, align = "left"))
+
         # news_text.append(render.Box(width = 64, height = 2))
         # news_text.append(render.WrappedText("%s" % article[1], font = "tom-thumb", color = "#ffffff", linespacing = 1, width = 64, align = "left"))
         news_text.append(render.Box(width = 64, height = 2))

--- a/apps/bigbrothernews/big_brother_news.star
+++ b/apps/bigbrothernews/big_brother_news.star
@@ -1,7 +1,7 @@
 """
 Applet: Big Brother News
-Summary: Ticker for bbspy
-Description: Shows the top story from bbspy.co.uk.
+Summary: Ticker for Big Blagger
+Description: Shows the top story from bigblagger.co.uk.
 Author: meejle
 """
 
@@ -12,12 +12,12 @@ load("schema.star", "schema")
 load("xpath.star", "xpath")
 
 NEWS_ICON = base64.decode("""
-iVBORw0KGgoAAAANSUhEUgAAAEAAAAAgCAMAAACVQ462AAACN1BMVEUAAAD///93d3e7u7s7OzuYmJji4uJYWFgeHh7v7++Hh4enp6ctLS1nZ2dLS0vT09MODg7JycmRkZHb29uxsbH6+voGBgYFBQUICAj7+/sJCQng4OARERH19fX29vYLCwuBgYGQkJCurq6qqqozMzMxMTEyMjJHR0dGRkbp6elMTExNTU3q6urr6+uhoaGioqKOjo6NjY1jY2MUFBTKysoNDQ0gICAPDw8MDAz09PTz8/MSEhJqamppaWmDg4OCgoKFhYXMzMwoKCgmJibPz89KSkrR0dHS0tLs7OykpKQqKipkZGTx8fHy8vIvLy8nJyckJCSlpaWmpqbu7u4rKyuLi4uKioqJiYksLCxmZmYhISEWFhbAwMCEhIRfX1+GhoaIiIigoKAuLi7t7e0iIiIXFxdhYWHo6OgaGhpRUVFSUlIcHBwbGxtcXFxZWVlQUFBTU1MdHR1VVVVaWlpPT09WVlZXV1ff39/Q0NCAgIDY2Njm5ubk5OTe3t7l5eXn5+dBQUHW1taSkpKTk5Obm5vj4+Pc3NxDQ0NFRUWVlZWdnZ2enp6UlJSWlpbh4eHFxcXIyMjDw8MwMDA/Pz+ysrI0NDQ+Pj44ODg5OTmwsLC/v7+zs7O1tbW9vb20tLS2tra5ubm6urpgYGCPj49sbGxubm5vb29wcHBxcXFzc3NycnJ0dHR1dXV2dnZ+fn58fHx5eXl7e3t9fX339/cQEBD4+Pjw8PAEBAQBAQH5+fn8/Pz9/f3+/v69J2ETAAACa0lEQVR42u3S6TdUYQDH8d9vIiTJkkH2pbIr2Yq0kDU0WRrUMGNJmzRFZEwUWqi0UFFUSqI0lca4/rieuaOjV0m9quPz6neec+73PM85F2v+Tc0e7vgbtR5kKf7c8eciwNfLB0rvn9ZviB+fpLD8CteYYNtIvOd0HSsyl9hTdgtLyFHbqNNxHCuqyFGXU2YPGx+GJr1JKwQqdQxpnhBL2Pi+LVKJ2lcHETXTmIwih6ZEcTrcEuWN/MVd+ym78SPQEyPfKEHHjmhrWYl8ieSgbwZf9pPcGnaeTAf8etibApxcVGsou7MU4IKhgNyXkmNdTqRGeZcGlX97cgbJgs5FNjzxYBVwgQyCcG7BJYOyWLMcsDjMF2ezIdxIi36+4jAjwnvoNjyUgGpy7IyXiTwRREsJnOlfBLnAtI+U5ZpFQH6LA3m5lbfFaiGvDZBsnYCGqYcAcyarSixU+EbTGVbeuZTSPlOmMotAmTjcTuoN3CnWDnITNDqSF03UnRIngzyAET7Tky4QfEeYHim9+0TZuAgYtfAa4Te7TkY8gNKTc8WFedCLm83K/2yWD2vQxD3tJHfX56nXcRJolBT13f3dpQP9IkCnUVcy7msOeeyFWDXagFT7WIkbTNZPPI9QegjfLpJlk+u5hZyFcOnLo9Apx5pagGwIIHl/r5+ORuty80syULh6to1zvSSltwAUpJMjlH0dpB2ssqSu08bszYApXtunUuUHQjkdrO076qwOBBKmQjzbHFFNaUjxND4MglZiHIShsQ+w2VaX516JX6omh7FkmryJ1SpfDnhdYaYZq6WgpRA2j304gzX/r+8805IKkDVoSgAAAABJRU5ErkJggg==
+iVBORw0KGgoAAAANSUhEUgAAAEAAAAAgCAIAAAAt/+nTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAHnklEQVRYhe2Xa0xTaRrHn3NOS09PoZRegAqtTKGFjnXLxYLiKuJmFRXHOJB4QbK4YySGTVnXuCo665JVo+slTpTJ1ssqoMPiTIxmllkryIQo6sp4GQqiTKFQKKXKpS303nPOfqizY2Z11mQ2437o79P557zPef9Pnvd53hyAMGHChAnzI0BeFjhEaATJ7whES2cTU4p1brIv8dnZh58/a3FS94MkRb8tkz8E9u+nfJnw0m+j58uTk9IYBvVsQqJgimZ6EoO/lz8o+XnEoomcp8+CFph+i15fyYsEtIXo36pd49EZlnMfwMTMjpQJN6dtHO0iDTa53YyOBNJMCzfLl4+Rkx2u0bfr+HtgALA6j73yj7FPIhg9f/kVd8bzycLuABEX1ZEaMTxTkf5sOD1qwuFj9j+4JYuT86WT0xNGl/21n8Mwmv7vRy0+Pj4yMnJ6+n9QT4YyAfJ+kzwP3Rfw+0/8uo4wzGjqLUFJX5G4xU+zxkZlS5nfPM7K/lhkHzPHcgWRq9nq/r9PPqUcALB3797i4mIURQOBgE6n6+7ubmxsLCkpaW1tfXmPuLi4hoYGPp+P47jJZKqqqjp+/DiO4zk5OT8+AXRLpiQBScOfTJrudCQwmWahH11+mcnojVNZ4jP6LY/FrnZ/xmfDSkIqEBvYlqH4FZ7y9yWhYLlcrlKpBgcHIyMja2pq5mg0PT09LpcLADDsu+5isVi5ubmxsbFGo7GgoODkyZMxMTE4jofeMplMBHkxSxAEeTnwPyWDwXjZPYZhaLIA9H8yyLQbD1kvOwOMqujCi+Qv2bl3H+rTvm59d37Mp6n1U/wvxrO7x4fosdP1524/+CpmBgbAAAAURQGgoqKivr4eQRChQICiqFAoPHLkyNDQUGtra0dHx7Jly6anp1ksVnt7e0lJidls5vP5TCbT4/Gkp6c/evTIbDbfuHFDKpUqFIqWlhaTyaTX669du7Z48eKmpqaBgQG9Xq/X6zUazeXLly0WS11d3YYNG+7cuXP+/Pn+/n7GyrohigKIhFmpmXcdM/riLZSAtaqN+PrmgB+j/MveGfzZ6IynAcfTpFlpnMaIhwd1ExhMAtAAQJIkAPT19SEIYjQarVZrXl4ej8dTq9UNDQ0EQeTn58fGxpIk6XK5iouLi4qKEASpqanRaDQIguA4bjAYOjsNpaUbDhw4IBKJFixYcOLEicLCQqlUqlQqBQKBTqcrLCxMTEy8cOECn88/deqUVltZUFAgEol4PN6lS5dQigIAYERjKZH+SFJ5nnmxxfFR8HbCV+/67sld7gdS72bqcTW335MvdeJIFAAACS/aNFSBtWvXVlZWpqSkVFZWkiSpVquNRuP69euPHTsWqjsAsNnstra2efPmNTc3V1RUZGVl+Xw+iqJlMllaWmowGJw7d+7ChQvr6+u3bdt2/fp1HMelUunFTz4JSYIgFAoFRVGZmZkAtEgkAoDq6urt27ejIStBB2kMsldc+3J3473F9/upRJuqmz27J4pQD3OHR7OfGdIWNQ/QCB0aG9/efiFzHo+HoigA4HK5NE3b7XaJRLJkyRKxWAwAoaGEIAhJkl6vNxSCYVhUVNShQwdVKtXBgwftdjuKok6nMzs7OzExkcfjhcqbk50tkUhC0ufzMZnMK1eulJaWnj59+rs+uLhZWro2JgKFVbuUnaUaoxqGNXDmz3mNH5Z/uvODLz7LoHcDvRuens9b/uFsNhe2ZCr+ujoJwQAAamtr6W/p6urat28fTdM7duxoa2ujKGpiYoKm6bKyMi6Xa7fbQ8soitLpdEePHqVp2u/3+3w+i8UyMjJC0/TVq1fNZrPb7Xa73WNjY1u3brVarV6vNyR37tzpcDicTufQ8HB7eztN02vWrAEA5MxGoWN9hcssicJuCWKd2c3fmOPJj4T7VjzskrlGz82fv465K87GGknPYOij5ogVvcLOm2cMf7jVCQASiUQgENA0TZKkyWRCUTQpKcnn86nVagaDkZeXV15eXlZWVltbO2vWLAzDEARxOp0DAwMIgiQnJ6MoyuFwgsGgzWaTSqUEQYjF4oiICK1Wm5qaum7dOjabzWaztVqtSqVKSkoCAKVSOT4+brPZxGKxyWRyOBxIJg7vacvHUrK8ngCO6LM4BI/A6lxFsk4XgmIXVFixoCHeS0zETO0JlDNZSPXYro9/1+UepV43mHNycm7fvu3xeDgczv3791euXGm1Wl+3+GX2799fVVXldrsJgjh8+LDP59uzZ09Inj17dtOmTa+MQgBgbYowe5EWx31Lrx8fLOVMylKek8qR8dkUggaFnXN8Tt+X6knSnbzl7BAdVb3dZrnn/AEfCILI5fKEhISpqanu7m6Px/Mm7gGAzWYrlcro6GiLxdLb24vjuFKp5PF4Vqu1t7c31GavTgAANirm6eLfQ203nfOvTV6nPn8/959cJgslZaBKa85CpnjqPcc4+J0iHX73H943NPTT8OKeezQ+3PR8WpaaMjOtTyjzGjkZHk/u4EPPYqFVKL6JpXY+ie1df4R83Pb/5R6+9z+AoOwsQcIvovHoRdHmuFVUwM+3NnU4454Yhy093UC96WEIEyZMmDBhfir+BSGMYXO7GbVlAAAAAElFTkSuQmCC
 """)
 
 def main(config):
     fontsize = config.get("fontsize", "tb-8")
-    articles = get_cacheable_data("https://www.bbspy.co.uk/feed", 1)
+    articles = get_cacheable_data("https://bigblagger.co.uk/feed", 1)
 
     if fontsize == "tb-8":
         return render.Root(
@@ -28,7 +28,7 @@ def main(config):
                     render.Marquee(
                         height = 32,
                         scroll_direction = "vertical",
-                        offset_start = 26,
+                        offset_start = 24,
                         offset_end = 32,
                         child =
                             render.Column(
@@ -49,7 +49,7 @@ def main(config):
                     render.Marquee(
                         height = 32,
                         scroll_direction = "vertical",
-                        offset_start = 26,
+                        offset_start = 24,
                         offset_end = 32,
                         child =
                             render.Column(
@@ -67,11 +67,11 @@ def render_article_larger(news):
 
     for article in news:
         news_text.append(render.Image(width = 64, height = 32, src = NEWS_ICON))
-        news_text.append(render.WrappedText("%s" % article[0], color = "#e48a47", font = "tb-8", linespacing = 1, width = 64, align = "left"))
+        news_text.append(render.WrappedText("%s" % article[0], color = "#FAE24C", font = "tb-8", linespacing = 1, width = 64, align = "left"))
+        # news_text.append(render.Box(width = 64, height = 2))
+        # news_text.append(render.WrappedText("%s" % article[1], font = "tb-8", color = "#ffffff", linespacing = 1, width = 64, align = "left"))
         news_text.append(render.Box(width = 64, height = 2))
-        news_text.append(render.WrappedText("%s" % article[1], font = "tb-8", color = "#ffffff", linespacing = 1, width = 64, align = "left"))
-        news_text.append(render.Box(width = 64, height = 2))
-        news_text.append(render.WrappedText("More at bbspy.co.uk", font = "tb-8", color = "#964c98", linespacing = 1, width = 64, align = "left"))
+        news_text.append(render.WrappedText("More at bigblagger .co.uk", font = "tb-8", color = "#EA37A5", linespacing = 1, width = 64, align = "left"))
 
     return (news_text)
 
@@ -81,18 +81,18 @@ def render_article_smaller(news):
 
     for article in news:
         news_text.append(render.Image(width = 64, height = 32, src = NEWS_ICON))
-        news_text.append(render.WrappedText("%s" % article[0], color = "#e48a47", font = "tom-thumb", linespacing = 1, width = 64, align = "left"))
+        news_text.append(render.WrappedText("%s" % article[0], color = "#FAE24C", font = "tom-thumb", linespacing = 1, width = 64, align = "left"))
+        # news_text.append(render.Box(width = 64, height = 2))
+        # news_text.append(render.WrappedText("%s" % article[1], font = "tom-thumb", color = "#ffffff", linespacing = 1, width = 64, align = "left"))
         news_text.append(render.Box(width = 64, height = 2))
-        news_text.append(render.WrappedText("%s" % article[1], font = "tom-thumb", color = "#ffffff", linespacing = 1, width = 64, align = "left"))
-        news_text.append(render.Box(width = 64, height = 2))
-        news_text.append(render.WrappedText("More at bbspy.co.uk", font = "tom-thumb", color = "#964c98", linespacing = 1, width = 64, align = "left"))
+        news_text.append(render.WrappedText("More at bigblagger .co.uk", font = "tom-thumb", color = "#EA37A5", linespacing = 1, width = 64, align = "left"))
 
     return (news_text)
 
 def connectionError(config):
     fontsize = config.get("fontsize", "tb-8")
     errorHead = "Error: Couldn't get the top story"
-    errorBlurb = "For the latest headlines, visit bbspy.co.uk"
+    errorBlurb = "For the latest headlines, visit bigblagger .co.uk"
     return render.Root(
         delay = 50,
         child = render.Marquee(
@@ -104,9 +104,9 @@ def connectionError(config):
                 main_align = "start",
                 children = [
                     render.Image(width = 64, height = 32, src = NEWS_ICON),
-                    render.WrappedText(content = errorHead, width = 64, color = "#e48a47", font = fontsize, linespacing = 1, align = "left"),
+                    render.WrappedText(content = errorHead, width = 64, color = "#FAE24C", font = fontsize, linespacing = 1, align = "left"),
                     render.Box(width = 64, height = 2),
-                    render.WrappedText(content = errorBlurb, width = 64, color = "#fff", font = fontsize, linespacing = 1, align = "left"),
+                    render.WrappedText(content = errorBlurb, width = 64, color = "#EA37A5", font = fontsize, linespacing = 1, align = "left"),
                 ],
             ),
         ),
@@ -115,7 +115,7 @@ def connectionError(config):
 def get_cacheable_data(url, articlecount):
     articles = []
 
-    res = http.get("https://www.bbspy.co.uk/feed".format(url), ttl_seconds = 900)
+    res = http.get("https://bigblagger.co.uk/feed".format(url), ttl_seconds = 900)
     if res.status_code != 200:
         return connectionError()
     data = res.body()


### PR DESCRIPTION
# Description
Ditched [bbspy](https://www.bbspy.co.uk) for [Big Blagger](https://bigblagger.co.uk) for now, due to a lack of updates. Have had to remove the blurbs for now. If bbspy comes back to life any time soon, I'll offer it as an option.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 72f70dd</samp>

### Summary
📰🔄🚫

<!--
1.  📰 - This emoji represents the news applet and the change of source from Big Brother News to Big Blagger.
2.  🔄 - This emoji represents the update of the applet metadata, the feed URL, the scrolling position and the news text format to reflect the new source and style.
3.  🚫 - This emoji represents the change of the error message display to show a red cross instead of a question mark when the feed is unavailable or invalid.
-->
Updated the `big_brother_news` applet to use Big Blagger as the news source. Changed the applet metadata, icon, feed URL, text format and error display to match the Big Blagger style.

> _Oh we're the crew of the big_brother_news_
> _And we sail the web for the latest clues_
> _We've switched our source to the Big Blagger site_
> _So pull on the rope and we'll set it right_

### Walkthrough
*  Update applet name, summary and description to use Big Blagger as news source ([link](https://github.com/tidbyt/community/pull/1948/files?diff=unified&w=0#diff-1a50e3149ea5a06b1e3cb6bc3cbb7fc272cf3ce61e6c1a31f922430226d4461cL3-R4))
*  Replace NEWS_ICON with base64-encoded image of Big Blagger logo ([link](https://github.com/tidbyt/community/pull/1948/files?diff=unified&w=0#diff-1a50e3149ea5a06b1e3cb6bc3cbb7fc272cf3ce61e6c1a31f922430226d4461cL15-R20))
*  Adjust offset_start of render.ScrollingContainer to improve vertical scrolling position of news text ([link](https://github.com/tidbyt/community/pull/1948/files?diff=unified&w=0#diff-1a50e3149ea5a06b1e3cb6bc3cbb7fc272cf3ce61e6c1a31f922430226d4461cL31-R31), [link](https://github.com/tidbyt/community/pull/1948/files?diff=unified&w=0#diff-1a50e3149ea5a06b1e3cb6bc3cbb7fc272cf3ce61e6c1a31f922430226d4461cL52-R52))
*  Simplify and colorize news_text list to match Big Blagger branding and display only article title and website link ([link](https://github.com/tidbyt/community/pull/1948/files?diff=unified&w=0#diff-1a50e3149ea5a06b1e3cb6bc3cbb7fc272cf3ce61e6c1a31f922430226d4461cL70-R74), [link](https://github.com/tidbyt/community/pull/1948/files?diff=unified&w=0#diff-1a50e3149ea5a06b1e3cb6bc3cbb7fc272cf3ce61e6c1a31f922430226d4461cL84-R88))
*  Change feed URL to https://bigblagger.co.uk/feed and update errorBlurb and render.WrappedText elements with new website link ([link](https://github.com/tidbyt/community/pull/1948/files?diff=unified&w=0#diff-1a50e3149ea5a06b1e3cb6bc3cbb7fc272cf3ce61e6c1a31f922430226d4461cL95-R95), [link](https://github.com/tidbyt/community/pull/1948/files?diff=unified&w=0#diff-1a50e3149ea5a06b1e3cb6bc3cbb7fc272cf3ce61e6c1a31f922430226d4461cL107-R109), [link](https://github.com/tidbyt/community/pull/1948/files?diff=unified&w=0#diff-1a50e3149ea5a06b1e3cb6bc3cbb7fc272cf3ce61e6c1a31f922430226d4461cL118-R118))


