### PR TITLE
dothrakiwotd: wotd instead of wot10s

### DIFF
--- a/apps/dothrakiwotd/dothraki_wotd.star
+++ b/apps/dothrakiwotd/dothraki_wotd.star
@@ -1523,7 +1523,7 @@ def render_error():
 def main():
     print("Starting")
 
-    date = str(time.now())[0:18]
+    date = str(time.now())[0:10]
 
     print(date)
 


### PR DESCRIPTION
# Description
Truncate date string so that we get word of the _day_ instead of a new one every 10s.
# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 97edb0d</samp>

### Summary
📅🗓️🕰️

<!--
1.  📅 Calendar: This emoji can symbolize the date format and the Dothraki calendar, as both are related to measuring time and events.
2.  🗓️ Spiral Calendar: This emoji can also represent the date format and the Dothraki calendar, but with a more detailed and circular design that might suggest the cyclical nature of seasons and moons in the Dothraki culture.
3.  🕰️ Mantelpiece Clock: This emoji can indicate the simplification and readability of the date format, as a clock is a device that shows the current time in a clear and easy way.
-->
Simplified date format in `dothraki_wotd` app. The app now displays the Dothraki word of the day along with the current date in the format YYYY-MM-DD.

> _`date_format` changed_
> _Only year, month and day_
> _Clear as winter sky_

### Walkthrough
*  Simplified the date format to show only year, month and day ([link](https://github.com/tidbyt/community/pull/1951/files?diff=unified&w=0#diff-ea2d37d2051b3a4963d555289f785abb8555828ab46f9b55547b377cff3b7141L1526-R1526)). This makes the output more readable and consistent with the Dothraki calendar.


