### PR TITLE
fix season calculation. remove randomize

### DIFF
--- a/apps/inseason/inseason.star
+++ b/apps/inseason/inseason.star
@@ -189,7 +189,7 @@ def get_display_list(items):
     """
 
     # since the text often cuts off, let's scramble the list each time
-    items = randomize_list(items)
+    #items = randomize_list(items)
 
     return_value = ""
     for i in items:
@@ -254,38 +254,20 @@ def get_season(date):
     Returns:
         The season number
     """
+
+    m = date.month
+    x = m % 12 // 3 + 1
+
     season = 0
 
-    if (date.month < 3):
+    if x == 1:
         season = 3
-    elif (date.month == 3):
-        if (date.day < 21):
-            season = 3
-        else:
-            season = 0
-    elif (date.month < 6):
+    if x == 2:
         season = 0
-    elif (date.month == 6):
-        if (date.day < 21):
-            season = 0
-        else:
-            season = 1
-    elif (date.month < 9):
+    if x == 3:
         season = 1
-    elif (date.month == 9):
-        if (date.day < 21):
-            season = 1
-        else:
-            season = 2
-    elif (date.month < 12):
-        season = 3
-    elif (date.month == 12):
-        if (date.day < 21):
-            season = 2
-        else:
-            season = 3
-    else:
-        season = 0
+    if x == 4:
+        season = 2
 
     return season
 

--- a/apps/inseason/inseason.star
+++ b/apps/inseason/inseason.star
@@ -6,7 +6,6 @@ Author: Robert Ison
 """
 
 load("encoding/base64.star", "base64")  #Used to read encoded image
-load("random.star", "random")
 load("render.star", "render")
 load("schema.star", "schema")
 load("time.star", "time")
@@ -171,13 +170,6 @@ def main(config):
         delay = int(config.get("scroll", 45)),
     )
 
-def get_random_number(x):
-    return random.number(0, x)
-
-def randomize_list(items):
-    items = sorted(items, reverse = False, key = get_random_number)
-    return items
-
 def get_display_list(items):
     """ 
     Gets the list of in season foods in a human readable format
@@ -187,9 +179,6 @@ def get_display_list(items):
     Returns:
         Easy to read display list
     """
-
-    # since the text often cuts off, let's scramble the list each time
-    #items = randomize_list(items)
 
     return_value = ""
     for i in items:


### PR DESCRIPTION
# Description
There was a bug in the calculation for season.  New algorithm implemented.

Also, since we can now use "Show Full Animation", I removed the randomization of the list of in season produce. 
It will now be alphabetical again, since it won't continually cut off the end of the list.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 876b3cd</samp>

### Summary
🐛🌱⚡

<!--
1.  🐛 for the bug fix
2.  🌱 for the season-related feature
3.  ⚡ for the optimization
-->
Updated the `inseason` app to improve its functionality and performance. Fixed a bug that caused inconsistent and unordered item lists, and optimized the `get_season` function to use a simpler formula.

> _The seasons of doom are calling_
> _We fix the bug and make the list_
> _No more chaos in the inseason app_
> _We optimize the function with a twist_

### Walkthrough
*  Fix bug that caused inconsistent item list by removing randomization ([link](https://github.com/tidbyt/community/pull/1952/files?diff=unified&w=0#diff-f9366c8a8190fe00232f74f6d6d5e1e5bd8cda8c1cd870009c3abe809a09ceb0L192-R192))
*  Simplify and optimize season calculation function with a concise formula ([link](https://github.com/tidbyt/community/pull/1952/files?diff=unified&w=0#diff-f9366c8a8190fe00232f74f6d6d5e1e5bd8cda8c1cd870009c3abe809a09ceb0L257-R270))


