### PR TITLE
chi-l-track - fixes

### DIFF
--- a/apps/chi-l-track/chi_l_track.star
+++ b/apps/chi-l-track/chi_l_track.star
@@ -6,7 +6,6 @@ Author: FabioCZ
 """
 
 load("cache.star", "cache")
-load("encoding/json.star", "json")
 load("http.star", "http")
 load("render.star", "render")
 load("schema.star", "schema")
@@ -14,7 +13,7 @@ load("secret.star", "secret")
 load("time.star", "time")
 
 CTA_ARRIVAL_URL = "http://lapi.transitchicago.com/api/1.0/ttarrivals.aspx"
-CTA_API_KEY_ENCRYPTED = "AV6+xWcEy0aq3L+XsSlftGr+3M9WAeYYRCvdZVV4IhA7geAcFIuA5ff/mRN+8bn6A2buqsZQvojzchfCQ+gI9Ig/uPXKv/+P1+EbPWChzTDg25SuhW8wsDGoKNaT70/dFt+tw5fNmnI/+3bOQPPup47BCNJa6f2EFiq53lJHAsiGw+/GN40="
+CTA_API_KEY_ENCRYPTED = "AV6+xWcELbih+T/00GIGkmFH3sopxrsAqzeCItxZTPGmlCZbB2BSE13mwVFSTelW2aZ/AEaGPCTovf3OkVuFKGdkbSWElxzQqN87HVNVSIC047ITpew7amAOk1KZaPZxyZACCQtl9/OUZQyuZJ3/+VSh11/TLJlc1mfhihTfCuNi4DQPwg4="
 
 CTA_L_STATON_LIST_URL = "https://data.cityofchicago.org/resource/8pix-ypme.json"
 
@@ -68,7 +67,7 @@ def getPredictionSuffix(route, destinationName, destinationId, isScheduled):
         else:
             return "!"
     elif route == "Pink":
-        if destinationId == "30014":
+        if destinationId == "30114":
             return ""
         else:
             return "!"
@@ -87,23 +86,18 @@ def getPredictionSuffix(route, destinationName, destinationId, isScheduled):
 
 def getPredictions(predConfig, devApiKey):
     preds = []
-    cacheKey = predConfig.stopId + predConfig.route
-    respRaw = cache.get(cacheKey)
     respJson = {}
-    if respRaw == None:
-        apiKey = secret.decrypt(CTA_API_KEY_ENCRYPTED) or devApiKey
-        resp = http.get(getApiUrl(predConfig, apiKey))
-        if resp.status_code != 200:
-            fail("CTA request failed with: %d, %s", resp.status_code, resp.body())
-        if resp.body()[0] == "<":
-            fail("CTA request failed - we got a bad xml response")
-        respRaw = resp.body()
-        respJson = resp.json()
-        if "eta" not in respJson["ctatt"]:
-            return preds
-        cache.set(cacheKey, respRaw, ttl_seconds = 45)
-    else:
-        respJson = json.decode(respRaw)
+    apiKey = secret.decrypt(CTA_API_KEY_ENCRYPTED) or devApiKey
+    resp = http.get(getApiUrl(predConfig, apiKey), ttl_seconds = 45)
+
+    if resp.status_code != 200:
+        fail("CTA request failed with: %d, %s", resp.status_code, resp.body())
+    if resp.body()[0] == "<":
+        fail("CTA request failed - we got a bad xml response")
+
+    respJson = resp.json()
+    if "eta" not in respJson["ctatt"]:
+        return preds
 
     for pred in respJson["ctatt"]["eta"]:
         if pred["rt"] == predConfig.route:
@@ -358,15 +352,10 @@ def directionName(dirId):
         return "??"
 
 def getStationOptions():
-    cacheKey = "stationsCache"
-    stationsRaw = cache.get(cacheKey)
-    if stationsRaw == None:
-        resp = http.get(CTA_L_STATON_LIST_URL)
-        if resp.status_code != 200:
-            fail("Failed to get L station list %d %s", resp.status_code, resp.body())
-        stationsRaw = resp.body()
-        cache.set(cacheKey, stationsRaw, ttl_seconds = 86400)  # 1 day
-    stationsJson = json.decode(stationsRaw)
+    resp = http.get(CTA_L_STATON_LIST_URL, ttl_seconds = 86400)  # 1 day
+    if resp.status_code != 200:
+        fail("Failed to get L station list %d %s", resp.status_code, resp.body())
+    stationsJson = resp.json()
     options = [schema.Option(display = x["station_descriptive_name"] + " - " + directionName(x["direction_id"]), value = x["stop_id"]) for x in stationsJson]
     return options
 

--- a/apps/chi-l-track/chi_l_track.star
+++ b/apps/chi-l-track/chi_l_track.star
@@ -13,7 +13,7 @@ load("secret.star", "secret")
 load("time.star", "time")
 
 CTA_ARRIVAL_URL = "http://lapi.transitchicago.com/api/1.0/ttarrivals.aspx"
-CTA_API_KEY_ENCRYPTED = "AV6+xWcELbih+T/00GIGkmFH3sopxrsAqzeCItxZTPGmlCZbB2BSE13mwVFSTelW2aZ/AEaGPCTovf3OkVuFKGdkbSWElxzQqN87HVNVSIC047ITpew7amAOk1KZaPZxyZACCQtl9/OUZQyuZJ3/+VSh11/TLJlc1mfhihTfCuNi4DQPwg4="
+CTA_API_KEY_ENCRYPTED = "AV6+xWcEod0tcqS3kB0TnKV1HItYtqB9nj6a5CRVHR7o1KDh8Kef1OvdTTVCfJrdFRta7xLqpAoHZMmZe6vvamjHZK0iQM3VzgYAXZHVyfS6J67QoX8Yk9WA0xLtFCd6ge1C674GUMm0YOh+H85s3qCy7FdZmGA8VMCC3h2ruNyAxD22z98="
 
 CTA_L_STATON_LIST_URL = "https://data.cityofchicago.org/resource/8pix-ypme.json"
 


### PR DESCRIPTION
# Description

Follow up to: https://github.com/tidbyt/community/pull/1949

* Regenerate api secret correctly (not sure what happened first time)
* Fix pink line destination tracking
* add http-level caching as recommended


# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ddb976a</samp>

### Summary
🔒🐛🚀

<!--
1.  🔒 - This emoji represents encryption or security, and can be used to indicate the change to use an encrypted CTA API key.
2. 🐛 - This emoji represents a bug or an error, and can be used to indicate the fix for the destination ID bug for the Pink line.
3. 🚀 - This emoji represents speed or performance, and can be used to indicate the simplification of the caching logic for the API calls.
-->
This pull request improves the `chi_l_track` app by using a more secure API key, fixing a data error, and optimizing the API caching.

> _The key is encrypted, no one can see_
> _The secrets of the CTA_
> _The Pink line bug is fixed at last_
> _No more confusion on the track_

### Walkthrough
*  Update encrypted CTA API key ([link](https://github.com/tidbyt/community/pull/1961/files?diff=unified&w=0#diff-fa455afc688b409993276e4ed3da81c5f09cae059c94aaf2c041362e491370f5L17-R17))
*  Fix destination ID for Pink line trains ([link](https://github.com/tidbyt/community/pull/1961/files?diff=unified&w=0#diff-fa455afc688b409993276e4ed3da81c5f09cae059c94aaf2c041362e491370f5L71-R71))
*  Refactor getPredictions and getStationOptions functions to use built-in ttl_seconds parameter of http.get instead of cache module ([link](https://github.com/tidbyt/community/pull/1961/files?diff=unified&w=0#diff-fa455afc688b409993276e4ed3da81c5f09cae059c94aaf2c041362e491370f5L90-R102), [link](https://github.com/tidbyt/community/pull/1961/files?diff=unified&w=0#diff-fa455afc688b409993276e4ed3da81c5f09cae059c94aaf2c041362e491370f5L361-R360))


