### PR TITLE
arcadeclassics: Use built-in random function

### DIFF
--- a/apps/arcadeclassics/arcade_classics.star
+++ b/apps/arcadeclassics/arcade_classics.star
@@ -7,6 +7,7 @@ Author: Steve Otteson
 
 load("encoding/base64.star", "base64")
 load("math.star", "math")
+load("random.star", "random")
 load("render.star", "render")
 load("schema.star", "schema")
 load("time.star", "time")
@@ -31,31 +32,28 @@ SPEED_ADJUST = {
 }
 
 def main(config):
-    seed = int(time.now().unix)
-    seed = [seed]
-
     animation = config.str("animation", PACMAN_ANIMATION)
     if animation == RANDOM_ANIMATION:
-        animation = ANIMATION_LIST.values()[rand(seed, len(ANIMATION_LIST) - 1)]
+        animation = ANIMATION_LIST.values()[rand(len(ANIMATION_LIST) - 1)]
 
     speed = int(config.str("speed", DEFAULT_SPEED))
     if speed < 0:
-        speed = rand(seed, MIN_SPEED + MAX_SPEED + 1) + MAX_SPEED
+        speed = rand(MIN_SPEED + MAX_SPEED + 1) + MAX_SPEED
 
     speed = speed * SPEED_ADJUST[animation]
     delay = speed * time.millisecond
 
     app_cycle_speed = SECONDS_TO_RENDER * time.second
-    num_frames = math.ceil(app_cycle_speed / delay)
+    num_frames = math.ceil(app_cycle_speed // delay)
 
     allFrames = []
     for _ in range(1, 1000):
         if animation == PACMAN_ANIMATION:
-            frames = pacman_get_frames(seed)
+            frames = pacman_get_frames()
         elif animation == SPACE_INVADERS_ANIMATION:
             frames = spaceinvaders_get_frames()
         else:
-            frames = centipede_get_frames(seed)
+            frames = centipede_get_frames()
 
         allFrames.extend(frames)
         if len(allFrames) >= num_frames:
@@ -66,9 +64,8 @@ def main(config):
         child = render.Animation(allFrames),
     )
 
-def rand(seed, max):
-    seed[0] = (seed[0] * 1103515245 + 12345) & 0xffffffff
-    return (seed[0] >> 16) % max
+def rand(maximum):
+    return random.number(0, maximum)
 
 DEFAULT_SPEED = "30"
 
@@ -197,11 +194,11 @@ CHASED_GHOST = 4
 # Make the odds of chasing a ghost a little higher
 CHANCE_FOR_CHASED_GHOST = 2
 
-def pacman_get_frames(seed):
-    yPos = rand(seed, PM_NUM_Y_POSITIONS)
-    mspacman = rand(seed, 2) == 1
-    reverse = rand(seed, 2) == 1
-    whichGhost = rand(seed, CHASING_GHOST_COUNT + CHANCE_FOR_CHASED_GHOST)
+def pacman_get_frames():
+    yPos = rand(PM_NUM_Y_POSITIONS)
+    mspacman = rand(2) == 1
+    reverse = rand(2) == 1
+    whichGhost = rand(CHASING_GHOST_COUNT + CHANCE_FOR_CHASED_GHOST)
     if whichGhost >= CHASING_GHOST_COUNT:
         whichGhost = CHASED_GHOST
 
@@ -380,13 +377,13 @@ CENT_ORIG_LEG_COLOR = CENT_OFF_WHITE
 CENT_HIST_MOVES_PER_SEGMENT = CENT_SPRITE_WIDTH // CENT_MOVE_PER_STATE
 CENT_MAX_HISTORY_ITEMS = CENT_HIST_MOVES_PER_SEGMENT * CENT_NUM_SEGMENTS
 
-def centipede_get_frames(seed):
-    colorScheme = get_color_scheme(seed)
+def centipede_get_frames():
+    colorScheme = get_color_scheme()
     centSprites = create_all_cent_sprites(colorScheme)
     mushroomSprite = create_mushroom_sprite(colorScheme)
-    mushroomMap = create_mushroom_map(seed, mushroomSprite)
+    mushroomMap = create_mushroom_map(mushroomSprite)
 
-    xDir = rand(seed, 2)
+    xDir = rand(2)
     if xDir == 0:
         xDir = -1
         centStartX = FRAME_WIDTH
@@ -591,9 +588,9 @@ def get_segment_render_child(centSprites, segmentIndex, history):
         ),
     )
 
-def add_mushroom(seed, mushroomMap, mushroomSprite):
-    col = rand(seed, CENT_NUM_COLS)
-    row = rand(seed, CENT_NUM_ROWS)
+def add_mushroom(mushroomMap, mushroomSprite):
+    col = rand(CENT_NUM_COLS)
+    row = rand(CENT_NUM_ROWS)
 
     x = col * CENT_SPRITE_WIDTH
     y = row * CENT_SPRITE_WIDTH
@@ -633,7 +630,7 @@ def create_mushroom_sprite(colorScheme):
 
     return makeSprite(mushroomPixels, colorReplacements = colorScheme)
 
-def get_color_scheme(seed):
+def get_color_scheme():
     colorSchemes = [
         # Green, red, off white
         {CENT_ORIG_BODY_COLOR: CENT_GREEN, CENT_ORIG_EYE_COLOR: CENT_RED, CENT_ORIG_LEG_COLOR: CENT_OFF_WHITE},
@@ -678,13 +675,13 @@ def get_color_scheme(seed):
         {CENT_ORIG_BODY_COLOR: CENT_GREEN, CENT_ORIG_EYE_COLOR: CENT_MAGENTA, CENT_ORIG_LEG_COLOR: CENT_RED},
     ]
 
-    return colorSchemes[rand(seed, len(colorSchemes))]
+    return colorSchemes[rand(len(colorSchemes))]
 
-def create_mushroom_map(seed, mushroomSprite):
-    mushroomCount = rand(seed, CENT_MAX_MUSHROOMS - CENT_MIN_MUSHROOMS + 1) + CENT_MIN_MUSHROOMS
+def create_mushroom_map(mushroomSprite):
+    mushroomCount = rand(CENT_MAX_MUSHROOMS - CENT_MIN_MUSHROOMS + 1) + CENT_MIN_MUSHROOMS
     mushroomMap = {}
     for _ in range(mushroomCount):
-        add_mushroom(seed, mushroomMap, mushroomSprite)
+        add_mushroom(mushroomMap, mushroomSprite)
 
     return mushroomMap
 


### PR DESCRIPTION
Arcade Classics was using its own RNG function. Instead use the built-in RNG, which is both faster and also is setup to have a much better cache hit ratio.

Also makes it so we don't have to pass `seed` all over the place.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e1bab1d</samp>

### Summary
🎲🔧🧹

<!--
1.  🎲 - This emoji represents the `random` module, which is used to generate random numbers for the games. It also suggests the element of chance and fun involved in playing arcade classics.
2.  🔧 - This emoji represents the refactoring process, which involves improving and fixing the existing code. It also suggests the idea of fine-tuning and optimizing the performance and functionality of the app.
3.  🧹 - This emoji represents the removal of unnecessary or redundant code, such as the custom `rand` function and its parameters and imports. It also suggests the idea of cleaning up and simplifying the code base.
-->
Refactor `arcade_classics` app to use `random` module. This simplifies the code, avoids potential bugs, and follows best practices for random number generation.

> _We're refactoring the code, me hearties, yo ho ho_
> _We're using `random` module, not `rand`, don't you know_
> _It makes the code more reliable and consistent, so_
> _Heave away and pull the line, on the count of three, let's go_

### Walkthrough
*  Import `random` module and use `random.number` function to simplify and improve random number generation ([link](https://github.com/tidbyt/community/pull/1964/files?diff=unified&w=0#diff-fbfeb25f692cdf56ab616a363ff718bc6689dcd23ebed46edb9e428dd45c0133R10), [link](https://github.com/tidbyt/community/pull/1964/files?diff=unified&w=0#diff-fbfeb25f692cdf56ab616a363ff718bc6689dcd23ebed46edb9e428dd45c0133L34-R41), [link](https://github.com/tidbyt/community/pull/1964/files?diff=unified&w=0#diff-fbfeb25f692cdf56ab616a363ff718bc6689dcd23ebed46edb9e428dd45c0133L200-R201), [link](https://github.com/tidbyt/community/pull/1964/files?diff=unified&w=0#diff-fbfeb25f692cdf56ab616a363ff718bc6689dcd23ebed46edb9e428dd45c0133L383-R386), [link](https://github.com/tidbyt/community/pull/1964/files?diff=unified&w=0#diff-fbfeb25f692cdf56ab616a363ff718bc6689dcd23ebed46edb9e428dd45c0133L594-R593), [link](https://github.com/tidbyt/community/pull/1964/files?diff=unified&w=0#diff-fbfeb25f692cdf56ab616a363ff718bc6689dcd23ebed46edb9e428dd45c0133L636-R633), [link](https://github.com/tidbyt/community/pull/1964/files?diff=unified&w=0#diff-fbfeb25f692cdf56ab616a363ff718bc6689dcd23ebed46edb9e428dd45c0133L681-R684))
*  Remove unnecessary seed variables and `time` module ([link](https://github.com/tidbyt/community/pull/1964/files?diff=unified&w=0#diff-fbfeb25f692cdf56ab616a363ff718bc6689dcd23ebed46edb9e428dd45c0133L34-R41), [link](https://github.com/tidbyt/community/pull/1964/files?diff=unified&w=0#diff-fbfeb25f692cdf56ab616a363ff718bc6689dcd23ebed46edb9e428dd45c0133L69-R68))
*  Use floor division operator `//` to ensure integer result for `num_frames` variable ([link](https://github.com/tidbyt/community/pull/1964/files?diff=unified&w=0#diff-fbfeb25f692cdf56ab616a363ff718bc6689dcd23ebed46edb9e428dd45c0133L49-R56))
*  Remove custom `rand` function and its seed parameter ([link](https://github.com/tidbyt/community/pull/1964/files?diff=unified&w=0#diff-fbfeb25f692cdf56ab616a363ff718bc6689dcd23ebed46edb9e428dd45c0133L69-R68), [link](https://github.com/tidbyt/community/pull/1964/files?diff=unified&w=0#diff-fbfeb25f692cdf56ab616a363ff718bc6689dcd23ebed46edb9e428dd45c0133L200-R201), [link](https://github.com/tidbyt/community/pull/1964/files?diff=unified&w=0#diff-fbfeb25f692cdf56ab616a363ff718bc6689dcd23ebed46edb9e428dd45c0133L383-R386), [link](https://github.com/tidbyt/community/pull/1964/files?diff=unified&w=0#diff-fbfeb25f692cdf56ab616a363ff718bc6689dcd23ebed46edb9e428dd45c0133L594-R593), [link](https://github.com/tidbyt/community/pull/1964/files?diff=unified&w=0#diff-fbfeb25f692cdf56ab616a363ff718bc6689dcd23ebed46edb9e428dd45c0133L636-R633), [link](https://github.com/tidbyt/community/pull/1964/files?diff=unified&w=0#diff-fbfeb25f692cdf56ab616a363ff718bc6689dcd23ebed46edb9e428dd45c0133L681-R684))


