### PR TITLE
Updated METAR app due to API changes by NOAA.

### DIFF
--- a/apps/metar/metar.star
+++ b/apps/metar/metar.star
@@ -12,7 +12,7 @@ load("http.star", "http")
 load("render.star", "render")
 load("schema.star", "schema")
 
-ADDS_URL = "https://www.aviationweather.gov/adds/dataserver_current/httpparam?dataSource=metars&requestType=retrieve&format=csv&stationString=%s&mostrecentforeachstation=constraint&hoursBeforeNow=2"
+ADDS_URL = "https://www.aviationweather.gov/cgi-bin/data/dataserver.php?dataSource=metars&requestType=retrieve&format=csv&stationString=%s&mostrecentforeachstation=constraint&hoursBeforeNow=2"
 DEFAULT_AIRPORT = "KJFK, KLGA, KBOS, KDCA"
 
 # encryption, schema


### PR DESCRIPTION
# Description
NOAA updated the aviationweather.gov API, migrated to the new backward-compatibility URL and tested.

Without this fix METAR app is completely broken.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 87bda49</samp>

### Summary
🛫🌤️🔄

<!--
1.  🛫 This emoji could represent the aviation theme of the app and the data source, as well as the idea of fixing a broken link or service.
2.  🌤️ This emoji could represent the weather information that the app provides, as well as the improved functionality and user experience after the change.
3.  🔄 This emoji could represent the update or refresh of the URL and the data, as well as the continuity and reliability of the app.
-->
Updated the metar app to use the new ADDS data server URL. This restores the functionality of the app, which displays weather information for airports.

> _`ADDS_URL` changed_
> _Old server was deprecated_
> _Metar app works now_

### Walkthrough
* Update the data source URL for the metar app ([link](https://github.com/tidbyt/community/pull/1967/files?diff=unified&w=0#diff-cb502cd39d932e3b3acc217cc64bde883beb55bf881d180d86793dafb6bba417L15-R15))


