### PR TITLE
fix(detailedmetar,rawmetar): update api

### DIFF
--- a/apps/detailedmetar/detailedmetar.star
+++ b/apps/detailedmetar/detailedmetar.star
@@ -22,7 +22,7 @@ def main(config):
     f_selector = config.bool("fahrenheit_temperatures", False)
 
     # API URL
-    apiURL = "https://beta.aviationweather.gov/cgi-bin/data/metar.php?ids=" + airport + "&format=json"
+    apiURL = "https://www.aviationweather.gov/cgi-bin/data/metar.php?ids=" + airport + "&format=json"
 
     # Store cahces by airport. That way if two users are pulling the same airport's METAR it is only fetched once.
     cacheName = "metar/" + airport

--- a/apps/rawmetar/raw_metar.star
+++ b/apps/rawmetar/raw_metar.star
@@ -22,7 +22,7 @@ def main(config):
             ),
         )
 
-    response = http.get("https://beta.aviationweather.gov/cgi-bin/data/metar.php?ids={}".format(station_id))
+    response = http.get("https://www.aviationweather.gov/cgi-bin/data/metar.php?ids={}".format(station_id))
     content = response.body()
 
     if not content:


### PR DESCRIPTION
# Description
This change is for both DetailedMETAR and Raw METAR apps 

beta.aviationweather.gov can't be connected as the certificate attached does not match the domain -- ~~have logged a ticket with them.~~ **UPDATE: got confirmation that beta's been decommissioned.** 

but for now, www.* does the same thing as beta.* from what I could tell... and generates out the expected response, so switching it to prod urls 

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 80296ff</samp>

### Summary
🚀🛠️🌤️

<!--
1.  🚀 This emoji can be used to indicate that the API URL was updated from beta to production, which is a sign of launching or deploying a feature or service to the public or to a wider audience.
2.  🛠️ This emoji can be used to indicate that the same change as F0L23R23 was applied to the raw_metar.star file, which is a sign of fixing or improving something, or working on a task or project.
3.  🌤️ This emoji can be used to indicate that the changes are related to the aviation weather data or the METAR format, which is a sign of the domain or topic of the apps.
-->
Updated the API URL for aviation weather data from beta to production in `detailedmetar.star` and `raw_metar.star`. This improves the accuracy and stability of the apps that display METAR information on the Tidbyt device.

> _`beta` to `prod`_
> _aviation weather API_
> _autumn winds are calm_

### Walkthrough
* Updated the API URL from beta to production to use the official and stable source of aviation weather data in both `detailedmetar.star` and `raw_metar.star` ([link](https://github.com/tidbyt/community/pull/1969/files?diff=unified&w=0#diff-1a845b3df75ba68543ee3a1655dbb32040827eff408bbdedc31f78cb48c684a6L25-R25), [link](https://github.com/tidbyt/community/pull/1969/files?diff=unified&w=0#diff-96eba09359a3508b8f5cac678f6a302c440c1369caedbb079c8804ed03cba6f7L25-R25))


