### PR TITLE
Update: Require API key and sensor ID for PurpleAir application

### DIFF
--- a/apps/purpleair/purpleair.star
+++ b/apps/purpleair/purpleair.star
@@ -11,15 +11,13 @@ Author: posburn
 load("encoding/base64.star", "base64")
 load("encoding/json.star", "json")
 load("http.star", "http")
-load("humanize.star", "humanize")
 load("math.star", "math")
 load("render.star", "render")
 load("schema.star", "schema")
-load("secret.star", "secret")
 
 # DEFAULTS
 
-DEFAULT_SENSOR_ID = "33997"  # Alcatraz Dock sensor
+DEFAULT_SENSOR_ID = None
 DEFAULT_LOCATION_BASED_SENSOR = '{"display": "SF Maritime NHP", "value": 70251}'
 TEMP_UNIT_F = "F"
 TEMP_UNIT_C = "C"
@@ -54,7 +52,7 @@ def main(config):
 
     # Fetch the air info
     data = None
-    if api_key != None:
+    if api_key != None and sensor_id != None:
         # [0] = data, [1] = was_cached
         data = fetch_sensor_data(api_key, PUBLIC_SENSOR + sensor_id + FETCH_SENSOR_FIELDS, {})
 
@@ -198,7 +196,7 @@ def get_sensor_id(config):
 def fetch_sensor_data(api_key, url, params):
     air_dict = {}
     headers = {"X-API-Key": api_key}
-    rep = http.get(url, params = params, headers = headers, ttl_seconds = 1800) # 30 min cache
+    rep = http.get(url, params = params, headers = headers, ttl_seconds = 1800)  # 30 min cache
     if rep.status_code != 200:
         print("Request failed with status %d" % rep.status_code)
         return None

--- a/apps/purpleair/purpleair.star
+++ b/apps/purpleair/purpleair.star
@@ -30,8 +30,10 @@ PARTICLE_SENSOR_B = "Sensor B"
 
 # MAIN APP
 
+api_key = None
+
 def main(config):
-    api_key = secret.decrypt(API_READ_KEY) or DEV_KEY
+    api_key = config.get("api_key")
     sensor_id = get_sensor_id(config)
     show_title = get_cfg_value(config, "show_title", True)
     show_temp = get_cfg_value(config, "show_temp", True)
@@ -53,7 +55,8 @@ def main(config):
     # Fetch the air info
     data = None
     if api_key != None:
-        data = fetch_sensor_data(api_key, PUBLIC_SENSOR + sensor_id, {})  # [0] = data, [1] = was_cached
+        # [0] = data, [1] = was_cached
+        data = fetch_sensor_data(api_key, PUBLIC_SENSOR + sensor_id + FETCH_SENSOR_FIELDS, {})
 
     if data == None:
         print("No data returned for sensor %s" % sensor_id)
@@ -113,16 +116,16 @@ def get_schema():
     return schema.Schema(
         version = "1",
         fields = [
-            schema.LocationBased(
-                id = "sensor_id",
-                name = "Sensors",
-                desc = "Choose the sensor based on your location.",
-                icon = "locationDot",
-                handler = get_sensors,
+            schema.Text(
+                id = "api_key",
+                name = "PurpleAir API Key",
+                desc = "Specify the API key to use",
+                icon = "gear",
+                default = "",
             ),
             schema.Text(
                 id = "sensor_id_direct",
-                name = "Sensor ID (optional)",
+                name = "Sensor ID",
                 desc = "Specify the sensor if you know the ID",
                 icon = "satelliteDish",
                 default = "",
@@ -174,88 +177,6 @@ def get_schema():
         ],
     )
 
-def get_sensors(location):
-    default_options = [schema.Option(display = "Alcatraz Dock", value = DEFAULT_SENSOR_ID)]
-    sensors = default_options
-
-    if location == None or location == "":
-        return sensors
-
-    api_key = secret.decrypt(API_READ_KEY) or DEV_KEY
-    if api_key == None:
-        return sensors
-
-    location_data = json.decode(location)
-    if location_data == None:
-        return sensors
-
-    # Get latitude and longitude of location to use in the api call
-    #desc = location_data.get("description", None)
-    latitude = float(location_data.get("lat", 0))
-    longitude = float(location_data.get("lng", 0))
-
-    # Truncate to protect the user's privacy
-    latitude = float(humanize.float("#.##", latitude))
-    longitude = float(humanize.float("#.##", longitude))
-
-    # Get the sensor list constrained to a small area around this location
-    delta = 0.035
-    params = {
-        "nwlng": str(longitude - delta),
-        "nwlat": str(latitude + delta),
-        "selng": str(longitude + delta),
-        "selat": str(latitude - delta),
-    }
-
-    sensor_list = fetch_sensor_list(api_key, LIST_SENSORS, params)
-
-    if sensor_list == None:
-        print("No data returned for sensor list")
-        return sensors
-
-    elif len(sensor_list) != 2 or sensor_list[0] == None:
-        print("sensor_list in incorrect format or missing")
-
-    else:
-        sensor_data = sensor_list[0].get("data", [])
-        count = len(sensor_data)
-        if count > 0:
-            sensors = []
-
-        for i in range(len(sensor_data)):
-            item = sensor_data[i]
-            if len(item) != 5:
-                continue
-
-            # Calculate miles/km
-            distance = distance_between(latitude, longitude, item[3], item[4])
-            distance = int(distance * 100) / 100
-            name = "(%f) %s" % (distance, item[1])
-
-            name = name.replace("0000", "")
-            value = str(item[0]).replace(".0", "")
-            sensors.append(schema.Option(display = name, value = value))
-
-        def sort_by_name(option):
-            return option.display
-    return sorted(sensors, key = sort_by_name)
-
-# Use the haversine formula to calculate the distance between two points in miles
-# https://www.movable-type.co.uk/scripts/latlong.html
-def distance_between(lat1, lng1, lat2, lng2):
-    r = 6371e3
-    la1 = lat1 * math.pi / 180
-    la2 = lat2 * math.pi / 180
-    delta_lat = (lat2 - lat1) * math.pi / 180
-    delta_lng = (lng2 - lng1) * math.pi / 180
-
-    a = math.pow(math.sin(delta_lat / 2), 2) + math.cos(la1) * math.cos(la2) * math.pow(math.sin(delta_lng / 2), 2)
-    c = 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
-    d = r * c  # d is in meters
-    km = d / 1000
-    miles = km / 0.621371
-    return miles
-
 # Return the sensor id to use based on configuration options
 def get_sensor_id(config):
     sensor = DEFAULT_SENSOR_ID
@@ -266,23 +187,19 @@ def get_sensor_id(config):
         sensor = str(json.decode(id_option))
         print("Sensor direct: %s" % id_option)
 
-    # If sensor not specified directly, use location to get sensor
-    if id_option == None or id_option == "":
-        local_selection = config.get("sensor_id", DEFAULT_LOCATION_BASED_SENSOR)
-        local_selection = json.decode(local_selection)
-        if "value" in local_selection:
-            sensor = str(local_selection["value"])
-
     print("Using sensor: %s" % sensor)
     return sensor
 
 # DATA
 
 # Returns a tuple: (data, was_cached)
+# Sample call:
+# https://api.purpleair.com/v1/sensors/84707?fields=name,temperature,humidity,pm2.5_cf_1_a,pm2.5_cf_1_b,confidence,confidence_auto,location_type
 def fetch_sensor_data(api_key, url, params):
     air_dict = {}
     headers = {"X-API-Key": api_key}
-    rep = http.get(url, params = params, headers = headers, ttl_seconds = 600)
+    print()
+    rep = http.get(url, params = params, headers = headers, ttl_seconds = 1800) # 30 min cache
     if rep.status_code != 200:
         print("Request failed with status %d" % rep.status_code)
         return None
@@ -317,18 +234,6 @@ def fetch_sensor_data(api_key, url, params):
             }
 
         return (air_dict, False)
-
-# Returns a tuple: (data, was_cached)
-def fetch_sensor_list(api_key, url, params):
-    # Check cache first
-
-    headers = {"X-API-Key": api_key}
-    rep = http.get(url, params = params, headers = headers, ttl_seconds = 14400)
-    if rep.status_code != 200:
-        print("Request failed with status %d" % rep.status_code)
-        return None
-    else:
-        return (rep.json(), False)
 
 # AQI & CALCULATIONS
 
@@ -429,7 +334,7 @@ def aqi_description(aqi, show_title = True):
 
     index = aqi_index(aqi)
     if index == AQI_ERROR:
-        return "Select a PurpleAir sensor"
+        return "Specify a sensor and API key"
     return AQI_TITLE[index]
 
 def aqi_color(aqi):
@@ -537,13 +442,13 @@ def render_simple_view(aqi, alternate_text = "", text_color = "#FFFFFFFF", offse
                         render.Box(child = render_aqi_text(aqi)),
                 ),
                 render.Padding(
-                    pad = (24, -1, 0, 0),
+                    pad = (24, -2, 0, 0),
                     child =
                         render.Stack(
                             children = [
                                 render.Box(
                                     width = 38,
-                                    height = 25,
+                                    height = 28,
                                     child =
                                         render.WrappedText(
                                             content = aqi_description(aqi, show_title),
@@ -556,7 +461,7 @@ def render_simple_view(aqi, alternate_text = "", text_color = "#FFFFFFFF", offse
                                     child =
                                         render.Box(
                                             width = 38,
-                                            height = 25,
+                                            height = 28,
                                             child =
                                                 render.WrappedText(
                                                     content = alternate_text,
@@ -652,12 +557,8 @@ def render_animation(aqi, temp, humidity, name, show_title = True, show_temp = T
 
 # CONSTANTS
 
-API_READ_KEY = "AV6+xWcE7hO0GOSye3S6fLtTsKex797gyaIfLQKc3t1oXawbQBTEVHciWK3ITe3um3dBzxDNau5bI3iNhYicAm3FFRWAj0hVL/nKmGrvphhvjzxbjynWIy2+g6IkGZw43GMf2wjIEnHcmuGVMicd779uABXs56OhMof9LFfiq7iuJ9e2PhN+h8x2"
-
-# unencrypted DEV key - set this to None before you PR
-DEV_KEY = None
 PUBLIC_SENSOR = "https://api.purpleair.com/v1/sensors/"
-LIST_SENSORS = "https://api.purpleair.com/v1/sensors?fields=name,location_type,latitude,longitude"
+FETCH_SENSOR_FIELDS = "?fields=name,temperature,humidity,pm2.5_cf_1_a,pm2.5_cf_1_b,confidence,confidence_auto,location_type"
 CACHE_KEY_DATA = "purpleAirData"
 BACKGROUND_COLOR = "#21024D"
 

--- a/apps/purpleair/purpleair.star
+++ b/apps/purpleair/purpleair.star
@@ -194,11 +194,10 @@ def get_sensor_id(config):
 
 # Returns a tuple: (data, was_cached)
 # Sample call:
-# https://api.purpleair.com/v1/sensors/84707?fields=name,temperature,humidity,pm2.5_cf_1_a,pm2.5_cf_1_b,confidence,confidence_auto,location_type
+# https://api.purpleair.com/v1/sensors/12345?fields=name,temperature,humidity,pm2.5_cf_1_a,pm2.5_cf_1_b,confidence,confidence_auto,location_type
 def fetch_sensor_data(api_key, url, params):
     air_dict = {}
     headers = {"X-API-Key": api_key}
-    print()
     rep = http.get(url, params = params, headers = headers, ttl_seconds = 1800) # 30 min cache
     if rep.status_code != 200:
         print("Request failed with status %d" % rep.status_code)

--- a/apps/purpleair/readme.md
+++ b/apps/purpleair/readme.md
@@ -1,6 +1,6 @@
 # PurpleAir for Tidbyt
 
-PurpleAir displays an estimate of the air quality index (AQI) using the specified [PurpleAir](https://www.purpleair.com) sensor. The US EPA method is used to calculate the index. It is updated every 60 minutes. The estimate should be very close or exactly match the index shown for the sensor on the [PurpleAir map](https://map.purpleair.com/1/mAQI/a0/p604800/cC5?select=33997#15.38/37.828489/-122.42342). Obtain a sensor ID for a sensor near you using the PurpleAir map.
+PurpleAir displays an estimate of the air quality index (AQI) using the specified [PurpleAir](https://www.purpleair.com) sensor. The US EPA method is used to calculate the index. It is updated every 30 minutes. The estimate should be very close or exactly match the index shown for the sensor on the [PurpleAir map](https://map.purpleair.com/1/mAQI/a0/p604800/cC5?select=33997#15.38/37.828489/-122.42342). Obtain a sensor ID for a sensor near you using the PurpleAir map.
 
 An API key is required to fetch sensor data from the PurpleAir API. Please get your API key from the [PurpleAir develop site](https://develop.purpleair.com/sign-in?redirectURL=%2Fkeys).
 

--- a/apps/purpleair/readme.md
+++ b/apps/purpleair/readme.md
@@ -1,8 +1,8 @@
 # PurpleAir for Tidbyt
 
-PurpleAir displays an estimate of the air quality index (AQI) using the specified [PurpleAir](https://www.purpleair.com) sensor. The US EPA method is used to calculate the index. It is updated every 10 minutes. The estimate should be very close or exactly match the index shown for the sensor on the [PurpleAir map](https://map.purpleair.com/1/mAQI/a0/p604800/cC5?select=33997#15.38/37.828489/-122.42342).
+PurpleAir displays an estimate of the air quality index (AQI) using the specified [PurpleAir](https://www.purpleair.com) sensor. The US EPA method is used to calculate the index. It is updated every 60 minutes. The estimate should be very close or exactly match the index shown for the sensor on the [PurpleAir map](https://map.purpleair.com/1/mAQI/a0/p604800/cC5?select=33997#15.38/37.828489/-122.42342).
 
-An API key is required to fetch sensor data and the list of sensors from the PurpleAir API. The encrypted key is included in the application as a secret.
+An API key is required to fetch sensor data and the list of sensors from the PurpleAir API. Please get your API key from the [PurpleAir develop site](https://develop.purpleair.com/sign-in?redirectURL=%2Fkeys).
 
 Note that only the US EPA calculation method is supported right now but I hope to support other methods in the future.
 

--- a/apps/purpleair/readme.md
+++ b/apps/purpleair/readme.md
@@ -1,9 +1,7 @@
 # PurpleAir for Tidbyt
 
-PurpleAir displays an estimate of the air quality index (AQI) using the specified [PurpleAir](https://www.purpleair.com) sensor. The US EPA method is used to calculate the index. It is updated every 60 minutes. The estimate should be very close or exactly match the index shown for the sensor on the [PurpleAir map](https://map.purpleair.com/1/mAQI/a0/p604800/cC5?select=33997#15.38/37.828489/-122.42342).
+PurpleAir displays an estimate of the air quality index (AQI) using the specified [PurpleAir](https://www.purpleair.com) sensor. The US EPA method is used to calculate the index. It is updated every 60 minutes. The estimate should be very close or exactly match the index shown for the sensor on the [PurpleAir map](https://map.purpleair.com/1/mAQI/a0/p604800/cC5?select=33997#15.38/37.828489/-122.42342). Obtain a sensor ID for a sensor near you using the PurpleAir map.
 
-An API key is required to fetch sensor data and the list of sensors from the PurpleAir API. Please get your API key from the [PurpleAir develop site](https://develop.purpleair.com/sign-in?redirectURL=%2Fkeys).
-
-Note that only the US EPA calculation method is supported right now but I hope to support other methods in the future.
+An API key is required to fetch sensor data from the PurpleAir API. Please get your API key from the [PurpleAir develop site](https://develop.purpleair.com/sign-in?redirectURL=%2Fkeys).
 
 ![PurpleAir for Tidbyt](screenshot.png)


### PR DESCRIPTION
# Description
Updates the PurpleAir application by requiring the user to provide both an API key and a sensor Id. PurpleAir will start charging me for API use beginning November 13th, 2023. The application will no longer use my API key for each instance.

Since PurpleAir now uses a point system to charge for each API call and points per field returned, I made the following changes to reduce the cost to users of the PurpleAir app:
* Removed choosing sensor by location
* Removed default sensor ID
* Increased cache timeout to 30 minutes
* Specify the exact fields needed in the api.purpleair.com/v1/sensors response

I also updated the readme with links on where to get an API key and the id of a sensor.

NOTE: I'm asking PurpleAir to turn off access using my API key when this update goes live or November 13th, whichever comes first.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2bffcc4</samp>

### Summary
📝🔑🎨

<!--
1.  📝 - This emoji can be used to indicate that the readme file was updated with new information and instructions.
2.  🔑 - This emoji can be used to indicate that the app now requires the user to provide their own API key and sensor ID in the app settings, and that the secret key was removed.
3.  🎨 - This emoji can be used to indicate that the app was refactored and the UI was improved with better layout and design.
-->
The `purpleair` app was updated to allow users to choose their own sensor and provide their own API key. The code and the UI were cleaned up and the readme file was revised accordingly.

> _`Readme` guides users_
> _`API key` and `sensor ID` needed_
> _Winter air quality_

### Walkthrough
*  Remove location-based sensor list and require user to specify sensor ID and API key ([link](https://github.com/tidbyt/community/pull/1984/files?diff=unified&w=0#diff-d0bf8e870e7e3f045a0eb2378287e162705fc649e8653052e62b0136b219647cL14-R20), [link](https://github.com/tidbyt/community/pull/1984/files?diff=unified&w=0#diff-d0bf8e870e7e3f045a0eb2378287e162705fc649e8653052e62b0136b219647cL33-R34), [link](https://github.com/tidbyt/community/pull/1984/files?diff=unified&w=0#diff-d0bf8e870e7e3f045a0eb2378287e162705fc649e8653052e62b0136b219647cL55-R57), [link](https://github.com/tidbyt/community/pull/1984/files?diff=unified&w=0#diff-d0bf8e870e7e3f045a0eb2378287e162705fc649e8653052e62b0136b219647cL116-R126), [link](https://github.com/tidbyt/community/pull/1984/files?diff=unified&w=0#diff-d0bf8e870e7e3f045a0eb2378287e162705fc649e8653052e62b0136b219647cL177-L258), [link](https://github.com/tidbyt/community/pull/1984/files?diff=unified&w=0#diff-d0bf8e870e7e3f045a0eb2378287e162705fc649e8653052e62b0136b219647cL269-L275), [link](https://github.com/tidbyt/community/pull/1984/files?diff=unified&w=0#diff-d0bf8e870e7e3f045a0eb2378287e162705fc649e8653052e62b0136b219647cL282-R199), [link](https://github.com/tidbyt/community/pull/1984/files?diff=unified&w=0#diff-d0bf8e870e7e3f045a0eb2378287e162705fc649e8653052e62b0136b219647cL321-L332), [link](https://github.com/tidbyt/community/pull/1984/files?diff=unified&w=0#diff-d0bf8e870e7e3f045a0eb2378287e162705fc649e8653052e62b0136b219647cL432-R334), [link](https://github.com/tidbyt/community/pull/1984/files?diff=unified&w=0#diff-d0bf8e870e7e3f045a0eb2378287e162705fc649e8653052e62b0136b219647cL655-R558), [link](https://github.com/tidbyt/community/pull/1984/files?diff=unified&w=0#diff-ce72daa4c4a02a4186c25e1e63dbdcf2a92f06ef8e3247930b2af62fd0b1f7faL3-R5))
*  Increase cache time for sensor data API call to 30 minutes to avoid rate limit ([link](https://github.com/tidbyt/community/pull/1984/files?diff=unified&w=0#diff-d0bf8e870e7e3f045a0eb2378287e162705fc649e8653052e62b0136b219647cL55-R57), [link](https://github.com/tidbyt/community/pull/1984/files?diff=unified&w=0#diff-d0bf8e870e7e3f045a0eb2378287e162705fc649e8653052e62b0136b219647cL282-R199))
*  Adjust padding and height of render widgets to improve text alignment and visibility ([link](https://github.com/tidbyt/community/pull/1984/files?diff=unified&w=0#diff-d0bf8e870e7e3f045a0eb2378287e162705fc649e8653052e62b0136b219647cL540-R442), [link](https://github.com/tidbyt/community/pull/1984/files?diff=unified&w=0#diff-d0bf8e870e7e3f045a0eb2378287e162705fc649e8653052e62b0136b219647cL546-R448), [link](https://github.com/tidbyt/community/pull/1984/files?diff=unified&w=0#diff-d0bf8e870e7e3f045a0eb2378287e162705fc649e8653052e62b0136b219647cL559-R461))
*  Add comment with sample API call and fields to fetch in `fetch_sensor_data` function ([link](https://github.com/tidbyt/community/pull/1984/files?diff=unified&w=0#diff-d0bf8e870e7e3f045a0eb2378287e162705fc649e8653052e62b0136b219647cL282-R199))


