### PR TITLE
Add Tesla Powerwall meter app

### DIFF
--- a/apps/powerwall/manifest.yaml
+++ b/apps/powerwall/manifest.yaml
@@ -1,0 +1,8 @@
+---
+id: powerwall
+name: Powerwall
+summary: Show Tesla Powerwall state
+desc: Show Tesla Powerwall battery percentage state.
+author: tabrindle
+fileName: powerwall.star
+packageName: powerwall

--- a/apps/powerwall/powerwall.star
+++ b/apps/powerwall/powerwall.star
@@ -1,0 +1,162 @@
+"""
+Applet: Powerwall
+Summary: Tesla Powerwall Monitor
+Description: Show Tesla Powerwall state.
+Author: tabrindle (based off jweier & marcusb's work on Tesla Solar)
+"""
+
+load("cache.star", "cache")
+load("encoding/json.star", "json")
+load("http.star", "http")
+load("humanize.star", "humanize")
+load("render.star", "render")
+load("schema.star", "schema")
+
+TESLA_AUTH_URL = "https://auth.tesla.com/oauth2/v3/token"
+URL = "https://owner-api.teslamotors.com/api/1/energy_sites/{}/live_status?language=en"
+
+IMG = ""
+
+CACHE_TTL = 25200
+
+DUMMY_DATA = {
+    "response": {
+        "solar_power": 0,
+        "energy_left": 28288.9652631579,
+        "total_pack_energy": 40502,
+        "percentage_charged": 69.84584776840128,
+        "backup_capable": True,
+        "battery_power": 690,
+        "load_power": 690,
+        "grid_status": "Active",
+        "grid_services_active": False,
+        "grid_power": 0,
+        "grid_services_power": 0,
+        "generator_power": 0,
+        "island_status": "on_grid",
+        "storm_mode_active": False,
+        "timestamp": "2023-11-02T23:36:20-04:00",
+        "wall_connectors": [],
+    },
+}
+
+def get_access_token(refresh_token, site_id):
+    #Try to load access token from cache
+    access_token_cached = cache.get(site_id)
+
+    if access_token_cached != None:
+        print("Hit! Using cached access token " + access_token_cached)
+        return {"status_code": "Cached", "access_token": str(access_token_cached)}
+    else:
+        print("Miss! Getting new access token from Tesla API.")
+
+        auth_rep = http.post(TESLA_AUTH_URL, json_body = {
+            "grant_type": "refresh_token",
+            "client_id": "ownerapi",
+            "refresh_token": refresh_token,
+            "scope": "openid email offline_access",
+        })
+
+        #Check the HTTP response code
+        if auth_rep.status_code != 200:
+            return {"status_code": str(auth_rep.status_code), "access_token": "None"}
+        else:
+            access_token = auth_rep.json()["access_token"]
+
+            # TODO: Determine if this cache call can be converted to the new HTTP cache.
+            cache.set(site_id, access_token, ttl_seconds = CACHE_TTL)
+            return {"status_code": str(auth_rep.status_code), "access_token": str(access_token)}
+
+def main(config):
+    print("-------Starting new update-------")
+
+    site_id = humanize.url_encode(config.str("site_id", ""))
+    refresh_token = config.str("refresh_token")
+    error_in_http_calls = False
+    error_details = {}
+    o = ""
+
+    if refresh_token and site_id:
+        url = URL.format(site_id)
+        print("Refresh Token: " + refresh_token)
+        print("Site ID: " + site_id)
+        print("Tesla Auth URL: " + TESLA_AUTH_URL)
+        print("Tesla Data URL: " + url)
+
+        access_token = get_access_token(refresh_token, site_id)
+
+        if access_token["access_token"] == "None":
+            error_details = {"error_section": "refresh_token", "error": "HTTP error " + str(access_token["status_code"])}
+            error_in_http_calls = True
+        else:
+            rep = http.get(url, headers = {"Authorization": "Bearer " + access_token["access_token"]})
+            if rep.status_code != 200:
+                response_error = rep.json()
+                error_details = {"error_section": "site_id", "error": "Error " + response_error["error"]}
+                error_in_http_calls = True
+            data = rep.body()
+            o = json.decode(data)
+    else:
+        print("Using Dummy Data")
+        o = DUMMY_DATA
+
+    if error_in_http_calls == False:
+        charge = int(o["response"]["percentage_charged"])
+
+        return render.Root(
+            child = render.Box(
+                height = 32,
+                width = 64,
+                color = "#000000",
+                child = render.Stack(
+                    children = [
+                        render.Box(
+                            child = render.PieChart(
+                                colors = ["004400", "0f0"],
+                                weights = [100 - charge, charge],
+                                diameter = 30,
+                            ),
+                        ),
+                        render.Box(
+                            child = render.Circle(
+                                color = "#000",
+                                diameter = 22,
+                            ),
+                        ),
+                        render.Box(
+                            child = render.Text(
+                                content = str(charge)[0:3] + "%",
+                                color = "#ffffff",
+                            ),
+                        ),
+                    ],
+                ),
+            ),
+        )
+    else:
+        error_message = "Check " + error_details["error_section"] + ". " + error_details["error"]
+        return render.Root(
+            child = render.Marquee(
+                width = 64,
+                child = render.Text(error_message),
+            ),
+        )
+
+def get_schema():
+    return schema.Schema(
+        version = "1",
+        fields = [
+            schema.Text(
+                id = "refresh_token",
+                name = "Refresh Token",
+                desc = "Refresh Token for the Tesla Owner API.",
+                icon = "key",
+            ),
+            schema.Text(
+                id = "site_id",
+                name = "Site ID",
+                desc = "The site ID that should be monitored.",
+                icon = "solarPanel",
+            ),
+        ],
+    )


### PR DESCRIPTION
# Description
Replace this with a description of your changes.
- Add a Tesla Powerwall battery meter app, based on the Tesla Solar app

![powerwall](https://github.com/tidbyt/community/assets/2925048/50fbd597-4231-4895-a4b0-1359dd5f7a71)

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a6bb8ac</samp>

### Summary
🌞🛫📝

<!--
1.  🌞 for the powerwall applet, which relates to solar energy and battery power.
2.  🛫 for the raw-metar applet, which relates to aviation and weather reports.
3.  📝 for the manifest files, which relate to metadata and documentation.
-->
This pull request adds two new applets to the tidbyt community repository: `powerwall` and `raw-metar`. The `powerwall` applet shows the status of a Tesla Powerwall battery on the tidbyt screen, using the Tesla Owner API. The `raw-metar` applet shows the METAR text weather report for a given airport station on the tidbyt screen, using the Aviation Weather Center API. Each applet has a manifest file and a Starlark file that contain the applet metadata and code.

> _Two applets added_
> _`powerwall` and `raw-metar`_
> _Show battery and sky_

### Walkthrough
*  Add two new applets for powerwall and raw-metar ([link](https://github.com/tidbyt/community/pull/1985/files?diff=unified&w=0#diff-1404fe3501365a7c039b30939a3a7e92a7d4cd9cfbccf4063285dc7913d761e6R1-R8), [link](https://github.com/tidbyt/community/pull/1985/files?diff=unified&w=0#diff-198ad9de83e071f155218549f2741bd734eaa825934299ae5f145c6dcec16726R1-R162), [link](https://github.com/tidbyt/community/pull/1985/files?diff=unified&w=0#diff-df3664efe6aaf2d2debf24d5f751e096522f7d9defa81b5e6ddefa3707c0352aR1-R8), [link](https://github.com/tidbyt/community/pull/1985/files?diff=unified&w=0#diff-96eba09359a3508b8f5cac678f6a302c440c1369caedbb079c8804ed03cba6f7R1-R77))
  * `powerwall.star` fetches and displays Tesla Powerwall battery status using Tesla Owner API ([link](https://github.com/tidbyt/community/pull/1985/files?diff=unified&w=0#diff-198ad9de83e071f155218549f2741bd734eaa825934299ae5f145c6dcec16726R1-R162))
  * `raw_metar.star` fetches and displays METAR text weather report using Aviation Weather Center API ([link](https://github.com/tidbyt/community/pull/1985/files?diff=unified&w=0#diff-96eba09359a3508b8f5cac678f6a302c440c1369caedbb079c8804ed03cba6f7R1-R77))
  * Both applets have corresponding `manifest.yaml` files with applet metadata ([link](https://github.com/tidbyt/community/pull/1985/files?diff=unified&w=0#diff-1404fe3501365a7c039b30939a3a7e92a7d4cd9cfbccf4063285dc7913d761e6R1-R8), [link](https://github.com/tidbyt/community/pull/1985/files?diff=unified&w=0#diff-df3664efe6aaf2d2debf24d5f751e096522f7d9defa81b5e6ddefa3707c0352aR1-R8))


