### PR TITLE
Update: ATP Tennis

### DIFF
--- a/apps/atptennis/atp_tennis.star
+++ b/apps/atptennis/atp_tennis.star
@@ -54,6 +54,10 @@ v1.9
 Added new feature to show who won each set (for completed & in progress matches) rather than having all of the match winner's sets in yellow. Makes it easier to see the flow of the match, especially in a 5 set match
 Updated scheduled matches to only show if both players are listed, prevents blanks
 Updated checks for walkover matches 
+
+v1.10 - idea
+Changed logic for completed matches
+Updated display for 'walkover' matches 
 """
 
 load("encoding/json.star", "json")
@@ -116,7 +120,6 @@ def main(config):
                     # And the "In Progress" match started < 24 hrs ago , sometimes the data feed will still show matches as "In Progress" after they have completed
                     # Adding a 24hr limit will remove them out of the list
                     if ATP_JSON["events"][x]["groupings"][0]["competitions"][y]["status"]["type"]["description"] == "In Progress":
-                        #print(y)
                         MatchTime = ATP_JSON["events"][EventIndex]["groupings"][0]["competitions"][y]["date"]
                         MatchTime = time.parse_time(MatchTime, format = "2006-01-02T15:04Z")
                         diffMatch = MatchTime - now
@@ -191,10 +194,8 @@ def main(config):
                 # check if we are between the start & end date of the tournament
                 if diffTournStart.hours < 0 and diffTournEnd.hours > 0:
                     for y in range(0, len(ATP_JSON["events"][x]["groupings"][0]["competitions"]), 1):
-                        MatchState = ATP_JSON["events"][x]["groupings"][0]["competitions"][y]["status"]["type"]["description"]
-
                         # if the match is completed and the start time of the match was < 24 hrs ago, lets add it to the list of completed matches
-                        if MatchState == "Final" or MatchState == "Retired":
+                        if ATP_JSON["events"][x]["groupings"][0]["competitions"][y]["status"]["type"]["completed"]:
                             MatchTime = ATP_JSON["events"][EventIndex]["groupings"][0]["competitions"][y]["date"]
                             MatchTime = time.parse_time(MatchTime, format = "2006-01-02T15:04Z")
                             diff = MatchTime - now
@@ -569,7 +570,7 @@ def getCompletedMatches(SelectedTourneyID, EventIndex, CompletedMatchList, JSON)
                 Player2Color = "#ff0"
 
             # if its not a walkover
-            if JSON["events"][EventIndex]["groupings"][0]["competitions"][x]["status"]["type"]["description"] != "Walkover":
+            if JSON["events"][EventIndex]["groupings"][0]["competitions"][x]["status"]["type"]["name"] != "STATUS_WALKOVER":
                 Number_Sets = len(JSON["events"][EventIndex]["groupings"][0]["competitions"][x]["competitors"][0]["linescores"])
 
                 for z in range(0, Number_Sets, 1):
@@ -629,7 +630,7 @@ def getCompletedMatches(SelectedTourneyID, EventIndex, CompletedMatchList, JSON)
                             width = 4,
                             height = 5,
                             child = render.Text(
-                                content = "WO",
+                                content = "W",
                                 color = "#ff0",
                                 font = displayfont,
                             ),
@@ -653,7 +654,7 @@ def getCompletedMatches(SelectedTourneyID, EventIndex, CompletedMatchList, JSON)
                             width = 4,
                             height = 5,
                             child = render.Text(
-                                content = "WO",
+                                content = "W",
                                 color = "#ff0",
                                 font = displayfont,
                             ),


### PR DESCRIPTION

# Description

- Changed logic to determine completed matches
- Updated display for 'walkover' matches

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 37eac1b</samp>

### Summary
🎾🆙🚶‍♂️

<!--
1.  🎾 - This emoji represents the tennis theme of the applet and the improved display of the matches.
2.  🆙 - This emoji represents the version update from 1.09 to 1.10 and the improved logic of the applet.
3.  🚶‍♂️ - This emoji represents the walkover matches, which are matches that are awarded to a player when their opponent withdraws or is disqualified.
-->
Updated `atp_tennis` applet to handle completed and walkover matches better. Used more reliable fields from the API response to determine match status and display. Bumped applet version to 1.10.

> _The applet `atp_tennis` got a new version_
> _With better logic and display for each session_
> _It used `completed` and `name`_
> _To check the match's game_
> _And avoided the vague `description` field's confusion_

### Walkthrough
*  Simplify the logic for determining match completion and walkover status by using boolean and name fields instead of description field ([link](https://github.com/tidbyt/community/pull/1987/files?diff=unified&w=0#diff-2fe7726a8148e3fb23a64991e8b2661bd9c098395de1a2f1ea0092f21db623bcL194-R198), [link](https://github.com/tidbyt/community/pull/1987/files?diff=unified&w=0#diff-2fe7726a8148e3fb23a64991e8b2661bd9c098395de1a2f1ea0092f21db623bcL572-R573), [link](https://github.com/tidbyt/community/pull/1987/files?diff=unified&w=0#diff-2fe7726a8148e3fb23a64991e8b2661bd9c098395de1a2f1ea0092f21db623bcL632-R633), [link](https://github.com/tidbyt/community/pull/1987/files?diff=unified&w=0#diff-2fe7726a8148e3fb23a64991e8b2661bd9c098395de1a2f1ea0092f21db623bcL656-R657))
* Update the applet's documentation with a new version number and a summary of the changes ([link](https://github.com/tidbyt/community/pull/1987/files?diff=unified&w=0#diff-2fe7726a8148e3fb23a64991e8b2661bd9c098395de1a2f1ea0092f21db623bcL1-R62))
* Remove a redundant print statement ([link](https://github.com/tidbyt/community/pull/1987/files?diff=unified&w=0#diff-2fe7726a8148e3fb23a64991e8b2661bd9c098395de1a2f1ea0092f21db623bcL119))


