### PR TITLE
update:  NASCAR - change data source

### DIFF
--- a/apps/nascarnextrace/nascarnextrace.star
+++ b/apps/nascarnextrace/nascarnextrace.star
@@ -10,6 +10,7 @@ Author: jvivona
 #                    - change text color to be schema.Color instead of drop down
 # 20230911 - jvivona - update code and API to better handle end of season with not upcoming race
 # 20230918 - jvivona - fixed marquee spacing for playoff drivers / points as we go through rounds and # of drivers drops below 9
+# 20231106 - jvivona - move data sources to gihub to take backpressure off datacenter
 
 load("animation.star", "animation")
 load("encoding/json.star", "json")
@@ -19,7 +20,7 @@ load("render.star", "render")
 load("schema.star", "schema")
 load("time.star", "time")
 
-VERSION = 23261
+VERSION = 23310
 
 # cache data for 15 minutes - cycle through with cache on the API side
 CACHE_TTL_SECONDS = 900
@@ -27,7 +28,7 @@ CACHE_TTL_SECONDS = 900
 DEFAULT_TIMEZONE = "America/New_York"
 
 #we grab the current schedule from nascar website and cache it at this api location to prevent getting blocked by nascar website, data is refreshed every 30 minutes
-NASCAR_API = "https://tidbyt.apis.ajcomputers.com/nascar/api/"
+NASCAR_API = "https://raw.githubusercontent.com/jvivona/tidbyt-data/main/nascar"
 DEFAULT_SERIES = "cup"
 DEFAULT_TIME_24 = False
 DEFAULT_DATE_US = True
@@ -66,19 +67,15 @@ DISPLAY_VALUES = {
 
 def main(config):
     series = config.get("NASCAR_Series", DEFAULT_SERIES)
-
-    NASCAR_DATA = json.decode(get_cachable_data(NASCAR_API + series))
-
     data_display = config.get("data_display", "nri")
+    NASCAR_DATA = json.decode(get_cachable_data("%s/%s/%s.json" % (NASCAR_API, series, data_display)))
 
     if data_display == "nri":
-        NASCAR_DATA = json.decode(get_cachable_data(NASCAR_API + series))
         if NASCAR_DATA.get("Race_Date", "") == "":
             return []
         else:
             text = nextrace(NASCAR_DATA, config)
     else:
-        NASCAR_DATA = json.decode(get_cachable_data(NASCAR_API + series + data_display))
         text = standings(NASCAR_DATA, config, data_display)
 
     return render.Root(

--- a/apps/nascarnextrace/nascarnextrace.star
+++ b/apps/nascarnextrace/nascarnextrace.star
@@ -67,7 +67,7 @@ DISPLAY_VALUES = {
 
 def main(config):
     series = config.get("NASCAR_Series", DEFAULT_SERIES)
-    data_display = config.get("data_display", "nri")
+    data_display = config.get("data_display", "drv")
     NASCAR_DATA = json.decode(get_cachable_data("%s/%s/%s.json" % (NASCAR_API, series, data_display)))
 
     if data_display == "nri":


### PR DESCRIPTION
# Description
change datasource for NASCAR API to github to remove backpressure from datacenter.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c2f9fdf</samp>

### Summary
🚗🔄🔢

<!--
1.  🚗 - This emoji represents the nascarnextrace app and the sport of NASCAR racing in general.
2.  🔄 - This emoji represents the change of data sources from the API server to GitHub, and the refactoring of the data fetching logic to use the new sources.
3.  🔢 - This emoji represents the increment of the app version number to reflect the changes.
-->
This pull request improves the `nascarnextrace` app by using GitHub as a data source instead of the API server, and simplifying the data fetching code. It also updates the app version number in `nascarnextrace.star`.

> _Sing, O Muse, of the swift and skillful coder_
> _Who changed the source of data for the app `nascarnextrace`_
> _From the API server, where many troubles lurked,_
> _To GitHub, where the data safely rests and works._

### Walkthrough
*  Moved data sources to GitHub to reduce load on datacenter and avoid API server issues ([link](https://github.com/tidbyt/community/pull/1998/files?diff=unified&w=0#diff-b1c40f21af46b32ce867ca5487d2de7ca7fb741c7fe133f2fe2a2ddf06ea4ff2R13), [link](https://github.com/tidbyt/community/pull/1998/files?diff=unified&w=0#diff-b1c40f21af46b32ce867ca5487d2de7ca7fb741c7fe133f2fe2a2ddf06ea4ff2L30-R31))
* Updated app version number to reflect changes ([link](https://github.com/tidbyt/community/pull/1998/files?diff=unified&w=0#diff-b1c40f21af46b32ce867ca5487d2de7ca7fb741c7fe133f2fe2a2ddf06ea4ff2L22-R23))
* Simplified main function by fetching data only once using series and data_display parameters ([link](https://github.com/tidbyt/community/pull/1998/files?diff=unified&w=0#diff-b1c40f21af46b32ce867ca5487d2de7ca7fb741c7fe133f2fe2a2ddf06ea4ff2L69-R73), [link](https://github.com/tidbyt/community/pull/1998/files?diff=unified&w=0#diff-b1c40f21af46b32ce867ca5487d2de7ca7fb741c7fe133f2fe2a2ddf06ea4ff2L81))


