### PR TITLE
marveloftheday: update secret to use appID as context

### DIFF
--- a/apps/marveloftheday/marvel_of_the_day.star
+++ b/apps/marveloftheday/marvel_of_the_day.star
@@ -13,8 +13,8 @@ load("secret.star", "secret")
 load("time.star", "time")
 
 BASE_URL = "https://gateway.marvel.com/v1/public/characters"
-PUBLIC_KEY = secret.decrypt("AV6+xWcEy092dgpbVtrQ6viXx2aP7gUnMvuSV2fPo8z7rcpCsZSB7iKhbuhn1Y9uf4X944Jxz5IaunEkS5HWH0nADmdQVa1EMOu8boaEFwxIXin9b9f4fu80Yh/hhgdZSmIZG446mxhINuZWXXEkjw9YXjyzrL5jTj23CTEMcYAGRMXovks=")
-PRIVATE_KEY = secret.decrypt("AV6+xWcExLAtVmhSs9vr0xHtg8hRIWQcXAKa1qG3l2W/Frgr+EcICQuMg9CbUwqEbVrY/OhIhFsGczEJkGjhEMsn+MFFqSTm68ZZvNXIbr3MFhOSPnKPCFybCmXU5T97NNLGDAARgtB+/7VgF0w7Ki8eiX5sbW7yisbLpFrEe/2mKxh9OcDmZ6tQAwhhYg==")
+PUBLIC_KEY = secret.decrypt("AV6+xWcE+glik4Q/UJ64HVitCtX/Iw4GMs4PXCybCA8EyTUt1POPVYqKOU3RGgOe2mjHa8PjfUuOBJRUjmViYUg+siN6ApfbF9qbr4N4JjcIblHXyLK5Pud1Ur5dgWkKpUZU1OdzTWz4pUnS7WKWnKXqASO81oGyzth03l+vQ3Wk1oVxZIA=")
+PRIVATE_KEY = secret.decrypt("AV6+xWcEPi0x8wyUv3WvkbErpatqjOP8YnClZuerV7D3Y/8tFLtFEw5FhlxuN2mNEPt54DqB+94xcybYJ5dNglGmc2XmXIrtISvO1+7TQ2U3djvTPARlZg7vOS/EXFWnSGMiLw8Bx8733nzQPbhklqMUBW27Bi6Nji7Y2ByDQuTexA74mtZRmuYPXV4XVA==")
 
 def main():
     """


### PR DESCRIPTION
# Description
Replace this with a description of your changes.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9759a59</samp>

### Summary
🔑🦸🛠️

<!--
1.  🔑 - This emoji represents the keys that were updated and encrypted. It can also convey the idea of security and access.
2.  🦸 - This emoji represents the Marvel characters that the app displays. It can also convey the idea of fun and entertainment.
3.  🛠️ - This emoji represents the fix or improvement that the pull request introduces. It can also convey the idea of work and maintenance.
-->
Updated the `PUBLIC_KEY` and `PRIVATE_KEY` variables in `apps/marveloftheday/marvel_of_the_day.star` with new encrypted values. This fixes the Marvel of the Day app, which displays a random Marvel character on the Tidbyt device.

> _Marvel of the Day_
> _`PUBLIC_KEY`, `PRIVATE_KEY`_
> _New and encrypted_

### Walkthrough
*  Update and encrypt Marvel API keys ([link](https://github.com/tidbyt/community/pull/2004/files?diff=unified&w=0#diff-955eba8fcec605510477c61b8554c0558f04f1c8c04ebbf3638a52b3da433756L16-R17), ) to fix the Marvel of the Day app, which displays a random Marvel character on the Tidbyt device


