### PR TITLE
liveontwitch: update secret to use appID as context

### DIFF
--- a/apps/liveontwitch/live_on_twitch.star
+++ b/apps/liveontwitch/live_on_twitch.star
@@ -14,7 +14,7 @@ load("secret.star", "secret")
 load("time.star", "time")
 
 TWITCH_CLIENT_ID = "t7n82ips6t16w5hmf27abea5ypqa2a"
-TWITCH_CLIENT_SECRET = secret.decrypt("AV6+xWcEaGyyQ31L8I3zSauUNqXvLAsuS4H/WZuX8qSFM0pGA8/l6xqPnAhvzHOMvKpmwus3e3bLBFxP2evfLsCA1CJKZ+52BCAyvhPTyZBBRfDAlp+J16Ebk5JOLezMlX7pcZ3OyLgB8UB+WuMkZBLuFVHbPzQTYRjdYl/GYNoJCXBi")
+TWITCH_CLIENT_SECRET = secret.decrypt("AV6+xWcE4zoYtbnfh1xYGcfdSy1k/kSwPwpeatGr6j0bExssUbv1zjVIpjsLNTQY5NHLzP2i4wKP2YVlXw0xsiLpTp3SdwSQ62KJuiN1qIcoLtdls9E9uhyU2xwZogvtEyJT+pc0MB4fCT3wJ8gfSmIKm+NTdWF/EHwbbI3PsqnDYA3K")
 NO_DATA_IN_CACHE = ""
 
 # If a streamer went live less than 2 minutes ago, show them in an isolated widget. Otherwise, show the full list.


### PR DESCRIPTION
# Description
Replace this with a description of your changes.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c8d2b55</samp>

### Summary
🐛🔒📺

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of this change. It conveys that the app had a problem that was resolved by updating the secret value.
2.  🔒 - This emoji represents security or encryption, which is relevant to this change because the secret value is encrypted and used for authentication. It conveys that the app is protecting the sensitive information and following the best practices for using the Twitch API.
3.  📺 - This emoji represents a TV or a stream, which is related to this change because the app displays the Twitch stream data on the Tidbyt device. It conveys that the app is about streaming and entertainment.
-->
Updated `TWITCH_CLIENT_SECRET` in `live_on_twitch.star` to fix authentication bug. The app shows Twitch streamer info on Tidbyt.

> _`TWITCH_CLIENT_SECRET`_
> _Updated to fix a bug_
> _Autumn leaves falling_

### Walkthrough
* Update the `TWITCH_CLIENT_SECRET` value to use a new encrypted secret ([link](https://github.com/tidbyt/community/pull/2005/files?diff=unified&w=0#diff-7230e91031664febc4723c0557b54bf7f537a0383896bb62dd62051a6a5531caL17-R17)). This fixes a bug that prevented the app from authenticating with the Twitch API. The app displays the live status and viewer count of a Twitch streamer on the Tidbyt device.


