### PR TITLE
Fix caching issue related to use of dynamic query params.

### DIFF
--- a/apps/marveloftheday/marvel_of_the_day.star
+++ b/apps/marveloftheday/marvel_of_the_day.star
@@ -5,9 +5,6 @@ Description: Shows the name and image of a Marvel Comics character using the Mar
 Author: flynnt
 """
 
-load("cache.star", "cache")
-load("encoding/base64.star", "base64")
-load("encoding/json.star", "json")
 load("hash.star", "hash")
 load("http.star", "http")
 load("random.star", "random")
@@ -31,23 +28,14 @@ def main():
 
         return render_data(image, name)
     else:
+        random.seed(time.now().unix // 86400)
         characterId = get_random_character_id()
-        key = base64.encode("character-" + str(characterId))
-        data = cache.get(key)
         params = get_auth_params()
+        req = http.get(BASE_URL + "/" + str(characterId), ttl_seconds = 86400, params = params)
+        if req.status_code != 200:
+            fail("API request failed with status:", req.status_code)
 
-        if data != None:
-            res = base64.decode(data)
-        else:
-            req = http.get(BASE_URL + "/" + str(characterId), params = params)
-            res = req.body()
-            if req.status_code != 200:
-                fail("API request failed with status:", req.status_code)
-
-            cache.set(key, base64.encode(res), ttl_seconds = 86400)
-
-        data = json.decode(res)
-        item = data["data"]["results"][0]
+        item = req.json()["data"]["results"][0]
         name = item["name"]
         imageUrlSegments = item["thumbnail"]
         imageUrl = imageUrlSegments["path"] + "." + imageUrlSegments["extension"]
@@ -83,10 +71,11 @@ def get_auth_params():
     """
     Returns Marvel API authentication params.
     """
+    timestamp = str(1699392191)
     params = {
-        "ts": str(time.now().unix),
+        "ts": timestamp,
         "apikey": PUBLIC_KEY,
-        "hash": hash.md5(str(time.now().unix) + PRIVATE_KEY + PUBLIC_KEY),
+        "hash": hash.md5(timestamp + PRIVATE_KEY + PUBLIC_KEY),
     }
 
     return params
@@ -101,19 +90,12 @@ def get_random_character_id():
     offset = random.number(0, maxOffset)
     baseParams = {"limit": str(limit), "offset": str(offset)}
     params = baseParams | get_auth_params()
-    key = base64.encode("character-rand")
-    data = cache.get(key)
 
-    if data != None:
-        res = base64.decode(data)
-    else:
-        req = http.get(BASE_URL, params = params)
-        if req.status_code != 200:
-            fail("API request failed with status:", req.status_code)
-        res = req.body()
+    req = http.get(BASE_URL, ttl_seconds = 82800, params = params)
+    if req.status_code != 200:
+        fail("API request failed with status:", req.status_code)
 
-    data = json.decode(res)
-    responseCharacter = data["data"]["results"][0]
+    responseCharacter = req.json()["data"]["results"][0]
     imagePath = responseCharacter["thumbnail"]["path"]
     hasImage = imagePath != "http://i.annihil.us/u/prod/marvel/i/mg/b/40/image_not_available"
     characterId = responseCharacter["id"]
@@ -123,5 +105,4 @@ def get_random_character_id():
         return get_random_character_id()
 
     print("Character found...")
-    cache.set(key, base64.encode(res), ttl_seconds = 82200)
     return int(characterId)


### PR DESCRIPTION
# Description
Refactors caching in app to use the old school `cache` module as opposed to the native caching added to the `http` module. It appears as though the native option uses the full URL and its query params as the cache key, which in most cases is fine, but in cases where the query params contain some kind of timestamp or auth hash, this will lead to a situation where nothing really gets cached, and, in my case, quickly led to being rate limited by the API. This refactor should take care of that situation as well as eliminate the need to manually set a random seed.

Additional context here:
https://discuss.tidbyt.com/t/http-caching-client/5129/2?u=tflynn

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 1309584</samp>

### Summary
🚀🗄️🔐

<!--
1.  🚀 This emoji represents speed, performance, and improvement. It can be used to indicate that the code makes the app faster and more efficient.
2.  🗄️ This emoji represents caching, storage, and data. It can be used to indicate that the code reduces the API requests and saves the results for later use.
3.  🔐 This emoji represents encoding, security, and encryption. It can be used to indicate that the code protects the API keys and prevents unauthorized access.
-->
The `marvel_oftheday` app is updated to cache and encode API responses. This improves the app's speed and stability.

> _Oh we are the `marvel_oftheday` crew_
> _And we love to code and cache and encode too_
> _We'll reduce the API requests with a clever trick_
> _And make our app more speedy and more slick_

### Walkthrough
*  Import modules for caching and encoding API responses ([link](https://github.com/tidbyt/community/pull/2015/files?diff=unified&w=0#diff-955eba8fcec605510477c61b8554c0558f04f1c8c04ebbf3638a52b3da433756R8-R10))
*  Implement caching logic for character ID and random character data, using base64 to handle binary data ([link](https://github.com/tidbyt/community/pull/2015/files?diff=unified&w=0#diff-955eba8fcec605510477c61b8554c0558f04f1c8c04ebbf3638a52b3da433756L31-R50), [link](https://github.com/tidbyt/community/pull/2015/files?diff=unified&w=0#diff-955eba8fcec605510477c61b8554c0558f04f1c8c04ebbf3638a52b3da433756L92-R116), [link](https://github.com/tidbyt/community/pull/2015/files?diff=unified&w=0#diff-955eba8fcec605510477c61b8554c0558f04f1c8c04ebbf3638a52b3da433756R126))


