### PR TITLE
twitch: use new api endpoint for followers

### DIFF
--- a/apps/twitch/twitch.star
+++ b/apps/twitch/twitch.star
@@ -86,9 +86,9 @@ def get_from_twitch_api(path, params, access_token, use_cache = True):
 
 def get_twitch_followers(user_id, access_token):
     res = get_from_twitch_api(
-        path = "/users/follows",
+        path = "/channels/followers",
         params = {
-            "to_id": user_id,
+            "broadcaster_id": user_id,
         },
         access_token = access_token,
     )


### PR DESCRIPTION
# Description

Previous followers endpoint has been deprecated.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 761c9bf</samp>

### Summary
🐛📺👥

<!--
1.  🐛 - This emoji represents a bug fix, since the original function was not working with the old API endpoint and needed to be updated to match the new one.
2.  📺 - This emoji represents Twitch, the online streaming platform that the function interacts with. It could also be used to indicate the Tidbyt device, which is a display device.
3.  👥 - This emoji represents followers, the users who subscribe to a channel on Twitch and are the main output of the function.
-->
Updated the Twitch app to use the new API endpoint for channel followers. Fixed a parameter name in the `get_twitch_followers` function in `apps/twitch/twitch.star`.

> _`get_twitch_followers`_
> _New endpoint, new parameter_
> _Autumn leaves falling_

### Walkthrough
* Updated the `get_twitch_followers` function to use the new Twitch API endpoint for getting channel followers ([link](https://github.com/tidbyt/community/pull/2032/files?diff=unified&w=0#diff-74ddc55600943ebe4541fcae967ca9a5bf6ab68d062911808e6b76f479585f6aL89-R91))


