### PR TITLE
BtcHalving: fixed color and padding

### DIFF
--- a/apps/btchalving/btchalving.star
+++ b/apps/btchalving/btchalving.star
@@ -15,7 +15,7 @@ PROGRESS_WIDTH = 64
 URL_BLOCK_TIP_HEIGHT = "https://mempool.space/api/blocks/tip/height"
 URL_DIFFICULTY_ADJUSTMENT = "https://mempool.space/api/v1/difficulty-adjustment"
 
-ACTIVE_PROGRESS_COLOR = "#af6223"
+ACTIVE_PROGRESS_COLOR = "#6d4626"
 BACKGROUND_COLOR = "#000"
 BORDER_COLOR_DARK = "#494542"
 BORDER_COLOR_LIGHT = "#848280"
@@ -181,7 +181,7 @@ def main():
                                     height = 7,
                                 ),
                                 render.Padding(
-                                    pad = (2, 0, 0, 0),
+                                    pad = (4, 0, 0, 0),
                                     child = render.Text(
                                         content = "{}%".format(difficulty_change),
                                         font = "tb-8",


### PR DESCRIPTION
# Description
Fixed the progress bar color to get more contrast between the background- and foreground (text-) colors. And add a bit more padding to the percentage.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ae38d05</samp>

### Summary
🎨📈⚙️

<!--
1.  🎨 - This emoji is often used to indicate improvements or changes related to the design, style, or aesthetics of a project. In this case, it reflects the adjustment of the color and padding of the progress bar and the difficulty change percentage, which enhance the visual appeal and clarity of the app.
2.  📈 - This emoji is often used to indicate growth, progress, or positive trends. In this case, it reflects the use of a progress bar to show how close the app is to the next Bitcoin halving event, as well as the display of the difficulty change percentage, which indicates how the network adjusts to the changing hash rate and mining activity.
3.  ⚙️ - This emoji is often used to indicate settings, configuration, or technical aspects of a project. In this case, it reflects the use of Bootstrap and CSS to implement the design and style changes, as well as the logic behind the calculation and display of the progress bar and the difficulty change percentage.
-->
Improved the btchalving app's UI by changing the color and padding of the `progress_bar` and `difficulty_change` elements in `apps/btchalving/btchalving.star`.

> _The clock is ticking, the reward is shrinking_
> _We face the doom of the btchalving_
> _But we won't give up, we'll keep on mining_
> _We'll tweak the colors and the padding_

### Walkthrough
* Darkened the progress bar color to improve contrast ([link](https://github.com/tidbyt/community/pull/2039/files?diff=unified&w=0#diff-d7af08ad31c9c9a093d72b28fb8d932aa90e4255dd9260026a51aa11bea66df1L18-R18))
* Increased the padding between the text and the progress bar to avoid overlap ([link](https://github.com/tidbyt/community/pull/2039/files?diff=unified&w=0#diff-d7af08ad31c9c9a093d72b28fb8d932aa90e4255dd9260026a51aa11bea66df1L184-R184))


