### PR TITLE
Update cache calls and new raid

### DIFF
--- a/apps/wowcharacterstats/wowcharacterstats.star
+++ b/apps/wowcharacterstats/wowcharacterstats.star
@@ -78,7 +78,6 @@ def main(config):
     character_name = config.get("character", DEFAULT_CHARACTER).lower()
     realm_name = config.get("realm", DEFAULT_REALM).replace(" ", "-").lower()
     region = config.get("region", DEFAULT_REGION)
-    character_cache_key = "%s-%s-%s" % (character_name, realm_name, region)
 
     blizzard_auth_url = "https://oauth.battle.net/token?grant_type=client_credentials"
     blizzard_profile_url = "https://%s.api.blizzard.com/profile/wow/character/%s/%s?namespace=profile-%s&locale=en_US&access_token=" % (region, realm_name, character_name, region)
@@ -102,9 +101,9 @@ def main(config):
             ),
         )
 
-    player_profile = fetch_data(character_cache_key + "-profile", blizzard_profile_url, access_token)
-    player_mythic = fetch_data(character_cache_key + "-mythic", blizzard_mythic_url, access_token)
-    player_raids = fetch_data(character_cache_key + "-raids", blizzard_raid_url, access_token)
+    player_profile = fetch_data(blizzard_profile_url, access_token)
+    player_mythic = fetch_data(blizzard_mythic_url, access_token)
+    player_raids = fetch_data(blizzard_raid_url, access_token)
 
     if player_profile == None:
         return render.Root(
@@ -234,7 +233,7 @@ def get_auth_token(url, id, secret):
 
     return token
 
-def fetch_data(cache_token, url, token):
+def fetch_data(url, token):
     response = http.get("%s%s" % (url, token), ttl_seconds = 300)
     if response.status_code != 200:
         print("Blizzard request failed with status %d" % response.status_code)

--- a/apps/wowcharacterstats/wowcharacterstats.star
+++ b/apps/wowcharacterstats/wowcharacterstats.star
@@ -239,7 +239,7 @@ def fetch_data(cache_token, url, token):
     if response.status_code != 200:
         print("Blizzard request failed with status %d" % response.status_code)
         return None
-    
+
     return response.json()
 
 def determine_icon(profile):


### PR DESCRIPTION
# Description
Update cache calls and new raid

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at aa991e3</samp>

### Summary
🚀🆕🔄

<!--
1.  🚀 This emoji can be used to indicate a performance improvement or a new feature that enhances the user experience. The improved caching logic for the WoW character stats app could be seen as both, as it reduces the loading time and the network requests for the app.
2.  🆕 This emoji can be used to indicate a new addition or a change that introduces something new to the app. The new HTTP cache feature of the tidbyt SDK is a new addition that enables the improved caching logic and could be useful for other apps as well.
3.  🔄 This emoji can be used to indicate an update or a change that modifies something existing in the app. The added and updated constants to match the current game state are examples of updates that reflect the latest changes in the WoW game.
-->
Improved performance and accuracy of the `wowcharacterstats` app by using HTTP caching and updating game data.

> _`tidbyt` cache helps_
> _WoW stats load faster now_
> _Winter is coming_

### Walkthrough
* Add a constant for the default time-to-live value for the Blizzard API access token and update the current instance constant to the latest raid ([link](https://github.com/tidbyt/community/pull/2043/files?diff=unified&w=0#diff-023d68d3bef60c061a84514352e526ee79709c4ae93e0b75fc029b4d7eb2a904L62-R65))
* Replace the TODO comment with an explanation of why the cache call is needed for the access token ([link](https://github.com/tidbyt/community/pull/2043/files?diff=unified&w=0#diff-023d68d3bef60c061a84514352e526ee79709c4ae93e0b75fc029b4d7eb2a904L226-R227))
* Simplify the `fetch_data` function to use the new HTTP cache feature of the tidbyt SDK and remove the unnecessary cache token and calls ([link](https://github.com/tidbyt/community/pull/2043/files?diff=unified&w=0#diff-023d68d3bef60c061a84514352e526ee79709c4ae93e0b75fc029b4d7eb2a904L237-R244))


