### PR TITLE
Opps, was caching 60 x Seconds instead of just Seconds.

### DIFF
--- a/apps/atcradar/atc_radar.star
+++ b/apps/atcradar/atc_radar.star
@@ -210,7 +210,7 @@ def main(config):
         radar_height = 32
 
     print(radar_height)
-    flights_cache_key = "_".join(["flights", lat, lng])
+    flights_cache_key = "_".join(["Flight", "Data", lat, lng])
     flights = get_flights_from_cache(flights_cache_key)
 
     data_from_date = None
@@ -242,7 +242,7 @@ def main(config):
             else:
                 flights = []
     else:
-        print("Got flight data from cache")
+        #print("Got flight data from cache")
         data_from_date = get_time_from_cache(flights_cache_key)
 
     if flights:
@@ -311,7 +311,8 @@ def get_flights_from_cache(key):
 
 def get_time_from_cache(key):
     cache_data = cache.get(key)
-    print("Cache_data: %s" % cache_data)
+    #print("Cache_data: %s" % cache_data)
+
     if cache_data == None:
         return None
     else:
@@ -633,7 +634,7 @@ def get_schema():
             ),
             schema.Text(
                 id = "key",
-                name = "API key",
+                name = "RapidAPI FlightRadar Key",
                 desc = "Flight Radar API key",
                 icon = "key",
             ),

--- a/apps/atcradar/atc_radar.star
+++ b/apps/atcradar/atc_radar.star
@@ -194,7 +194,7 @@ def main(config):
 
     hide_when_nothing_to_display = config.bool("hide", True)
     location = json.decode(config.get("location", DEFAULT_LOCATION))
-    cache_tty = int(config.get("cache", 60)) * 60
+    cache_tty = int(config.get("cache", 60))
 
     orig_lat = location["lat"]
     orig_lng = location["lng"]


### PR DESCRIPTION
# Description
I accidentally set TTL (Time to Live) to Seconds * 60 making the cache last 60 times longer than it should have.

# Copilot
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 2ee9b5e</samp>

### Summary
🐛🕒📈

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the change.
2.  🕒 - This emoji represents a clock or time, which is the aspect of the app that was affected by the change.
3.  📈 - This emoji represents improvement or enhancement, which is the outcome of the change for the app performance and user experience.
-->
Fixed a caching bug in `atc_radar.star` that prevented the app from showing updated flight data. Changed the time unit for `cache_tty` from hours to seconds.

> _`cache_tty` fixed_
> _Hours became seconds now_
> _Fresh flight data - spring_

### Walkthrough
* Fix flight data caching bug by changing `cache_tty` to use seconds instead of hours ([link](https://github.com/tidbyt/community/pull/2048/files?diff=unified&w=0#diff-620b0f733e0117260dbff46c4a5fb310b9112872c762b53aa416942d3961f1e5L197-R197))


