### PR TITLE
New App: Empire State Building Tower Lights

### DIFF
--- a/apps/esbnyccolors/esb_nyc_colors.star
+++ b/apps/esbnyccolors/esb_nyc_colors.star
@@ -1,0 +1,72 @@
+"""
+Applet: ESB NYC Colors
+Summary: Empire State Bld Colors
+Description: Shows today's colors of the Empire State Building.
+Author: sklose
+"""
+
+load("http.star", "http")
+load("render.star", "render")
+
+def main():
+    rep = http.get("https://lzxe5agehadtlh2kaecrlk62c40dimdp.lambda-url.us-east-1.on.aws/", ttl_seconds = 3600)
+    if rep.status_code != 200:
+        fail("request failed with status %d", rep.status_code)
+
+    json = rep.json()
+    description = json["description"]
+    color1 = json["colors"][0]
+    color2 = json["colors"][0]
+    color3 = json["colors"][0]
+
+    if len(json["colors"]) > 1:
+        color2 = json["colors"][1]
+        color3 = json["colors"][1]
+
+    if len(json["colors"]) > 2:
+        color3 = json["colors"][2]
+
+    colorMap = {
+        "blue": "#00f",
+        "red": "#f00",
+        "green": "#0f0",
+        "white": "#fff",
+        "yellow": "#ff9",
+        "purple": "#808",
+        "pink": "#f0b",
+        "orange": "#fa0",
+        "brown": "#a22",
+        "gold": "#fd0",
+    }
+
+    return render.Root(
+        child = render.Column(
+            expanded = True,
+            main_align = "space_around",
+            cross_align = "center",
+            children = [
+                render.Marquee(
+                    width = 64,
+                    child = render.Text(
+                        content = "%s" % description,
+                        font = "Dina_r400-6",
+                    ),
+                    offset_start = 5,
+                    offset_end = 32,
+                ),
+                render.Box(
+                    color = colorMap[color1],
+                    child = render.Box(
+                        width = 40,
+                        height = 16,
+                        color = colorMap[color2],
+                        child = render.Box(
+                            width = 20,
+                            height = 8,
+                            color = colorMap[color3],
+                        ),
+                    ),
+                ),
+            ],
+        ),
+    )

--- a/apps/esbnyccolors/manifest.yaml
+++ b/apps/esbnyccolors/manifest.yaml
@@ -1,0 +1,8 @@
+---
+id: esb-nyc-colors
+name: ESB NYC Colors
+summary: Empire State Bld Colors
+desc: Shows today's colors of the Empire State Building.
+author: sklose
+fileName: esb_nyc_colors.star
+packageName: esbnyccolors


### PR DESCRIPTION
# Description
A new app that shows the colors of the Empire State Building's Tower Lights and the reason for the colors. See https://www.esbnyc.com/about/tower-lights/calendar

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at cad3307</samp>

### Summary
🌆🎨📝

<!--
1.  🌆 - This emoji represents the Empire State Building, which is the main subject of the applet. It also conveys the idea of a city skyline and a colorful display.
2.  🎨 - This emoji represents the colors, which are the main feature of the applet. It also conveys the idea of creativity and artistry.
3.  📝 - This emoji represents the code and the metadata, which are the main components of the applet. It also conveys the idea of writing and documentation.
-->
This pull request adds a new applet `esb_nyc_colors` that shows the current colors of the Empire State Building on the Tidbyt device. It consists of two files: `esb_nyc_colors.star` for the applet logic and `manifest.yaml` for the applet metadata.

> _`esb_nyc_colors`_
> _Shows the building's mood today_
> _Autumn in the sky_

### Walkthrough
* Create and register a new applet for displaying the Empire State Building colors on the Tidbyt device ([link](https://github.com/tidbyt/community/pull/2054/files?diff=unified&w=0#diff-118ff0969a2863f323318d9126b416739c778191592c60509a52bfd2287a6a05R1-R72), [link](https://github.com/tidbyt/community/pull/2054/files?diff=unified&w=0#diff-0f1b9e265c174d524b7ea585ee5a6205015b36e995e8cc3c92054668d8046e56R1-R8))
  * Add the applet code in `esb_nyc_colors.star` that uses the `http` and `render` modules to fetch and display the color data ([link](https://github.com/tidbyt/community/pull/2054/files?diff=unified&w=0#diff-118ff0969a2863f323318d9126b416739c778191592c60509a52bfd2287a6a05R1-R72))
  * Add the applet metadata in `manifest.yaml` that specifies the applet id, name, summary, description, author, file name, and package name ([link](https://github.com/tidbyt/community/pull/2054/files?diff=unified&w=0#diff-0f1b9e265c174d524b7ea585ee5a6205015b36e995e8cc3c92054668d8046e56R1-R8))


