### PR TITLE
Fix UK/London transport apps

### DIFF
--- a/apps/nationalrail/national_rail.star
+++ b/apps/nationalrail/national_rail.star
@@ -2751,9 +2751,21 @@ def render_times(scheduled, expected):
     )
 
 def render_destination(destination):
-    return render.Text(
-        content = destination["sixteen_char_name"].title(),
-        font = FONT,
+    return render.Column(
+        children = [
+            render.Row(
+                children = [
+                    render.Text(
+                        content = destination["name"].title(),
+                        font = FONT,
+                    ),
+                ],
+                expanded = True,
+                main_align = "start",
+            ),
+        ],
+        expanded = True,
+        cross_align = "start",
     )
 
 def render_no_departures():
@@ -2874,7 +2886,7 @@ def main(config):
         child = render.Column(
             cross_align = "center",
             children = [
-                render_title(origin_station["sixteen_char_name"].title()),
+                render_title(origin_station["name"].title()),
                 render_separator(),
             ] + rendered_trains,
         ),

--- a/apps/tubestatus/tube_status.star
+++ b/apps/tubestatus/tube_status.star
@@ -283,7 +283,7 @@ def render_problems(lines):
     for i in range(0, len(problems), 2):
         panes = [render_status(problems[i])]
         if i + 1 < len(problems):
-            panes.append(render_status(lines[i + 1]))
+            panes.append(render_status(problems[i + 1]))
         frames.append(
             render.Column(
                 children = panes,


### PR DESCRIPTION
# Description
National Rail wasn't showing stations well. Bugged me now I've moved house and am using it more.

Tube status was reporting duplicate problems, because I was looking something up in the wrong collection.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at fc8704d</samp>

### Summary
🐛🚆📊

<!--
1.  🐛 - This emoji represents a bug fix, which is what the first change does by correcting the argument passed to the `render_status` function.
2.  🚆 - This emoji represents a train, which is the main subject of the National Rail app. It also indicates an improvement or enhancement to the app's functionality or appearance, which is what the second change does by using full station names.
3.  📊 - This emoji represents a chart or a table, which is the format of the data displayed by the National Rail app. It also suggests a refactoring or a code improvement, which is what the second change does by returning a column instead of a text.
-->
Improved the National Rail and Tube Status apps for the UK by fixing bugs and enhancing the display of station and line information. Changed the `render_destination` function in `apps/nationalrail/national_rail.star` and the `render_status` function in `apps/tubestatus/tube_status.star`.

> _Oh we are the coders of the starry sky_
> _We fix the bugs and make the apps run high_
> _We heave and haul on the `render_status` line_
> _And we show the stations with their proper name and sign_

### Walkthrough
* Use full names of origin and destination stations for National Rail app (`apps/nationalrail/national_rail.star`, [link](https://github.com/tidbyt/community/pull/2056/files?diff=unified&w=0#diff-1125330c4be8cf22afcc0e4dac90c04abad865e0dae49fc90d01cfb85cdf8d33L2754-R2768), [link](https://github.com/tidbyt/community/pull/2056/files?diff=unified&w=0#diff-1125330c4be8cf22afcc0e4dac90c04abad865e0dae49fc90d01cfb85cdf8d33L2877-R2889))
* Return `render.Column` instead of `render.Text` from `render_destination` function to allow for future enhancements (`apps/nationalrail/national_rail.star`, [link](https://github.com/tidbyt/community/pull/2056/files?diff=unified&w=0#diff-1125330c4be8cf22afcc0e4dac90c04abad865e0dae49fc90d01cfb85cdf8d33L2754-R2768))
* Fix bug in Tube Status app where `render_status` function was called with wrong argument (`apps/tubestatus/tube_status.star`, [link](https://github.com/tidbyt/community/pull/2056/files?diff=unified&w=0#diff-c66ad87161d84472990861287d73fa17f036db561b03803a261786ed0fcf20d7L286-R286))


