### PR TITLE
NationalToday: Bug fix

### DIFF
--- a/apps/nationaltoday/nationaltoday.star
+++ b/apps/nationaltoday/nationaltoday.star
@@ -7,7 +7,7 @@ Author: rs7q5
 
 #nationalToday.star
 #Created 20220130 RIS
-#Last Modified 20231121 RIS
+#Last Modified 20231122 RIS
 
 load("http.star", "http")
 load("qrcode.star", "qrcode")
@@ -15,7 +15,8 @@ load("re.star", "re")
 load("render.star", "render")
 load("schema.star", "schema")
 
-BASE_URL = "https://nationaltoday.com/today/"  #what-is-today/"
+BASE_URL = "https://nationaltoday.com/what-is-today/"
+BASE_URL2 = "https://nationaltoday.com/today/"  #used in case what-is-today gives 404
 
 QR_CODE = qrcode.generate(
     url = BASE_URL,
@@ -30,6 +31,9 @@ def main(config):
 
     #get the data
     rep = http.get(url = BASE_URL, ttl_seconds = 1800)  #cache for 30 minutes
+    if rep.status_code != 200:
+        rep = http.get(url = BASE_URL2, ttl_seconds = 1800)  #cache for 30 minutes
+
     if rep.status_code != 200:
         holiday_txt = ["Error", "Could not get holidays!!!!"]
     else:

--- a/apps/nationaltoday/nationaltoday.star
+++ b/apps/nationaltoday/nationaltoday.star
@@ -7,7 +7,7 @@ Author: rs7q5
 
 #nationalToday.star
 #Created 20220130 RIS
-#Last Modified 20230516 RIS
+#Last Modified 20231121 RIS
 
 load("http.star", "http")
 load("qrcode.star", "qrcode")
@@ -15,7 +15,7 @@ load("re.star", "re")
 load("render.star", "render")
 load("schema.star", "schema")
 
-BASE_URL = "https://nationaltoday.com/what-is-today/"
+BASE_URL = "https://nationaltoday.com/today/"  #what-is-today/"
 
 QR_CODE = qrcode.generate(
     url = BASE_URL,


### PR DESCRIPTION
# Description
The old url extension was giving 404, used an alternate one. may go back if the old one starts to work again, but this makes the app functional again



# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6411cf1</samp>

### Summary
🌐🎉🗓️

<!--
1.  🌐 - This emoji can represent the change of the website URL, as it is a symbol of the internet or the world wide web.
2.  🎉 - This emoji can represent the feature of fetching the current day's celebrations, as it is a symbol of celebration, party, or fun.
3.  🗓️ - This emoji can represent the update of the last modified date in the app metadata, as it is a symbol of a calendar or a date.
-->
Fixed the National Today app to work with the new website and show the latest events. Updated the app metadata to reflect the changes.

> _Oh we're the crew of the National Today_
> _We fetch the celebrations from the new URL_
> _We heave and we haul and we update the date_
> _And we sing and we dance and we have a good day_

### Walkthrough
* Update the base URL for the National Today website to match the new format ([link](https://github.com/tidbyt/community/pull/2060/files?diff=unified&w=0#diff-a12d30d39342cdf09276bd7f6f3434eec6e672fe0191a1bfb73e6e7d46d2eac3L18-R18))
* Adjust the last modified date to reflect the latest change ([link](https://github.com/tidbyt/community/pull/2060/files?diff=unified&w=0#diff-a12d30d39342cdf09276bd7f6f3434eec6e672fe0191a1bfb73e6e7d46d2eac3L10-R10))


