### PR TITLE
chore(nightscout): Pass token using `Api-Secret` header

### DIFF
--- a/apps/nightscout/nightscout.star
+++ b/apps/nightscout/nightscout.star
@@ -816,15 +816,16 @@ def get_nightscout_data(nightscout_url, nightscout_token, show_mgdl):
     nightscout_url = nightscout_url.split("/")[0]
     oldest_reading = str((time.now() - time.parse_duration("240m")).unix)
     json_url = "https://" + nightscout_url + "/api/v1/entries.json?count=1000&find[date][$gte]=" + oldest_reading
+    headers = {}
     if nightscout_token != "":
-        json_url = json_url + "&token=" + nightscout_token
+        headers["Api-Secret"] = nightscout_token
 
     print(json_url)
 
     key = nightscout_url + "_nightscout_data"
 
     # Request latest entries from the Nightscout URL
-    resp = http.get(json_url)
+    resp = http.get(json_url, headers = headers)
     if resp.status_code != 200:
         # If Error, Get the JSON object from the cache
         nightscout_data_cached = cache.get(key)


### PR DESCRIPTION
# Description
This PR changes the Nightscout app to pass a configured token using the `Api-Secret` header instead of using the `token` query param. This is safer since URLs are often kept in access logs.

This header is documented in Nightscout's [Swagger doc](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/nightscout/cgm-remote-monitor/master/lib/server/swagger.yaml).

I have tested this against my own instance.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 61e5f1b</samp>

### Summary
🔒🔄📄

<!--
1.  🔒 - This emoji can symbolize security, encryption, or privacy, and it relates to the change of using a more secure authentication method with the Nightscout API.
2.  🔄 - This emoji can represent compatibility, synchronization, or updating, and it relates to the change of using a different method of authentication that is more compatible with the Nightscout API.
3.  📄 - This emoji can represent documents, headers, or data, and it relates to the change of adding the `headers` variable and sending the `Api-Secret` header to the Nightscout API.
-->
Improved security and compatibility of Nightscout app by using `Api-Secret` header for authentication. Modified `apps/nightscout/nightscout.star` to send the header with `http.get`.

> _To access the Nightscout API_
> _The old way was not very spry_
> _So they added `headers`_
> _To avoid any wedges_
> _And used `Api-Secret` to fly_

### Walkthrough
*  Use `Api-Secret` header for authentication with Nightscout API ([link](https://github.com/tidbyt/community/pull/2065/files?diff=unified&w=0#diff-76126fb2f5f6edd57d467ea196a5537f9f0f062d734669d13d9fa5c63bc7fdd4L819-R821), [link](https://github.com/tidbyt/community/pull/2065/files?diff=unified&w=0#diff-76126fb2f5f6edd57d467ea196a5537f9f0f062d734669d13d9fa5c63bc7fdd4L827-R828))


