### PR TITLE
New App: Wiki Page Today

### DIFF
--- a/apps/wikipagetoday/manifest.yaml
+++ b/apps/wikipagetoday/manifest.yaml
@@ -1,0 +1,8 @@
+---
+id: wiki-page-today
+name: Wiki Page Today
+summary: Wikipedia Featured Article
+desc: Display Wikipedia's Featured Article of the Day in a Tidbyt format.
+author: UnBurn
+fileName: wiki_page_today.star
+packageName: wikipagetoday

--- a/apps/wikipagetoday/wiki_page_today.star
+++ b/apps/wikipagetoday/wiki_page_today.star
@@ -1,0 +1,76 @@
+"""
+Applet: Wiki Page Today
+Summary: Wikipedia Featured Article
+Description: Display Wikipedia's Featured Article of the Day in a Tidbyt format.
+Author: UnBurn
+"""
+
+load("encoding/base64.star", "base64")
+load("http.star", "http")
+load("render.star", "render")
+load("time.star", "time")
+
+WIKIPEDIA_ICON = base64.decode("iVBORw0KGgoAAAANSUhEUgAAAAcAAAAGCAYAAAAPDoR2AAAALUlEQVQIW2NkAIL/QACikQEjCIAkgBRIAVwOxkeRhAtCFROWBJmHrgsshs9BAO7FNfeFAdnIAAAAAElFTkSuQmCC")
+WIKIPEDIA_URL = "https://api.wikimedia.org/feed/v1/wikipedia/en/featured/%s/%s/%s"
+
+TTL_TIME = 86400
+
+def get_featured_article(date):
+    url = (WIKIPEDIA_URL % date)
+
+    article = http.get(url, ttl_seconds = TTL_TIME).json()["tfa"]
+    return article
+
+def get_reduced_extract(extract):
+    MAX_LENGTH = 50
+
+    sentences = extract.split(".")
+    ret = sentences[0] + "."
+    for s in sentences[1:]:
+        new_sentence = ret + s + "."
+        if len(new_sentence) <= MAX_LENGTH:
+            ret = new_sentence
+
+    return ret
+
+def main():
+    now = time.now()
+    date = (now.year, now.month, now.day)
+    article = get_featured_article(date)
+
+    title = article["normalizedtitle"]
+    extract = article["extract"]
+    description = get_reduced_extract(extract)
+    image = http.get(article["thumbnail"]["source"], ttl_seconds = TTL_TIME).body()
+
+    top_bar = render.Stack(
+        children = [
+            render.Box(width = 64, height = 6, color = "#3f3f3f"),
+            render.Row(
+                children = [
+                    render.Padding(child = render.Image(src = WIKIPEDIA_ICON, width = 7, height = 6), pad = (1, 0, 1, 0)),
+                    render.Marquee(width = 56, delay = 500, child = render.Text(title, font = "tom-thumb")),
+                ],
+            ),
+        ],
+    )
+
+    body = render.Row(
+        children = [
+            render.Padding(child = render.Image(src = image, width = 16, height = 25), pad = (0, 0, 1, 0)),
+            render.Marquee(
+                height = 25,
+                delay = 500,
+                scroll_direction = "vertical",
+                child = (render.WrappedText(content = description, font = "tb-8")),
+            ),
+        ],
+    )
+
+    return render.Root(
+        delay = 5,
+        show_full_animation = True,
+        child = render.Column(
+            children = [top_bar, render.Box(color = "#fff", width = 64, height = 1), body],
+        ),
+    )

--- a/apps/wikipagetoday/wiki_page_today.star
+++ b/apps/wikipagetoday/wiki_page_today.star
@@ -14,6 +14,7 @@ WIKIPEDIA_ICON = base64.decode("iVBORw0KGgoAAAANSUhEUgAAAAcAAAAGCAYAAAAPDoR2AAAA
 WIKIPEDIA_URL = "https://api.wikimedia.org/feed/v1/wikipedia/en/featured/%s/%s/%s"
 
 TTL_TIME = 86400
+MARQUEE_DELAY = 150
 
 def get_featured_article(date):
     url = (WIKIPEDIA_URL % date)
@@ -22,14 +23,16 @@ def get_featured_article(date):
     return article
 
 def get_reduced_extract(extract):
-    MAX_LENGTH = 50
+    MAX_LENGTH = 100
 
     sentences = extract.split(".")
     ret = sentences[0] + "."
     for s in sentences[1:]:
         new_sentence = ret + s + "."
-        if len(new_sentence) <= MAX_LENGTH:
+        if s != "" and len(new_sentence) <= MAX_LENGTH:
             ret = new_sentence
+        else:
+            break
 
     return ret
 
@@ -49,7 +52,7 @@ def main():
             render.Row(
                 children = [
                     render.Padding(child = render.Image(src = WIKIPEDIA_ICON, width = 7, height = 6), pad = (1, 0, 1, 0)),
-                    render.Marquee(width = 56, delay = 500, child = render.Text(title, font = "tom-thumb")),
+                    render.Marquee(width = 56, delay = MARQUEE_DELAY, child = render.Text(title, font = "tom-thumb")),
                 ],
             ),
         ],
@@ -60,7 +63,7 @@ def main():
             render.Padding(child = render.Image(src = image, width = 16, height = 25), pad = (0, 0, 1, 0)),
             render.Marquee(
                 height = 25,
-                delay = 500,
+                delay = MARQUEE_DELAY,
                 scroll_direction = "vertical",
                 child = (render.WrappedText(content = description, font = "tb-8")),
             ),
@@ -68,8 +71,8 @@ def main():
     )
 
     return render.Root(
-        delay = 5,
         show_full_animation = True,
+        delay = 20,
         child = render.Column(
             children = [top_bar, render.Box(color = "#fff", width = 64, height = 1), body],
         ),


### PR DESCRIPTION
# Description

This app reads from the Wikipedia API for the article of the day, and renders a byte sized portion of it here for the Tidbyt.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 07bb562</samp>

### Summary
📜🌐📰

<!--
1.  📜 This emoji represents the manifest file, which is like a scroll or document that contains the applet's metadata and settings.
2.  🌐 This emoji represents the Wikipedia API, which is the source of the featured article and is accessed through the internet or the web.
3.  📰 This emoji represents the featured article itself, which is like a newspaper or a report that contains interesting and informative content.
-->
This pull request adds a new applet `wiki-page-today` that displays Wikipedia's featured article of the day on a Tidbyt device. It includes a manifest file and a Starlark script file that implement the applet logic and rendering.

> _`wiki-page-today`_
> _A new applet for Tidbyt_
> _Shows daily knowledge_

### Walkthrough
* Create a new applet `wiki-page-today` that displays Wikipedia's featured article of the day on Tidbyt ([link](https://github.com/tidbyt/community/pull/2069/files?diff=unified&w=0#diff-0a789490161ebac249f04507a184c7d4e407cb99db4840739694b90833b4cf08R1-R8), [link](https://github.com/tidbyt/community/pull/2069/files?diff=unified&w=0#diff-4676c67f0b8814f330948f0117ea31fac963437d8bc7368f4139c01a7e1375bdR1-R73))
* Add a manifest file `manifest.yaml` with metadata for the applet, such as id, name, summary, description, author, file name, and package name ([link](https://github.com/tidbyt/community/pull/2069/files?diff=unified&w=0#diff-0a789490161ebac249f04507a184c7d4e407cb99db4840739694b90833b4cf08R1-R8))
* Add a script file `wiki_page_today.star` with the main logic for the applet, written in Starlark ([link](https://github.com/tidbyt/community/pull/2069/files?diff=unified&w=0#diff-4676c67f0b8814f330948f0117ea31fac963437d8bc7368f4139c01a7e1375bdR1-R73))


