### PR TITLE
tempest: handle missing precip_accum_local_day

### DIFF
--- a/apps/tempest/tempest.star
+++ b/apps/tempest/tempest.star
@@ -84,7 +84,7 @@ def main(config):
         units["units_wind"],
     )
     pressure = "%g" % conditions["sea_level_pressure"]
-    rain = "%g" % conditions["precip_accum_local_day"]
+    rain = "%g" % conditions.get("precip_accum_local_day", 0.0)
     feels = "%d°" % conditions["feels_like"]
     dew_pt = "%d°" % conditions["dew_point"]
     pressure_trend = conditions["pressure_trend"]


### PR DESCRIPTION
# Description
Replace this with a description of your changes.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 8d153fe</samp>

### Summary
🐛🌧️🛠️

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the pull request.
2.  🌧️ - This emoji represents precipitation, which is the data that the code is handling and displaying on the device.
3.  🛠️ - This emoji represents a tool or a fix, which is the result of the code modification.
-->
Fixed a bug in the `tempest` app that caused a crash when the weather API did not provide precipitation data for some locations. Changed the code to use the `get` method with a default value for the `precip_accum_local_day` key in the `conditions` dictionary.

> _`get` with default_
> _avoids KeyError in app_
> _snowy or not, show_

### Walkthrough
*  Handle missing precipitation data from API by using `get` method with default value ([link](https://github.com/tidbyt/community/pull/2074/files?diff=unified&w=0#diff-ef4bf4a9479b690031c00b504c4c038548ea5634ad04a25fba6d9d7f49a9b67aL87-R87))


