### PR TITLE
fix(nightscout): Fix root `API_SECRET` returning 401

### DIFF
--- a/apps/nightscout/manifest.yaml
+++ b/apps/nightscout/manifest.yaml
@@ -2,7 +2,7 @@
 id: nightscout
 name: Nightscout
 summary: Shows Nightscout CGM Data
-desc: Displays Continuous Glucose Monitoring (CGM) blood sugar data from the Nightscout Open Source project (https://nightscout.github.io/). Will display blood sugar as mg/dL or mmol/L. Optionally display historical readings on a graph. Also a clock. (v2.3.3).
+desc: Displays Continuous Glucose Monitoring (CGM) blood sugar data from the Nightscout Open Source project (https://nightscout.github.io/). Will display blood sugar as mg/dL or mmol/L. Optionally display historical readings on a graph. Also a clock. (v2.3.5).
 author: Jeremy Tavener, Paul Murphy
 fileName: nightscout.star
 packageName: nightscout

--- a/apps/nightscout/nightscout.star
+++ b/apps/nightscout/nightscout.star
@@ -7,6 +7,7 @@ Authors: Jeremy Tavener, Paul Murphy
 
 load("cache.star", "cache")
 load("encoding/json.star", "json")
+load("hash.star", "hash")
 load("http.star", "http")
 load("math.star", "math")
 load("render.star", "render")
@@ -818,7 +819,7 @@ def get_nightscout_data(nightscout_url, nightscout_token, show_mgdl):
     json_url = "https://" + nightscout_url + "/api/v1/entries.json?count=1000&find[date][$gte]=" + oldest_reading
     headers = {}
     if nightscout_token != "":
-        headers["Api-Secret"] = nightscout_token
+        headers["Api-Secret"] = hash.sha1(nightscout_token)
 
     print(json_url)
 


### PR DESCRIPTION
# Description
This PR fixes occasional Nightscout 401s introduced by #2065.

Nightscout has two different types of API key. There's the `API_SECRET` env, and there's role-based keys. The `Api-Secret` header accepts a literal value if a role-based key is passed, but if `API_SECRET` is used, the value must be SHA1 hashed. Both types of secret support hashed values. I missed this in #2065 because I only use role-based keys, but I have tested this PR with both types and gotten a 200 response.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6818a28</samp>

### Summary
🔑🌙🧮

<!--
1.  🔑 - This emoji represents the concept of encryption, security, and authentication, which are relevant to the use of hashed tokens instead of plain text tokens.
2.  🌙 - This emoji represents the Nightscout app and its logo, which is a crescent moon. It also suggests the idea of night-time monitoring and management of diabetes, which is one of the main features of the app.
3.  🧮 - This emoji represents the concept of calculation, computation, and hashing, which are involved in the `hash` module and its functionality. It also suggests the idea of data analysis and processing, which are important aspects of the Nightscout app.
-->
This pull request enhances the security of the `nightscout` app by using the `hash` module to generate and verify hashed tokens for the Nightscout API. It also modifies the app code and configuration file to support the new authentication method.

> _To secure the `nightscout` app_
> _A `hash` module was added to the stack_
> _It generates tokens with salt_
> _That the API can exalt_
> _And reject any requests that are whack_

### Walkthrough
*  Hash the `nightscout_token` with SHA-1 and use it as the `Api-Secret` header for the Nightscout API requests ([link](https://github.com/tidbyt/community/pull/2076/files?diff=unified&w=0#diff-76126fb2f5f6edd57d467ea196a5537f9f0f062d734669d13d9fa5c63bc7fdd4R16), [link](https://github.com/tidbyt/community/pull/2076/files?diff=unified&w=0#diff-76126fb2f5f6edd57d467ea196a5537f9f0f062d734669d13d9fa5c63bc7fdd4L821-R822))


