### PR TITLE
App: Empire State Building Colors

### DIFF
--- a/apps/esbnyccolors/esb_nyc_colors.star
+++ b/apps/esbnyccolors/esb_nyc_colors.star
@@ -37,6 +37,7 @@ def main():
         "orange": "#fa0",
         "brown": "#a22",
         "gold": "#fd0",
+        "teal": "#088",
     }
 
     return render.Root(
@@ -46,13 +47,11 @@ def main():
             cross_align = "center",
             children = [
                 render.Marquee(
-                    width = 64,
+                    width = 128,
                     child = render.Text(
-                        content = "%s" % description,
+                        content = description,
                         font = "Dina_r400-6",
                     ),
-                    offset_start = 5,
-                    offset_end = 32,
                 ),
                 render.Box(
                     color = colorMap[color1],


### PR DESCRIPTION
# Description
- add new color `teal`
- marquee optimization

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 508d7a2</samp>

### Summary
🎨🌃🆙

<!--
1.  🎨 - This emoji is often used to indicate changes related to colors, design, or aesthetics. It can represent the new color option added to the app, as well as the improved readability of the text.
2.  🌃 - This emoji is a symbol of a cityscape at night, which can evoke the image of the Empire State Building lit up in different colors. It can also represent the app's theme and purpose, which is to showcase the iconic landmark's lighting displays.
3.  🆙 - This emoji is a sign of improvement, enhancement, or upgrade. It can represent the changes made to the `render.Marquee` component, which make the text description more visible and clear. It can also imply that the app's quality and functionality have been increased.
-->
This pull request enhances the Empire State Building app by adding a new color option and improving the text display. It modifies the `colors` dictionary and the `render.Marquee` component in `esb_nyc_colors.star`.

> _We're sailing to the city of the lights_
> _Where the Empire State shines bright_
> _We'll update the `colors` and the `render.Marquee`_
> _On the count of three, heave away!_

### Walkthrough
* Add a new color option "teal" to the color dictionary ([link](https://github.com/tidbyt/community/pull/2080/files?diff=unified&w=0#diff-118ff0969a2863f323318d9126b416739c778191592c60509a52bfd2287a6a05R40))
* Increase the width of the render.Marquee component to fit the text description ([link](https://github.com/tidbyt/community/pull/2080/files?diff=unified&w=0#diff-118ff0969a2863f323318d9126b416739c778191592c60509a52bfd2287a6a05L49-R54))
* Simplify the content of the render.Marquee component to use the description variable ([link](https://github.com/tidbyt/community/pull/2080/files?diff=unified&w=0#diff-118ff0969a2863f323318d9126b416739c778191592c60509a52bfd2287a6a05L49-R54))


