### PR TITLE
Mars Clock - Location update

### DIFF
--- a/apps/marsclock/manifest.yaml
+++ b/apps/marsclock/manifest.yaml
@@ -2,7 +2,7 @@
 id: mars-clock
 name: Mars Clock
 summary: Mars Time at a Glance
-desc: Experience Martian timekeeping with Mars Clock, showcasing the current Mars Coordinated Time (MTC) and Mars Sol Date.
+desc: Explore the current Martian time at a specific location on Mars, including the Martian Sol Date. With sols being approximately 40 Earth minutes longer than Earth days, the 24-hour Martian clock continuously shifts compared to Earth's timekeeping.
 author: Adam Henson
 fileName: mars_clock.star
 packageName: marsclock

--- a/apps/marsclock/mars_clock.star
+++ b/apps/marsclock/mars_clock.star
@@ -11,12 +11,22 @@ load("render.star", "render")
 load("schema.star", "schema")
 load("time.star", "time")
 
-DEFAULT_SHOWSOL = True
+DEFAULT_SHOWSOL = False
+DEFAULT_SHOWLOC = True
 
 # Image blob
 MARS_ICON = base64.decode("""iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAAIGNIUk0AAHomAACAhAAA+gAAAIDoAAB1MAAA6mAAADqYAAAXcJy6UTwAAAKXUExURQAAAAICAg8SEh8lIjA4OD5MVDdHUh8rNAYLDQAAAQ0SFio2OE5cYWx2eoyRlpKXnIeLjHR/e0xXTBkgGQECAhYaHkBTZVtzhHaJl4qVmpqOgKqIZ6qFXKqEWJ59VGxjSCouJQICAw4RD0NHRF1iXWprYH11ZJh9X6+AVMSHUsGGUs2NVdCRVrGDUoRuTScoHwQEBDE0Ll1dUG1nVHpsVKd6VMmBTdaJTuWWVOyeWe6jXOmiW9aUVreFVWtfRgwODBYZGFpZUnZsXX5vWpN5XcWFV9qLUuqYVfqpW/ysXfqsXvapX+ihXLKFV2toTy0yKDAwLnhpXZt8YrSHYsGJX8+MWOCTVe+eVvytXf2xX/2wYPuuX/WsYMKRWmFlTkdPQUNBQIZtW6R9X7mGXauAWseLW9qTWuaXVvSlW/yyYfqxYdKaX3ZzVlxlU0NDRHloWI92XZZ4Wp18WsCKXbCDWLGAU9+cWvmwYPmwYfy0YvOqYMCSXXpzV2ZuXTI4O2FeVHdrWHhpVYVwVqSAW35sUHlmSqB5ULWGVrWIV9acXeGiX62KXYh/YF5mWx0lKVdeXG1nWHRrVnxtVZN4WJt5U6F8VKqBVq+EVqiBVaeEWruQXqeKYJWJZTk8MggLDERRVGNpYHNvW4BzWot2WaB8VrSHWcCOW8WTXbiOXJ6BWZV+Wp2LZHVwVA4PDCAqMVtrbmxsXXhwW4JyWI51VpR3VJR3U5t7VpB3VIh2VpqHYpOKaS8yKQIDBTA/THJ/goJ+cYh2W4tzVIZuT4RtTolwUIVxVI+AX5WKZ0FCNQIDAys1QnSEnJWhsZWVlJCKfJGIdYyFcIeAaXFqUy8vJhEVGz9JV2lyfn+GjYOJkG91ekFEQg8QDv///+fl0v0AAAABYktHRNwHYIO3AAAAB3RJTUUH4QUDEjQelR77kwAAAEZ0RVh0UmF3IHByb2ZpbGUgdHlwZSBhcHAxMgAKYXBwMTIKICAgICAgMTUKNDQ3NTYzNmI3OTAwMDEwMDA0MDAwMDAwNjQwMDAwCo97YnMAAABSdEVYdFJhdyBwcm9maWxlIHR5cGUgZXhpZgAKZXhpZgogICAgICAyMgo0NTc4Njk2NjAwMDA0OTQ5MmEwMDA4MDAwMDAwMDAwMDAwMDAwMDAwMDAwMAr5oEG6AAABDklEQVQY02NgAAJGJmYWVjZ2DgYI4OTi5uHl4xcQFBIWAQuIiolLSEpJy8jKySsoAvlKyiqqauoamlraOrp6+gwMBoZGxiamZuYWllbWNrZ29gwOjk7OLq5u7h6eXt4+vn7+DAGBQcEhoWHhEZFR0TGxcfEMCYlJySmpaekZkVGZWdk5uQx5+QWFRcUlpWXlFZVV1TW1DHX1DY1NzS2tbe0dnV3dPb0Mff0TJk6aPGXqtOkzZs6aPWcuw7z5CxYuWrxk6bLlK1auWr1mLQPDuvUbNm7avGXrtu07du7aDXTpnr379h84eOjwkaPHjp84CfLLnlOnz5w9d/7CxUuXT0L9e+Xqtes3bt66DWIDAJewYFOQtEy3AAAAJXRFWHRkYXRlOmNyZWF0ZQAyMDE3LTA1LTAzVDE4OjUyOjMwKzAyOjAwnsrZywAAACV0RVh0ZGF0ZTptb2RpZnkAMjAxNy0wNS0wM1QxODo1MjozMCswMjowMO+XYXcAAABXelRYdFJhdyBwcm9maWxlIHR5cGUgaXB0YwAAeJzj8gwIcVYoKMpPy8xJ5VIAAyMLLmMLEyMTS5MUAxMgRIA0w2QDI7NUIMvY1MjEzMQcxAfLgEigSi4A6hcRdPJCNZUAAAAASUVORK5CYII=""")
 
-def time_on_mars():
+def mtc_location_offset(mtc, lon):
+    # Given MTC and a longitude, compute local mars time
+    # Local time = MTC + (location's east longitude / 15) mars hours
+    lcf = float(lon) / 15
+    local_time = mtc + lcf
+    local_time = math.mod(local_time, 24)
+    return local_time
+
+def time_on_mars(lon):
+    # Computes current MSD and MTC
     # Math courtesy of marsclock.com
     t0 = time.from_timestamp(0)
     t1 = time.now()
@@ -27,49 +37,39 @@ def time_on_mars():
     jd2 = jd1 + (37 + 32.184) / 86400
     dtj2k = jd2 - 2451545
     msd = (((dtj2k - 4.5) / 1.027491252) + 44796.0 - 0.00096)
-    c1 = (24 * msd)
-    mtc = math.mod(c1, 24)
-    return (msd, mtc)
+    mtc = (24 * msd)  #aka C1
 
-def hours_to_hms(decimal_hours, colons):
+    # Apply offset to MTC to get our local time
+    lmt = mtc_location_offset(mtc, lon)
+    return (msd, lmt)
+
+def hours_to_hms(decimal_hours):
+    # Convert decimal hours to hr:min:sec notation
     total_seconds = int(decimal_hours * 3600)  # Convert hours to seconds
     hours = total_seconds / 3600
     minutes = math.mod(total_seconds, 3600) // 60
     seconds = math.mod(total_seconds, 60)
-
     hours_str = str(hours)
     minutes_str = str(minutes)
     seconds_str = str(seconds)
 
-    # Add zero padding
-    #if hours < 10:
-    #  hours_str = "0" + hours_str
+    # Add zero padding to mins & secs
     if minutes < 10:
         minutes_str = "0" + minutes_str
     if seconds < 10:
         seconds_str = "0" + seconds_str
-
     hours_str = hours_str.rsplit(".")[0]
     minutes_str = minutes_str.rsplit(".")[0]
     seconds_str = seconds_str.rsplit(".")[0]
+    return hours_str + ":" + minutes_str
 
-    if (colons):
-        return hours_str + ":" + minutes_str
-        #return hours_str + ":" + minutes_str + ":" + seconds_str
-
+def mars_dt_strs(lon):
+    # Generates final MSD and Local Mars Time strings
+    (msd, lmt) = time_on_mars(lon)
+    if lon == "0.0":
+        marstime = str(hours_to_hms(lmt)) + " MTC"
     else:
-        return hours_str + " " + minutes_str
-        #return hours_str + " " + minutes_str + " " + seconds_str
-
-def mars_dt_strs(colons):
-    # Get current MSD and MTC
-    (msd, mtc) = time_on_mars()
-
-    # Prettify MTC
-    if (colons):
-        marstime = str(hours_to_hms(mtc, 1)) + " MTC"
-    else:
-        marstime = str(hours_to_hms(mtc, 0)) + " MTC"
+        marstime = str(hours_to_hms(lmt))
 
     # Strip decimal from Sols
     marssol = str(msd)
@@ -77,9 +77,44 @@ def mars_dt_strs(colons):
     marssol = "sol " + marssol
     return marssol, marstime
 
+def render_locname(lon):
+    locnames = {
+        "0.0": "Airy-0",
+        "16.70": "Schiap- arelli",
+        "33.30": "Pathfinder",
+        "70.5": "Hellas Basin",
+        "77.43": "Percy",
+        "109.7": "Tianwen-1",
+        "134.26": "Viking 2",
+        "137.38": "Curiosity",
+        "226.20": "Olympus Mons",
+        "312.05": "Viking 1",
+        "339.26": "Acidalia Planitia",
+        "350.54": "Cydonia",
+    }
+    return locnames[lon]
+
 def main(config):
-    (marssol, marstime) = mars_dt_strs(1)
-    showsol = config.bool("showsol", DEFAULT_SHOWSOL)
+    # Pull config values from schema
+    secondline = config.get("secondline")
+    if secondline == "showlocation":
+        showloc = True
+        showsol = False
+    elif secondline == "showsol":
+        showloc = False
+        showsol = True
+    elif secondline == "shownone":
+        showloc = False
+        showsol = False
+    else:
+        showloc = DEFAULT_SHOWLOC
+        showsol = DEFAULT_SHOWSOL
+    lon = config.get("location", "0.0")
+
+    # Compute local sol & time
+    (marssol, marstime) = mars_dt_strs(lon)
+    locname = render_locname(lon)
+
     if (showsol):
         clockblock = [
             render.Text(
@@ -91,9 +126,27 @@ def main(config):
                 width = 1,
                 color = "#000",
             ),
-            render.Text(
+            render.WrappedText(
                 content = marssol,
                 font = "tom-thumb",
+                align = "right",
+            ),
+        ]
+    elif (showloc):
+        clockblock = [
+            render.Text(
+                content = marstime,
+                font = "tb-8",
+            ),
+            render.Box(
+                height = 2,
+                width = 1,
+                color = "#000",
+            ),
+            render.WrappedText(
+                content = locname,
+                font = "tom-thumb",
+                align = "right",
             ),
         ]
     else:
@@ -106,38 +159,126 @@ def main(config):
 
     return render.Root(
         delay = 500,
-        child = render.Box(
-            render.Row(
-                expanded = True,
-                main_align = "space_evenly",
-                cross_align = "center",
-                children = [
-                    render.Column(
-                        children = [
-                            render.Image(src = MARS_ICON),
-                        ],
-                    ),
-                    render.Column(
-                        expanded = True,
-                        main_align = "center",
-                        cross_align = "end",
-                        children = clockblock,
-                    ),
-                ],
-            ),
+        child = render.Column(
+            expanded = True,
+            main_align = "space_evenly",
+            children = [
+                render.Row(
+                    expanded = True,
+                    main_align = "space_evenly",
+                    cross_align = "center",
+                    children = [
+                        render.Column(
+                            children = [
+                                render.Row(
+                                    main_align = "space_evenly",
+                                    cross_align = "center",
+                                    children = [
+                                        render.Image(src = MARS_ICON),
+                                        render.Box(
+                                            width = 1,
+                                            color = "#000",
+                                        ),
+                                    ],
+                                ),
+                            ],
+                        ),
+                        render.Column(
+                            main_align = "space_evenly",
+                            cross_align = "end",
+                            children = clockblock,
+                        ),
+                    ],
+                ),
+            ],
         ),
     )
 
 def get_schema():
+    locations = [
+        schema.Option(
+            display = "Mars Coordinated Time",
+            value = "0.0",
+        ),
+        schema.Option(
+            display = "Acidalia Planitia (The Martian - Ares III)",
+            value = "339.26",
+        ),
+        schema.Option(
+            display = "Curiosity Rover (2012)",
+            value = "137.38",
+        ),
+        schema.Option(
+            display = "Cydonia (The Face)",
+            value = "350.54",
+        ),
+        schema.Option(
+            display = "Hellas Basin",
+            value = "70.5",
+        ),
+        schema.Option(
+            display = "Mars Pathfinder (1997)",
+            value = "33.30",
+        ),
+        schema.Option(
+            display = "Olympus Mons",
+            value = "226.20",
+        ),
+        schema.Option(
+            display = "Perseverance Rover (2021)",
+            value = "77.43",
+        ),
+        schema.Option(
+            display = "Schiaparelli Crater (The Martian - Ares IV)",
+            value = "16.70",
+        ),
+        schema.Option(
+            display = "Tianwen-1 (2021)",
+            value = "109.7",
+        ),
+        schema.Option(
+            display = "Viking 1 (1976)",
+            value = "312.05",
+        ),
+        schema.Option(
+            display = "Viking 2 (1976)",
+            value = "134.26",
+        ),
+    ]
+
+    secondlines = [
+        schema.Option(
+            display = "Location",
+            value = "showlocation",
+        ),
+        schema.Option(
+            display = "Mars Sol Date",
+            value = "showsol",
+        ),
+        schema.Option(
+            display = "None",
+            value = "shownone",
+        ),
+    ]
+
     return schema.Schema(
         version = "1",
         fields = [
-            schema.Toggle(
-                id = "showsol",
-                name = "Show Sols",
-                desc = "Display current Mars Sol Date below the clock",
-                icon = "calendar",
-                default = True,
+            schema.Dropdown(
+                id = "location",
+                name = "Location on Mars",
+                desc = "Show the time on Mars at this location",
+                icon = "locationCrosshairs",
+                default = locations[0].value,
+                options = locations,
+            ),
+            schema.Dropdown(
+                id = "secondline",
+                name = "Show below clock",
+                desc = "Show the location or Mars Sol Date below the clock",
+                icon = "a",
+                default = secondlines[0].value,
+                options = secondlines,
             ),
         ],
     )


### PR DESCRIPTION
# Description
You can now choose from one of 12 locations on Mars, and toggle between location or sol as your optional second line.

Minor code cleanup.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 3fa8723</samp>

### Summary
🌎🛠️📈

<!--
1.  🌎 - This emoji represents the new feature of showing the local time on Mars at a specific location, which is related to the concept of geography and different time zones on Earth and Mars.
2.  🛠️ - This emoji represents the added options to customize the Mars clock app, which is related to the concept of tools and settings that users can adjust to their preferences.
3.  📈 - This emoji represents the simplification and improvement of some functions and components in the `mars_clock.star` file, which is related to the concept of performance and optimization of the app.
-->
Added customization options and improved functionality for the Mars clock app. Users can now select a location on Mars and choose what to display below the clock, either the location name or the Mars Sol Date. The `mars_clock.star` file was refactored and simplified, and the `desc` field in the `manifest.yaml` file was updated accordingly.

> _Sing, O Muse, of the skillful coder who updated the app_
> _That shows the time on Mars, the red and rugged planet,_
> _Where the brave explorers roam and the rovers scan the land._
> _He added options to the `manifest.yaml` and the `mars_clock.star`,_

### Walkthrough
*  Add options to show local time on Mars at a specific location and choose between different second line displays ([link](https://github.com/tidbyt/community/pull/2081/files?diff=unified&w=0#diff-eb4337ead0cdfb980279d027b1a3a7b02d2e575aa48b496ca0ce3ae10fe0d0bcL5-R8), [link](https://github.com/tidbyt/community/pull/2081/files?diff=unified&w=0#diff-028278a981d80f3c6bb03e8c84bd27d77a5935255b48a867fa70ebd03e55dda3L14-R29), [link](https://github.com/tidbyt/community/pull/2081/files?diff=unified&w=0#diff-028278a981d80f3c6bb03e8c84bd27d77a5935255b48a867fa70ebd03e55dda3L30-R73), [link](https://github.com/tidbyt/community/pull/2081/files?diff=unified&w=0#diff-028278a981d80f3c6bb03e8c84bd27d77a5935255b48a867fa70ebd03e55dda3L80-R117), [link](https://github.com/tidbyt/community/pull/2081/files?diff=unified&w=0#diff-028278a981d80f3c6bb03e8c84bd27d77a5935255b48a867fa70ebd03e55dda3L94-R151), [link](https://github.com/tidbyt/community/pull/2081/files?diff=unified&w=0#diff-028278a981d80f3c6bb03e8c84bd27d77a5935255b48a867fa70ebd03e55dda3L109-R282))
  - Define constants for default values of second line and location fields in `mars_clock.star` ([link](https://github.com/tidbyt/community/pull/2081/files?diff=unified&w=0#diff-028278a981d80f3c6bb03e8c84bd27d77a5935255b48a867fa70ebd03e55dda3L14-R29))
  - Implement `mtc_location_offset` function to compute local Mars time from Mars Coordinated Time and longitude ([link](https://github.com/tidbyt/community/pull/2081/files?diff=unified&w=0#diff-028278a981d80f3c6bb03e8c84bd27d77a5935255b48a867fa70ebd03e55dda3L14-R29))
  - Modify `time_on_mars` function to take longitude argument and use `mtc_location_offset` function ([link](https://github.com/tidbyt/community/pull/2081/files?diff=unified&w=0#diff-028278a981d80f3c6bb03e8c84bd27d77a5935255b48a867fa70ebd03e55dda3L14-R29))
  - Implement `render_locname` function to return display name of location from longitude using predefined options ([link](https://github.com/tidbyt/community/pull/2081/files?diff=unified&w=0#diff-028278a981d80f3c6bb03e8c84bd27d77a5935255b48a867fa70ebd03e55dda3L30-R73))
  - Modify `mars_dt_strs` function to take longitude argument and pass it to `time_on_mars` function ([link](https://github.com/tidbyt/community/pull/2081/files?diff=unified&w=0#diff-028278a981d80f3c6bb03e8c84bd27d77a5935255b48a867fa70ebd03e55dda3L30-R73))
  - Modify `main` function to use `get` method of config object to access values of `secondline` and `location` fields from schema ([link](https://github.com/tidbyt/community/pull/2081/files?diff=unified&w=0#diff-028278a981d80f3c6bb03e8c84bd27d77a5935255b48a867fa70ebd03e55dda3L80-R117))
  - Set `showloc` and `showsol` variables according to value of `secondline` field ([link](https://github.com/tidbyt/community/pull/2081/files?diff=unified&w=0#diff-028278a981d80f3c6bb03e8c84bd27d77a5935255b48a867fa70ebd03e55dda3L80-R117))
  - Set `lon` variable according to value of `location` field ([link](https://github.com/tidbyt/community/pull/2081/files?diff=unified&w=0#diff-028278a981d80f3c6bb03e8c84bd27d77a5935255b48a867fa70ebd03e55dda3L80-R117))
  - Set `locname` variable by calling `render_locname` function with `lon` argument ([link](https://github.com/tidbyt/community/pull/2081/files?diff=unified&w=0#diff-028278a981d80f3c6bb03e8c84bd27d77a5935255b48a867fa70ebd03e55dda3L80-R117))
  - Modify `clockblock` variable to include conditional branch for showing location name below clock using `render.WrappedText` component with `align` attribute set to "right" ([link](https://github.com/tidbyt/community/pull/2081/files?diff=unified&w=0#diff-028278a981d80f3c6bb03e8c84bd27d77a5935255b48a867fa70ebd03e55dda3L80-R117))
  - Modify `render.Root` component to use `render.Column` as child instead of `render.Box` and add `render.Box` with width of 1 and color of "#000" between Mars icon and clockblock, creating vertical separator ([link](https://github.com/tidbyt/community/pull/2081/files?diff=unified&w=0#diff-028278a981d80f3c6bb03e8c84bd27d77a5935255b48a867fa70ebd03e55dda3L94-R151))
  - Replace `render.Text` component for showing Mars Sol Date with `render.WrappedText` component with `align` attribute set to "right" ([link](https://github.com/tidbyt/community/pull/2081/files?diff=unified&w=0#diff-028278a981d80f3c6bb03e8c84bd27d77a5935255b48a867fa70ebd03e55dda3L94-R151))
  - Modify `get_schema` function to replace `schema.Toggle` field for showing Mars Sol Date with two `schema.Dropdown` fields for choosing location and second line display ([link](https://github.com/tidbyt/community/pull/2081/files?diff=unified&w=0#diff-028278a981d80f3c6bb03e8c84bd27d77a5935255b48a867fa70ebd03e55dda3L109-R282))
  - Define `locations` and `secondlines` variables as lists of `schema.Option` objects with display names and values for each option ([link](https://github.com/tidbyt/community/pull/2081/files?diff=unified&w=0#diff-028278a981d80f3c6bb03e8c84bd27d77a5935255b48a867fa70ebd03e55dda3L109-R282))
  - Set `icon` and `default` attributes for each `schema.Dropdown` field and `options` attribute to corresponding list of options ([link](https://github.com/tidbyt/community/pull/2081/files?diff=unified&w=0#diff-028278a981d80f3c6bb03e8c84bd27d77a5935255b48a867fa70ebd03e55dda3L109-R282))
* Simplify `hours_to_hms` function to remove `colons` argument and always use colons to separate hours, minutes and seconds ([link](https://github.com/tidbyt/community/pull/2081/files?diff=unified&w=0#diff-028278a981d80f3c6bb03e8c84bd27d77a5935255b48a867fa70ebd03e55dda3L30-R73))


