### PR TITLE
adelaidemetro: add default text value

### DIFF
--- a/apps/adelaidemetro/adelaide_metro.star
+++ b/apps/adelaidemetro/adelaide_metro.star
@@ -1342,6 +1342,7 @@ def MoreOptions(TrainOrTramOrBus):
                 name = "Bus Stop ID",
                 desc = "Enter the Stop ID",
                 icon = "bus",
+                default = "",
             ),
         ]
     return None


### PR DESCRIPTION
# Description
Replace this with a description of your changes.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 99ad307</samp>

### Summary
🚏🛠️🚫

<!--
1.  🚏 This emoji represents a bus stop, which is the main feature of the app and the parameter that was modified.
2.  🛠️ This emoji represents a wrench or a tool, which implies that the code was added to fix a bug or improve the functionality of the app.
3.  🚫 This emoji represents a prohibition sign, which suggests that the code was added to prevent an error or a crash from occurring.
-->
Added a default value for the `stop` parameter in the Adelaide Metro app. This improves the app's error handling and user experience.

> _`stop` parameter_
> _gets a default empty string_
> _no more winter crash_

### Walkthrough
* Set default value of `stop` parameter to empty string to avoid app crash ([link](https://github.com/tidbyt/community/pull/2091/files?diff=unified&w=0#diff-459d339907c7789deca38209515953894ac4b6c896c7d3271fc1a74462a09c5bR1345))


