### PR TITLE
Bug fix for Scopes

### DIFF
--- a/apps/meeting_stats/meeting_stats.star
+++ b/apps/meeting_stats/meeting_stats.star
@@ -444,7 +444,8 @@ def get_schema():
                 client_id = (MSFT_CLIENT_ID or CLIENT_ID_DEFAULT),
                 authorization_endpoint = MSFT_EVENTFETCH_AUTH_ENDPOINT,
                 scopes = [
-                    "offline_access%20Calendars.read",
+                    "offline_access",
+                    "Calendars.read",
                 ],
             ),
         ],


### PR DESCRIPTION
# Description
Updates Scopes to match Outlook calendar app

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 36af9ef</samp>

### Summary
🛠️🗓️🔒

<!--
1.  🛠️ - This emoji represents a wrench or a tool, and can be used to indicate a fix or an improvement to the code or functionality of the app. In this case, the change to use a list of strings for the scopes parameter is a fix for a potential bug or inconsistency with the OAuth2 library.
2.  🗓️ - This emoji represents a calendar, and can be used to indicate a feature or a dependency related to dates, events, or scheduling. In this case, the change affects the meeting_stats app, which fetches calendar events from Microsoft Graph API, so the calendar emoji is relevant to the app's domain and purpose.
3.  🔒 - This emoji represents a lock, and can be used to indicate a feature or a dependency related to security, authentication, or authorization. In this case, the change involves the scopes parameter, which defines the permissions that the app requests from the user when using the Microsoft OAuth2 client. The lock emoji can convey the importance of handling the scopes correctly and securely.
-->
Updated the meeting_stats app to use a list of scopes for Microsoft OAuth2 client. This improves compatibility with the OAuth2 library and Microsoft Graph API.

> _`scopes` now a list_
> _Avoids encoding troubles_
> _Winter of bugs thaws_

### Walkthrough
* Change scopes parameter for Microsoft OAuth2 client to use list of strings instead of single string ([link](https://github.com/tidbyt/community/pull/2094/files?diff=unified&w=0#diff-6374439dc71ae7f339bb20a0e8e2297551bd3da1cd4b81c9766f84a682105033L447-R448))


