### PR TITLE
Fix: Adelaide Metro

### DIFF
--- a/apps/adelaidemetro/adelaide_metro.star
+++ b/apps/adelaidemetro/adelaide_metro.star
@@ -32,6 +32,10 @@ Extended display time to 3 seconds
 
 v2.3
 Added default Bus Stop ID to prevent app freezing
+
+v2.3.1
+Removed lagging print comment
+Added default train station in Schema, removed in error from last update :(
 """
 
 load("encoding/json.star", "json")
@@ -55,7 +59,7 @@ def main(config):
     Display1 = []
 
     if TrainOrTramOrBus == "Tram":
-        SelectedStation = config.get("TramStationList", "17755")
+        SelectedStation = config.get("TramStationList", "18513")
 
     if TrainOrTramOrBus == "Bus":
         SelectedStation = config.get("BusStop", "13339")
@@ -67,7 +71,7 @@ def main(config):
         SelectedStation = AwayStops(SelectedStation)
 
     STOP_ID = str(SelectedStation)
-    print(STOP_ID)
+    #print(STOP_ID)
 
     NEXTSCHED_URL = NEXTSCHED1_URL + STOP_ID
     #print(NEXTSCHED_URL)
@@ -1316,6 +1320,7 @@ def MoreOptions(TrainOrTramOrBus):
                 name = "Train Station",
                 desc = "Choose your station",
                 icon = "train",
+                default = StationOptions[0].value,
                 options = StationOptions,
             ),
             schema.Toggle(
@@ -1334,7 +1339,7 @@ def MoreOptions(TrainOrTramOrBus):
                 name = "Tram Stop",
                 desc = "Choose your station",
                 icon = "trainTram",
-                default = TramStationOptions[0].value,
+                default = TramStationOptions[1].value,
                 options = TramStationOptions,
             ),
         ]


### PR DESCRIPTION
# Description
Removed lagging print comment
Added default train station in Schema, removed in error from last update :(

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e7e0f91</samp>

### Summary
🛠️🚊🗺️

<!--
1.  🛠️ - This emoji represents the improvement and fixing of the app functionality, such as adding comments, updating default station IDs, and removing a debug print statement.
2.  🚊 - This emoji represents the Adelaide Metro app domain, which is public transport and trains.
3.  🗺️ - This emoji represents the addition of default values for the schema options, which enhance the user experience and navigation of the app.
-->
Improve Adelaide Metro app by adding comments, updating defaults, and removing debug code. The app displays real-time public transport information for Adelaide, Australia.

> _Riding the rails of doom and despair_
> _We need an app that shows us the way_
> _`schema_options` and `station_IDs`_
> _We update them all and remove the `print`_

### Walkthrough
*  Add comment with version number and summary to `adelaide_metro.star` ([link](https://github.com/tidbyt/community/pull/2095/files?diff=unified&w=0#diff-459d339907c7789deca38209515953894ac4b6c896c7d3271fc1a74462a09c5bR35-R38))
*  Update default tram station ID to Victoria Square in `adelaide_metro.star` and schema ([link](https://github.com/tidbyt/community/pull/2095/files?diff=unified&w=0#diff-459d339907c7789deca38209515953894ac4b6c896c7d3271fc1a74462a09c5bL58-R62), [link](https://github.com/tidbyt/community/pull/2095/files?diff=unified&w=0#diff-459d339907c7789deca38209515953894ac4b6c896c7d3271fc1a74462a09c5bL1337-R1342))
*  Remove print statement for stop ID from `adelaide_metro.star` ([link](https://github.com/tidbyt/community/pull/2095/files?diff=unified&w=0#diff-459d339907c7789deca38209515953894ac4b6c896c7d3271fc1a74462a09c5bL70-R74))
*  Add default value for train station option in schema ([link](https://github.com/tidbyt/community/pull/2095/files?diff=unified&w=0#diff-459d339907c7789deca38209515953894ac4b6c896c7d3271fc1a74462a09c5bR1323))


