### PR TITLE
Added Copper to backend api as well as this app. Copper prices are de…

### DIFF
--- a/apps/goldpriceticker/goldpriceticker.star
+++ b/apps/goldpriceticker/goldpriceticker.star
@@ -21,6 +21,7 @@ PRECIOUS_METAL_NAMES = {
     "platinum": "Platnm",
     "palladium": "Palladm",
     "rhodium": "Rhodium",
+    "copper": "Copper",
 }
 
 timezone = "America/New_York"
@@ -42,7 +43,7 @@ def main(config):
     PRECIOUS_METAL = "gold"
 
     #Lets check the config to see if they passed a precious metal
-    if (config.str("metal") == "gold" or config.str("metal") == "silver" or config.str("metal") == "platinum" or config.str("metal") == "palladium" or config.str("metal") == "rhodium"):
+    if (config.str("metal") == "gold" or config.str("metal") == "silver" or config.str("metal") == "platinum" or config.str("metal") == "palladium" or config.str("metal") == "rhodium" or config.str("metal") == "copper"):
         PRECIOUS_METAL = config.str("metal")
 
     # Precious metal markets are open almost 24x5, so its hard to determine what a closing price is. However according to Kitco, its 5PM
@@ -328,6 +329,10 @@ def get_schema():
                     schema.Option(
                         display = "Rhodium",
                         value = "rhodium",
+                    ),
+                    schema.Option(
+                        display = "Copper",
+                        value = "copper",
                     ),
                 ],
                 default = "gold",


### PR DESCRIPTION
…livered to my api in ounces, but I convert it to pounds to conform with normal standard as well as reduce rounding errors

# Description
Replace this with a description of your changes.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 29bba20</samp>

### Summary
🪙🛠️🆕

<!--
1.  🪙 - This emoji represents a coin, which is often made of copper or other metals. It is a fitting symbol for adding copper as a new metal option for the app.
2.  🛠️ - This emoji represents a tool, which is another common use of copper and other metals. It also suggests the idea of updating or improving something, which is what this pull request does for the app.
3.  🆕 - This emoji represents something new, which is what copper is for the app. It also conveys a sense of excitement or novelty, which might attract users to try out the new feature.
-->
This pull request adds a new feature to the `goldpriceticker` app that allows users to choose copper as a precious metal option. It modifies the app code in `goldpriceticker.star` to support fetching and displaying the copper price on the Tidbyt device.

> _The price of copper rises in the night_
> _A new metal joins the `goldpriceticker` fight_
> _We update the `METALS` and the schema_
> _To display the copper on the Tidbyt_

### Walkthrough
*  Add copper as a new precious metal option for the app ([link](https://github.com/tidbyt/community/pull/2099/files?diff=unified&w=0#diff-8b78cb36c893ca6688bf7f166195a900a100f327d079f6a85d8778312e0c0862R24), [link](https://github.com/tidbyt/community/pull/2099/files?diff=unified&w=0#diff-8b78cb36c893ca6688bf7f166195a900a100f327d079f6a85d8778312e0c0862L45-R46), [link](https://github.com/tidbyt/community/pull/2099/files?diff=unified&w=0#diff-8b78cb36c893ca6688bf7f166195a900a100f327d079f6a85d8778312e0c0862R333-R336))


