### PR TITLE
Update: BBL Cricket

### DIFF
--- a/apps/bblcricket/bbl_cricket.star
+++ b/apps/bblcricket/bbl_cricket.star
@@ -13,6 +13,9 @@ Using team name instead of abbrevation for Team Score line
 
 v2.1.1
 Added handling for other delays in play
+
+v2.1.2
+Fixed 2nd innings display
 """
 
 load("encoding/json.star", "json")
@@ -286,7 +289,7 @@ def main(config):
                 T20_Status2 = "Overs: " + Overs
                 T20_Status3 = "Run Rate: " + CRR
                 T20_Status4 = "Req Rate: " + RRR
-            else:  # For any other situation - drinks or other delays
+            elif MatchStatus != "Live":  # For any other situation - drinks or other delays
                 T20_Status1 = MatchStatus
                 T20_Status2 = "Overs: " + Overs
                 T20_Status3 = "Run Rate: " + CRR


### PR DESCRIPTION
# Description
Live play during 2nd innings was not showing correct statuses

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 471cddc</samp>

### Summary
🐛📈📝

<!--
1.  🐛 - This emoji represents a bug fix, and can be used to indicate that the app no longer has an issue with the second innings score.
2.  📈 - This emoji represents an improvement or enhancement, and can be used to indicate that the app now has a more accurate match status display that reflects the current situation of the game.
3.  📝 - This emoji represents a documentation update, and can be used to indicate that the changelog and the version number of the app have been updated to reflect the latest changes.
-->
This pull request fixes a scoring bug and enhances the match status display in the `bblcricket` app for the Tidbyt device. It also updates the app's metadata in `bbl_cricket.star`.

> _`bblcricket` app_
> _bug fixed, status refined_
> _summer cheers abound_

### Walkthrough
*  Update changelog with new version and fix description ([link](https://github.com/tidbyt/community/pull/2107/files?diff=unified&w=0#diff-a6935863dc87806e246668a1bf154340d6aed869357b76791a7b49fd86d458abR16-R18))
*  Prevent showing "Live" match status when match is in a break or a delay ([link](https://github.com/tidbyt/community/pull/2107/files?diff=unified&w=0#diff-a6935863dc87806e246668a1bf154340d6aed869357b76791a7b49fd86d458abL289-R292))


