### PR TITLE
EPL App: Reverse home and away teams

### DIFF
--- a/apps/eplscores/eplscores.star
+++ b/apps/eplscores/eplscores.star
@@ -383,12 +383,12 @@ def main(config):
                                     children = [
                                         render.Column(
                                             children = [
-                                                render.Box(width = 64, height = 12, color = awayColor, child = render.Row(expanded = True, main_align = "start", cross_align = "center", children = [
-                                                    render.Image(awayLogo, width = 30, height = 30),
-                                                    render.Box(width = 34, height = 12, child = render.Text(content = homeScore, color = homeScoreColor, font = scoreFont)),
-                                                ])),
                                                 render.Box(width = 64, height = 12, color = homeColor, child = render.Row(expanded = True, main_align = "start", cross_align = "center", children = [
                                                     render.Image(homeLogo, width = 30, height = 30),
+                                                    render.Box(width = 34, height = 12, child = render.Text(content = homeScore, color = homeScoreColor, font = scoreFont)),
+                                                ])),
+                                                render.Box(width = 64, height = 12, color = awayColor, child = render.Row(expanded = True, main_align = "start", cross_align = "center", children = [
+                                                    render.Image(awayLogo, width = 30, height = 30),
                                                     render.Box(width = 34, height = 12, child = render.Text(content = awayScore, color = awayScoreColor, font = scoreFont)),
                                                 ])),
                                             ],

--- a/apps/eplscores/eplscores.star
+++ b/apps/eplscores/eplscores.star
@@ -244,13 +244,13 @@ def main(config):
                                 ),
                                 render.Column(
                                     children = [
-                                        render.Box(width = 64, height = 12, color = awayColor, child = render.Row(expanded = True, main_align = "start", cross_align = "center", children = [
-                                            render.Box(width = 40, height = 12, child = render.Text(content = get_team_name(awayTeamName), color = retroTextColor, font = retroFont)),
-                                            render.Box(width = 26, height = 12, child = render.Text(content = get_record(awayScore), color = retroTextColor, font = retroFont)),
-                                        ])),
                                         render.Box(width = 64, height = 12, color = homeColor, child = render.Row(expanded = True, main_align = "start", cross_align = "center", children = [
                                             render.Box(width = 40, height = 12, child = render.Text(content = get_team_name(homeTeamName), color = retroTextColor, font = retroFont)),
                                             render.Box(width = 26, height = 12, child = render.Text(content = get_record(homeScore), color = retroTextColor, font = retroFont)),
+                                        ])),
+                                        render.Box(width = 64, height = 12, color = awayColor, child = render.Row(expanded = True, main_align = "start", cross_align = "center", children = [
+                                            render.Box(width = 40, height = 12, child = render.Text(content = get_team_name(awayTeamName), color = retroTextColor, font = retroFont)),
+                                            render.Box(width = 26, height = 12, child = render.Text(content = get_record(awayScore), color = retroTextColor, font = retroFont)),
                                         ])),
                                     ],
                                 ),
@@ -282,15 +282,15 @@ def main(config):
                                     children = [
                                         render.Box(width = 64, height = 12, color = borderColor, child = render.Row(expanded = True, main_align = "start", cross_align = "center", children = [
                                             render.Box(width = 1, height = 10, color = borderColor),
-                                            render.Box(width = 31, height = 10, child = render.Box(width = 29, height = 10, color = backgroundColor, child = render.Text(content = away[:3].upper(), color = awayScoreColor, font = textFont))),
-                                            render.Box(width = 31, height = 10, child = render.Box(width = 29, height = 10, color = backgroundColor, child = render.Text(content = get_record(awayScore), color = awayScoreColor, font = scoreFont))),
+                                            render.Box(width = 31, height = 10, child = render.Box(width = 29, height = 10, color = backgroundColor, child = render.Text(content = home[:3].upper(), color = homeScoreColor, font = textFont))),
+                                            render.Box(width = 31, height = 10, child = render.Box(width = 29, height = 10, color = backgroundColor, child = render.Text(content = get_record(homeScore), color = homeScoreColor, font = scoreFont))),
                                             render.Box(width = 1, height = 10, color = borderColor),
                                         ])),
                                         render.Box(width = 64, height = 1, color = borderColor),
                                         render.Box(width = 64, height = 10, color = borderColor, child = render.Row(expanded = True, main_align = "start", cross_align = "center", children = [
                                             render.Box(width = 1, height = 10, color = borderColor),
-                                            render.Box(width = 31, height = 10, child = render.Box(width = 29, height = 10, color = backgroundColor, child = render.Text(content = home[:3].upper(), color = homeScoreColor, font = textFont))),
-                                            render.Box(width = 31, height = 10, child = render.Box(width = 29, height = 10, color = backgroundColor, child = render.Text(content = get_record(homeScore), color = homeScoreColor, font = scoreFont))),
+                                            render.Box(width = 31, height = 10, child = render.Box(width = 29, height = 10, color = backgroundColor, child = render.Text(content = away[:3].upper(), color = awayScoreColor, font = textFont))),
+                                            render.Box(width = 31, height = 10, child = render.Box(width = 29, height = 10, color = backgroundColor, child = render.Text(content = get_record(awayScore), color = awayScoreColor, font = scoreFont))),
                                             render.Box(width = 1, height = 10, color = borderColor),
                                         ])),
                                     ],
@@ -326,17 +326,6 @@ def main(config):
                                     children = [
                                         render.Row(
                                             children = [
-                                                render.Box(width = 32, height = 24, color = awayColor, child = render.Row(expanded = True, main_align = "start", cross_align = "center", children = [
-                                                    render.Column(expanded = True, main_align = "start", cross_align = "center", children = [
-                                                        render.Stack(children = [
-                                                            render.Box(width = 32, height = 24, child = render.Image(awayLogo, width = 32, height = 32)),
-                                                            render.Column(expanded = True, main_align = "start", cross_align = "center", children = [
-                                                                render.Box(width = 32, height = 16),
-                                                                render.Box(width = 32, height = 8, color = "#000a", child = render.Text(content = awayScore, color = awayScoreColor, font = scoreFont)),
-                                                            ]),
-                                                        ]),
-                                                    ]),
-                                                ])),
                                                 render.Box(width = 32, height = 24, color = homeColor, child = render.Row(expanded = True, main_align = "start", cross_align = "center", children = [
                                                     render.Column(expanded = True, main_align = "start", cross_align = "center", children = [
                                                         render.Stack(children = [
@@ -344,6 +333,17 @@ def main(config):
                                                             render.Column(expanded = True, main_align = "start", cross_align = "center", children = [
                                                                 render.Box(width = 32, height = 16),
                                                                 render.Box(width = 32, height = 8, color = "#000a", child = render.Text(content = homeScore, color = homeScoreColor, font = scoreFont)),
+                                                            ]),
+                                                        ]),
+                                                    ]),
+                                                ])),
+                                                render.Box(width = 32, height = 24, color = awayColor, child = render.Row(expanded = True, main_align = "start", cross_align = "center", children = [
+                                                    render.Column(expanded = True, main_align = "start", cross_align = "center", children = [
+                                                        render.Stack(children = [
+                                                            render.Box(width = 32, height = 24, child = render.Image(awayLogo, width = 32, height = 32)),
+                                                            render.Column(expanded = True, main_align = "start", cross_align = "center", children = [
+                                                                render.Box(width = 32, height = 16),
+                                                                render.Box(width = 32, height = 8, color = "#000a", child = render.Text(content = awayScore, color = awayScoreColor, font = scoreFont)),
                                                             ]),
                                                         ]),
                                                     ]),
@@ -385,11 +385,11 @@ def main(config):
                                             children = [
                                                 render.Box(width = 64, height = 12, color = awayColor, child = render.Row(expanded = True, main_align = "start", cross_align = "center", children = [
                                                     render.Image(awayLogo, width = 30, height = 30),
-                                                    render.Box(width = 34, height = 12, child = render.Text(content = awayScore, color = awayScoreColor, font = scoreFont)),
+                                                    render.Box(width = 34, height = 12, child = render.Text(content = homeScore, color = homeScoreColor, font = scoreFont)),
                                                 ])),
                                                 render.Box(width = 64, height = 12, color = homeColor, child = render.Row(expanded = True, main_align = "start", cross_align = "center", children = [
                                                     render.Image(homeLogo, width = 30, height = 30),
-                                                    render.Box(width = 34, height = 12, child = render.Text(content = homeScore, color = homeScoreColor, font = scoreFont)),
+                                                    render.Box(width = 34, height = 12, child = render.Text(content = awayScore, color = awayScoreColor, font = scoreFont)),
                                                 ])),
                                             ],
                                         ),
@@ -427,14 +427,14 @@ def main(config):
                                         render.Column(
                                             children = [
                                                 render.Box(width = 64, height = 12, color = "#222", child = render.Row(expanded = True, main_align = "start", cross_align = "center", children = [
-                                                    render.Box(width = 16, height = 16, child = render.Image(awayLogo, width = awayLogoSize, height = awayLogoSize)),
-                                                    render.Box(width = 24, height = 12, child = render.Text(content = away[:3], color = awayScoreColor, font = textFont)),
-                                                    render.Box(width = 24, height = 12, child = render.Text(content = get_record(awayScore), color = awayScoreColor, font = scoreFont)),
-                                                ])),
-                                                render.Box(width = 64, height = 12, color = "#222", child = render.Row(expanded = True, main_align = "start", cross_align = "center", children = [
                                                     render.Box(width = 16, height = 16, child = render.Image(homeLogo, width = homeLogoSize, height = homeLogoSize)),
                                                     render.Box(width = 24, height = 12, child = render.Text(content = home[:3], color = homeScoreColor, font = textFont)),
                                                     render.Box(width = 24, height = 12, child = render.Text(content = get_record(homeScore), color = homeScoreColor, font = scoreFont)),
+                                                ])),
+                                                render.Box(width = 64, height = 12, color = "#222", child = render.Row(expanded = True, main_align = "start", cross_align = "center", children = [
+                                                    render.Box(width = 16, height = 16, child = render.Image(awayLogo, width = awayLogoSize, height = awayLogoSize)),
+                                                    render.Box(width = 24, height = 12, child = render.Text(content = away[:3], color = awayScoreColor, font = textFont)),
+                                                    render.Box(width = 24, height = 12, child = render.Text(content = get_record(awayScore), color = awayScoreColor, font = scoreFont)),
                                                 ])),
                                             ],
                                         ),
@@ -471,15 +471,15 @@ def main(config):
                                     children = [
                                         render.Column(
                                             children = [
-                                                render.Box(width = 64, height = 12, color = awayColor, child = render.Row(expanded = True, main_align = "start", cross_align = "center", children = [
-                                                    render.Box(width = 16, height = 16, child = render.Image(awayLogo, width = awayLogoSize, height = awayLogoSize)),
-                                                    render.Box(width = 24, height = 12, child = render.Text(content = away[:3], color = awayScoreColor, font = textFont)),
-                                                    render.Box(width = 24, height = 12, child = render.Text(content = get_record(awayScore), color = awayScoreColor, font = scoreFont)),
-                                                ])),
                                                 render.Box(width = 64, height = 12, color = homeColor, child = render.Row(expanded = True, main_align = "start", cross_align = "center", children = [
                                                     render.Box(width = 16, height = 16, child = render.Image(homeLogo, width = homeLogoSize, height = homeLogoSize)),
                                                     render.Box(width = 24, height = 12, child = render.Text(content = home[:3], color = homeScoreColor, font = textFont)),
                                                     render.Box(width = 24, height = 12, child = render.Text(content = get_record(homeScore), color = homeScoreColor, font = scoreFont)),
+                                                ])),
+                                                render.Box(width = 64, height = 12, color = awayColor, child = render.Row(expanded = True, main_align = "start", cross_align = "center", children = [
+                                                    render.Box(width = 16, height = 16, child = render.Image(awayLogo, width = awayLogoSize, height = awayLogoSize)),
+                                                    render.Box(width = 24, height = 12, child = render.Text(content = away[:3], color = awayScoreColor, font = textFont)),
+                                                    render.Box(width = 24, height = 12, child = render.Text(content = get_record(awayScore), color = awayScoreColor, font = scoreFont)),
                                                 ])),
                                             ],
                                         ),


### PR DESCRIPTION
# Description
Home team is listed before away team for non North American sports.

Sources: https://en.wikipedia.org/wiki/Home_(sports)#Miscellaneous, https://www.espn.com/soccer/scoreboard/_/date/20231215/league/eng.1, https://www.espn.com/soccer/scoreboard/_/date/20231210/league/eng.1 (notice how order of these scores matches test plan)

# Test Plan

Render pre-game and post-game scoreboards with change.

## Pre-game:
- retro
<img src="https://github.com/tidbyt/community/assets/1836021/6ca98e82-560d-459c-addc-10d2586700f1" width=40%>

- stadium
<img src="https://github.com/tidbyt/community/assets/1836021/59c14a41-145f-4a7c-9280-d803a3b628f6" width=40%>

- horizontal
<img src="https://github.com/tidbyt/community/assets/1836021/91e25a26-f4af-4ea5-ae7a-7a56f81f4f45" width=40%>

- logos
<img src="https://github.com/tidbyt/community/assets/1836021/9f51d3fa-a22f-4d42-91b2-ba1ecf4c1b26" width=40%>

- black
<img src="https://github.com/tidbyt/community/assets/1836021/a61db250-0d7c-4af2-89bd-39c75a854732" width=40%>

- colors
<img src="https://github.com/tidbyt/community/assets/1836021/63f03333-10e0-4133-a3fe-82e186172d62" width=40%>

## Post-Game (w/ scores)
- retro
<img src="https://github.com/tidbyt/community/assets/1836021/f0480a64-d1ef-4cf8-ae35-1b50aee04970" width=40%>

- stadium
<img src="https://github.com/tidbyt/community/assets/1836021/88ffd6e0-499e-4c85-8d30-16474580a4cc" width=40%>

- horizontal
<img src="https://github.com/tidbyt/community/assets/1836021/2e271c8f-2774-4baa-82dc-6b41e8925072" width=40%>

- logos
<img src="https://github.com/tidbyt/community/assets/1836021/1e656afc-f03c-42c1-9d00-03cbf64a482e" width=40%>

- black
<img src="https://github.com/tidbyt/community/assets/1836021/efc01ea9-669c-4f5b-a55a-32628ffe68fa" width=40%>

- colors
<img src="https://github.com/tidbyt/community/assets/1836021/d0ab9c3e-310a-40ec-805d-9063d58bd04e" width=40%>


# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7fd9d73</samp>

### Summary
🏠🔄➕

<!--
1.  🏠 - This emoji represents the home team, which is now shown first in various layouts of the app. It also conveys the idea of playing at home, which is an advantage for some teams.
2.  🔄 - This emoji represents the change of order, which swaps the positions of the home and away teams in the app. It also suggests the idea of switching or reversing something, which is what this pull request does to the original layout.
3.  ➕ - This emoji represents the addition of a new row to the minimal layout, which displays the home team in the bottom right corner. It also conveys the idea of increasing or expanding something, which is what this pull request does to the minimal layout.
-->
This pull request improves the `eplscores` app by following the standard order of showing the home team first in all layouts. It also adds a new row to the minimal layout to show the home team name.

> _The order of the teams has been reversed_
> _To match the ancient soccer curse_
> _The home team now appears below_
> _In the `minimal` layout of `eplscores`_

### Walkthrough
*  Swap the order of the home and away teams in all layouts to match the convention of most sports scoreboards ([link](https://github.com/tidbyt/community/pull/2108/files?diff=unified&w=0#diff-5abab976052309554d1a3705dea45ee4d078eac82af370311716f9275354a9e5L247-R254), [link](https://github.com/tidbyt/community/pull/2108/files?diff=unified&w=0#diff-5abab976052309554d1a3705dea45ee4d078eac82af370311716f9275354a9e5L285-R286), [link](https://github.com/tidbyt/community/pull/2108/files?diff=unified&w=0#diff-5abab976052309554d1a3705dea45ee4d078eac82af370311716f9275354a9e5L292-R293), [link](https://github.com/tidbyt/community/pull/2108/files?diff=unified&w=0#diff-5abab976052309554d1a3705dea45ee4d078eac82af370311716f9275354a9e5L329-R346), [link](https://github.com/tidbyt/community/pull/2108/files?diff=unified&w=0#diff-5abab976052309554d1a3705dea45ee4d078eac82af370311716f9275354a9e5L386-R393), [link](https://github.com/tidbyt/community/pull/2108/files?diff=unified&w=0#diff-5abab976052309554d1a3705dea45ee4d078eac82af370311716f9275354a9e5L430-R438))
* Add a new row to display the home team on the bottom right corner of the screen in the minimal layout ([link](https://github.com/tidbyt/community/pull/2108/files?diff=unified&w=0#diff-5abab976052309554d1a3705dea45ee4d078eac82af370311716f9275354a9e5R474-R478))
* Remove the old row that displayed the home team on the top right corner of the screen in the minimal layout ([link](https://github.com/tidbyt/community/pull/2108/files?diff=unified&w=0#diff-5abab976052309554d1a3705dea45ee4d078eac82af370311716f9275354a9e5L479-L483))


