### PR TITLE
Sports Scores: update nhl scores to show OT and SO.

### DIFF
--- a/apps/sportsscores/sports_scores.star
+++ b/apps/sportsscores/sports_scores.star
@@ -6,7 +6,7 @@ Author: rs7q5
 """
 #sports_scores.star
 #Created 20220220 RIS
-#Last Modified 20231125 RIS
+#Last Modified 20231213 RIS
 
 load("http.star", "http")
 load("humanize.star", "humanize")
@@ -633,14 +633,17 @@ def get_nhlgames(today_str):
             if game["periodDescriptor"].get("otPeriods"):
                 periodType = str(int(game["periodDescriptor"]["otPeriods"])) + periodType
 
-            # period_num = int(game["period"])
+            #there is probably a better way to do this, but works for now as a quick patch
+            period_num = int(game["period"])
+            if period_num > 3:
+                period = periodType
 
             period_T = game["clock"]["timeRemaining"]
             if game["clock"]["inIntermission"]:
                 period_T = "END"
 
             #if period_T == "Final":
-            if status == "OFF":
+            if status in ["OFF", "FINAL"]:
                 if period == "3rd":
                     status_txt = "F"
                 else:
@@ -653,6 +656,8 @@ def get_nhlgames(today_str):
                     stats_tmp["highlight"] = "home"
                 else:  #no ties in hockey, but here for completion
                     pass  #this case should never happen as ties in hockey aren't a thing, but here for completion
+
+                #elif period>4:
             else:
                 status_txt = period_T + "/" + period  #switch status and period here so time doesn't get cutoff
         else:  #this is a safety net


### PR DESCRIPTION


# Description
Hopefully this should not break anything else. will watch and see.

# Copilot
<!-- please don't change the line below -->
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 45fced6</samp>

### Summary
🐛🔄💡

<!--
1.  🐛 for fixing a bug
2.  🔄 for updating logic
3.  💡 for adding a comment for a potential enhancement
-->
Fix bug and improve logic for `sportsscores` app. The app now correctly shows overtime and shootout periods and the final status of the game. A comment suggests a possible feature to add.

> _Oh we're the crew of the `sportsscores` app_
> _And we work hard to fix every bug and gap_
> _We've sorted out the overtime and shootout display_
> _And we've improved the logic for the final game day_

### Walkthrough
*  Handle overtime and shootout periods for hockey games ([link](https://github.com/tidbyt/community/pull/2111/files?diff=unified&w=0#diff-9ab92a093815db2f6e6752154b1d17f3fe13047fd2892a6680cfcc14bc626980L636-R639), [link](https://github.com/tidbyt/community/pull/2111/files?diff=unified&w=0#diff-9ab92a093815db2f6e6752154b1d17f3fe13047fd2892a6680cfcc14bc626980L643-R646), [link](https://github.com/tidbyt/community/pull/2111/files?diff=unified&w=0#diff-9ab92a093815db2f6e6752154b1d17f3fe13047fd2892a6680cfcc14bc626980R659-R660))
* Update last modified date in `sports_scores.star` ([link](https://github.com/tidbyt/community/pull/2111/files?diff=unified&w=0#diff-9ab92a093815db2f6e6752154b1d17f3fe13047fd2892a6680cfcc14bc626980L9-R9))


