### PR TITLE
Fix: make hieroglyphs random again

### DIFF
--- a/apps/hieroglyphs/hieroglyphs.star
+++ b/apps/hieroglyphs/hieroglyphs.star
@@ -27,8 +27,6 @@ def main():
     index = int(h, 16) % len(GLYPHS)
     key = sorted(GLYPHS.keys())[index]
 
-    key = "W25"
-
     glyph = GLYPHS[key]
 
     texts = [


### PR DESCRIPTION
# Description
Ooops, I added a hardcoded override to make some interesting screenshots. Forgot to take it out. So it's always showing the same one. Easily fixed.

# Copilot
<!-- please don't change the line below -->
copilot:all
