### PR TITLE
Update: MARTA Map http cache

### DIFF
--- a/apps/martamap/marta_map.star
+++ b/apps/martamap/marta_map.star
@@ -15,7 +15,7 @@ DEFAULT_ORIENTATION_BOOL = False  #Default to horizontal
 DEFAULT_ARRIVALS = True
 DEFAULT_STATION = "Lindbergh Center"
 DEFAULT_SCROLL = True
-# DEAFULT_DIRECTION = None
+DEAFULT_DIRECTION = "None"
 
 # FONT = "CG-pixel-3x5-mono"
 FONT = "CG-pixel-4x5-mono"
@@ -71,7 +71,7 @@ def main(config):
 
 def get_schema():
     station_options = get_station_list_options()
-    # direction_options = get_direction_list_options()
+    direction_options = get_direction_list_options()
 
     return schema.Schema(
         version = "1",
@@ -105,14 +105,14 @@ def get_schema():
                 icon = "toggleOn",
                 default = True,
             ),
-            # schema.Dropdown(
-            #     id = "direction",
-            #     name = "Filter Direction",
-            #     desc = "Filter the arrivals to one cardinal direction.",
-            #     icon = "compass",
-            #     default = direction_options[0].value,
-            #     options = direction_options,
-            # ),
+            schema.Dropdown(
+                id = "direction",
+                name = "Filter Direction",
+                desc = "Filter the arrivals to one cardinal direction.",
+                icon = "compass",
+                default = direction_options[0].value,
+                options = direction_options,
+            ),
             schema.Color(
                 id = "text_color",
                 name = "Text Color",
@@ -237,16 +237,16 @@ def get_station_list_options():
         )
     return options
 
-# def get_direction_list_options():
-#     options = []
-#     for direction in DIRECTION_MAP.keys():
-#         options.append(
-#             schema.Option(
-#                 display = direction,
-#                 value = direction,
-#             ),
-#         )
-#     return options
+def get_direction_list_options():
+    options = []
+    for direction in DIRECTION_MAP.keys():
+        options.append(
+            schema.Option(
+                display = direction,
+                value = direction,
+            ),
+        )
+    return options
 
 def arrival_template(config, color, time, head_sign):
     text_color = config.str("text_color", DEFAULT_TEXT_COLOR)
@@ -316,15 +316,17 @@ def render_arrivals(config):
     all_arrivals = get_chachable_json("https://api.marta.io/trains", 10)
 
     user_station = STATIONS_MAP[config.get("station") or DEFAULT_STATION]
+    direction_filter = DIRECTION_MAP[config.get("direction") or DEAFULT_DIRECTION]
 
     #Filter all_arrivals for the user's station
     for arrival in all_arrivals:
         # if direction == None:
         #Append the correct station arrivals
         if arrival["STATION"] == user_station:
-            user_station_arrivals.append(arrival)
-
-        #Append only 1 direction if selected in Schema
+            if direction_filter == "None":
+                user_station_arrivals.append(arrival)
+            elif arrival["DIRECTION"] == direction_filter:  #Append only 1 direction if selected in Schema
+                user_station_arrivals.append(arrival)
 
     # Sort arrivals by shortest time to arrival
     user_station_arrivals = (sorted(user_station_arrivals, key = lambda d: int(d["WAITING_SECONDS"])))
@@ -801,11 +803,11 @@ HEAD_SIGN_MAP = {
 }
 
 DIRECTION_MAP = {
-    "No Filter": None,
+    "No Direction Filter": "None",
     "Northbound": "N",
     "Eastbound": "E",
     "Southbound": "S",
-    "Westbounr": "W",
+    "Westbound": "W",
 }
 
 LINE_CODE_MAP = {

--- a/apps/martamap/marta_map.star
+++ b/apps/martamap/marta_map.star
@@ -5,8 +5,6 @@ Description: Display real-time MARTA train locations.
 Author: InTheDaylight14
 """
 
-load("cache.star", "cache")
-load("encoding/json.star", "json")
 load("http.star", "http")
 load("render.star", "render")
 load("schema.star", "schema")
@@ -160,31 +158,29 @@ def decode_coordinates(coordinate, mapping):
     return (65, 65)
 
 def get_trains(MARTA_API_URL):
-    cached_trains = cache.get("cached_trains")
-    if cached_trains != None:
-        return json.decode(cached_trains)
-
-    response = http.get(MARTA_API_URL)
-    if response.status_code != 200:
-        print("MARTA Train API request failed with status %d", response.status_code)
-    all_trains = response.json()
+    all_trains = get_chachable_json(MARTA_API_URL, 20)
     trains = {}
 
-    if "RailArrivals" in all_trains:  #Original API
-        all_train_arrivals = all_trains["RailArrivals"]
+    # if "RailArrivals" in all_trains:  #Original API
+    #     all_train_arrivals = all_trains["RailArrivals"]
 
-        for arrival in all_train_arrivals:
-            if arrival["TRAIN_ID"] not in trains.keys():
-                trains[arrival["TRAIN_ID"]] = arrival
-    else:  #New API
-        for train in all_trains:
-            if train["trainId"] not in trains.keys():
-                trains[train["trainId"]] = train
-
-    # TODO: Determine if this cache call can be converted to the new HTTP cache.
-    cache.set("cached_trains", json.encode(trains), ttl_seconds = 20)
+    #     for arrival in all_train_arrivals:
+    #         if arrival["TRAIN_ID"] not in trains.keys():
+    #             trains[arrival["TRAIN_ID"]] = arrival
+    # else:  #New API
+    for train in all_trains:  #Adds unique train IDs and skips duplicates. Only need the lat and long for a train once.
+        if train["trainId"] not in trains.keys():
+            trains[train["trainId"]] = train
 
     return trains
+
+def get_chachable_json(url, timeout):
+    response = http.get(url, ttl_seconds = timeout)
+
+    if response.status_code != 200:
+        fail("request to %s failed with status code: %d - %s" % (url, response.status_code, response.body()))
+
+    return response.json()
 
 def render_line(points, color, orientation):
     if orientation == "vertical":
@@ -315,13 +311,29 @@ def render_headsign_text(config, head_sign):
 
 def render_arrivals(config):
     rendered_arrivals = []
-    station_arrivals = get_arrivals(config)
+    user_station_arrivals = []
 
-    #Truncate list of arrivals to 4
-    if len(station_arrivals) > 4:
-        station_arrivals = station_arrivals[0:4]
+    all_arrivals = get_chachable_json("https://api.marta.io/trains", 10)
 
-    for arrival in station_arrivals:
+    user_station = STATIONS_MAP[config.get("station") or DEFAULT_STATION]
+
+    #Filter all_arrivals for the user's station
+    for arrival in all_arrivals:
+        # if direction == None:
+        #Append the correct station arrivals
+        if arrival["STATION"] == user_station:
+            user_station_arrivals.append(arrival)
+
+        #Append only 1 direction if selected in Schema
+
+    # Sort arrivals by shortest time to arrival
+    user_station_arrivals = (sorted(user_station_arrivals, key = lambda d: int(d["WAITING_SECONDS"])))
+
+    #Truncate list of arrivals to 4 if needed
+    if len(user_station_arrivals) > 4:
+        user_station_arrivals = user_station_arrivals[0:4]
+
+    for arrival in user_station_arrivals:
         waiting_time = arrival["WAITING_TIME"]
         if waiting_time == "Arriving":
             waiting_time = "Ar "
@@ -349,41 +361,6 @@ def render_arrivals(config):
             ),
         ],
     )
-
-def get_arrivals(config):
-    cached_arrivals = cache.get("cached_arrivals")
-    if cached_arrivals != None:
-        return json.decode(cached_arrivals)
-
-    station = STATIONS_MAP[config.get("station") or DEFAULT_STATION]
-    # direction = config.bool("direction") or DEAFULT_DIRECTION
-    # if direction != None:
-    #     direction = DIRECTION_MAP[direction]
-
-    response = http.get("https://api.marta.io/trains")
-    if response.status_code != 200:
-        fail("MARTA Train API request failed with status %d", response.status_code)
-    all_arrivals = response.json()
-    arrivals = []
-
-    for arrival in all_arrivals:
-        # if direction == None:
-        #Append the correct station arrivals
-        if arrival["STATION"] == station:
-            arrivals.append(arrival)
-
-        #Append only 1 direction if selected in Schema
-
-    # elif arrival["STATION"] == station and arrival["DIRECTION"] == direction:
-    #     arrivals.append(arrival)
-
-    #Sort arrivals by shortest time to arrival
-    arrivals = (sorted(arrivals, key = lambda d: int(d["WAITING_SECONDS"])))
-
-    # TODO: Determine if this cache call can be converted to the new HTTP cache.
-    cache.set("cached_arrivals", json.encode(arrivals), ttl_seconds = 10)
-
-    return arrivals
 
 RED_LINE_POINTS = {
     "vertical": [

--- a/apps/martamap/marta_map.star
+++ b/apps/martamap/marta_map.star
@@ -15,7 +15,7 @@ DEFAULT_ORIENTATION_BOOL = False  #Default to horizontal
 DEFAULT_ARRIVALS = True
 DEFAULT_STATION = "Lindbergh Center"
 DEFAULT_SCROLL = True
-DEAFULT_DIRECTION = "None"
+DEAFULT_DIRECTION = "No Direction Filter"
 
 # FONT = "CG-pixel-3x5-mono"
 FONT = "CG-pixel-4x5-mono"
@@ -320,7 +320,6 @@ def render_arrivals(config):
 
     #Filter all_arrivals for the user's station
     for arrival in all_arrivals:
-        # if direction == None:
         #Append the correct station arrivals
         if arrival["STATION"] == user_station:
             if direction_filter == "None":
@@ -800,6 +799,7 @@ HEAD_SIGN_MAP = {
     "Hamilton E Holmes": "HE HOLMES",
     "Airport": "AIRPORT  ",  #Padding so Marquee text is the same length and the scroll cleanly...
     "Lindbergh": "LINDBERGH",
+    "King Memorial": "KING MEM ",
 }
 
 DIRECTION_MAP = {


### PR DESCRIPTION
# Description
Migrated all variable caching to HTTP cache. Re-enabled and reconfigured the direction filter. Added a missing headsign for weekend service. 

There was a logic mistake that was caching a filtered API response based on a particular Tidbyt's configured station. Essentially a random station's arrival times would be cached and displayed, depending on which Tidbyt's configuration was filtered for the cache. This has been fixed, no more leaking a random user's station arrivals. This was too close w.r.t. PII and broke the intended functionality of showing arrival times for one configured station per device. 

# Copilot
<!-- please don't change the line below -->
copilot:all
