### PR TITLE
fix: (apps/awair) work around generated fields without default values

### DIFF
--- a/apps/awair/awair.star
+++ b/apps/awair/awair.star
@@ -52,6 +52,7 @@ def api_connection_options(api_connection_type):
                 name = "Public IP address and port of Awair device",
                 desc = "Requires a public IP address with port forwarding to an Awair device configured for Local API access.",
                 icon = "computer",
+                default = "",
             ),
         ]
     elif api_connection_type == "cloud_token":
@@ -61,12 +62,14 @@ def api_connection_options(api_connection_type):
                 name = "Access token for Awair Developer API",
                 desc = "Your API access token from your Awair developer console at https://developer.getawair.com/.",
                 icon = "key",
+                default = "",
             ),
             schema.Text(
                 id = "device_id",
                 name = "Awair device id",
                 desc = "The device's integer deviceID, see 'GET Devices' at https://developer.getawair.com/.",
                 icon = "server",
+                default = "",
             ),
             schema.Dropdown(
                 id = "device_type",


### PR DESCRIPTION
# Description

This is an attempt to work around an issue in the mobile app described at https://discord.com/channels/928484660785336380/928638975298650172/1182047678914367638

The app hangs when configuring the app's generated fields. Poking around on discord, I found the above response from @matslina that describes an issue with generated fields when they don't have default values declared.

In this PR, I'm setting the default value to an empty string, but I'm not sure if this is sufficient to fix the issue (since the web dev environment isn't a complete reproduction of the mobile app's config screen).


# Copilot
<!-- please don't change the line below -->
copilot:all
