### PR TITLE
splatoon3schedule: support null boss object for Eggstra Work

### DIFF
--- a/apps/splatoon3schedule/splatoon3schedule.star
+++ b/apps/splatoon3schedule/splatoon3schedule.star
@@ -70,8 +70,7 @@ def make_salmon_run_mode(schedule_key, title_color):
         is_splatfest = False,
         title_color = title_color,
         subtitle_color_map = {},
-        # TODO: how will the boss object be defined for Eggstra Work?
-        subtitle_generator = lambda x: "%s (%s)" % (x["coopStage"]["name"], x["boss"]["name"]),
+        subtitle_generator = lambda x: x["coopStage"]["name"] + (" (%s)" % x["boss"]["name"] if x["boss"] else ""),
         images_accessor = lambda x: x["weapons"],
     )
 


### PR DESCRIPTION
# Description

As it turns out, in Eggstra Work, the boss object is null. Support this by not displaying a boss string in case the corresponding object is null.

# Copilot
<!-- please don't change the line below -->
copilot:all
