### PR TITLE
Public repos do not need PAT to access rest API

### DIFF
--- a/apps/githubbadge/github_badge.star
+++ b/apps/githubbadge/github_badge.star
@@ -165,8 +165,8 @@ def get_schema():
         fields = [
             schema.Text(
                 id = "access_token",
-                name = "GitHub Personal Access Token (optional, only required for private repos)",
-                desc = "Personal Access token",
+                name = "GitHub Personal Access Token",
+                desc = "Personal Access token (optional, only required for private repos)",
                 icon = "lock",
             ),
             schema.Text(

--- a/apps/githubbadge/github_badge.star
+++ b/apps/githubbadge/github_badge.star
@@ -72,21 +72,22 @@ def fetch_workflow_data(config):
     workflow_id = config.str("workflow_id")
     branch = config.str("branch", DEFAULT_BRANCH)
 
+    headers = {"Accept": "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28"}
     if access_token:
-        data = http.get(
-            "https://api.github.com/repos/{}/{}/actions/workflows/{}/runs".format(owner_name, repo_name, workflow_id),
-            params = {"branch": branch, "per_page": "1", "page": "1"},
-            headers = {"Accept": "application/vnd.github+json", "Authorization": "Bearer {}".format(access_token), "X-GitHub-Api-Version": "2022-11-28"},
-        ).json()
+        headers["Authorization"] = "Bearer {}".format(access_token)
 
-        if data and data.get("workflow_runs"):
-            return data.get("workflow_runs")[0], None
-        elif data.get("message"):
-            return [], data.get("message")
+    data = http.get(
+        "https://api.github.com/repos/{}/{}/actions/workflows/{}/runs".format(owner_name, repo_name, workflow_id),
+        params = {"branch": branch, "per_page": "1", "page": "1"},
+        headers = headers,
+    ).json()
 
-        return [], "Error occured"
-    else:
-        return [], None
+    if data and data.get("workflow_runs"):
+        return data.get("workflow_runs")[0], None
+    elif data.get("message"):
+        return [], data.get("message")
+
+    return [], "Error occurred"
 
 def get_display_text(config):
     return config.get("display_text") or "{}/{}".format(config.str("owner_name"), config.str("repo_name"))
@@ -156,7 +157,7 @@ def main(config):
     elif workflow_data:
         return render_status_badge("failed", workflow_data)
     else:
-        return render_status_badge("failed", "Could not connect to Github")
+        return render_status_badge("failed", "Could not connect to GitHub")
 
 def get_schema():
     return schema.Schema(
@@ -164,7 +165,7 @@ def get_schema():
         fields = [
             schema.Text(
                 id = "access_token",
-                name = "Github Personal Access Token",
+                name = "GitHub Personal Access Token (optional, only required for private repos)",
                 desc = "Personal Access token",
                 icon = "lock",
             ),
@@ -173,23 +174,26 @@ def get_schema():
                 name = "Repo Name",
                 desc = "Name of the repository",
                 icon = "boxArchive",
+                default = "pixlet",
             ),
             schema.Text(
                 id = "owner_name",
                 name = "User/Org Name",
                 desc = "Name of the user/organization that the repo belongs to",
                 icon = "user",
+                default = "tidbyt",
             ),
             schema.Text(
                 id = "workflow_id",
                 name = "Worflow",
-                desc = "The ID or File name of the workflow file (eg. deploy.yml)",
+                desc = "The ID or File name of the workflow file (e.g., deploy.yml)",
                 icon = "lock",
+                default = "main.yml",
             ),
             schema.Text(
                 id = "display_text",
                 name = "Display text",
-                desc = "Text to display for the workflow, defaults to user/repo.",
+                desc = "Text to display for the workflow, defaults to user/repo",
                 icon = "font",
             ),
             schema.Text(


### PR DESCRIPTION
# Description
Update GitHub Badge app to optionally use the GitHub PAT (it's only necessary if the repo is private).

Otherwise included a few minor spelling corrections.

# Copilot
<!-- please don't change the line below -->
copilot:all
