### PR TITLE
StocksFagi: Fix font size on 'extreme' in classification

### DIFF
--- a/apps/stockfagi/stockfagi.star
+++ b/apps/stockfagi/stockfagi.star
@@ -70,6 +70,7 @@ def main():
 
     value = int(data["fgi"]["now"]["value"])
     classification = data["fgi"]["now"]["valueText"]
+    has_extreme_in_classification = "Extreme" in classification
     text_color = get_text_color(value)
 
     return render.Root(
@@ -138,11 +139,11 @@ def main():
                     main_align = "center",
                     children = [
                         render.Padding(
-                            pad = (0, 18, 0, 0),
+                            pad = (0, (22 if has_extreme_in_classification else 18), 0, 0),
                             child = render.Text(
                                 content = classification,
                                 color = text_color,
-                                font = "6x13",
+                                font = "tom-thumb" if has_extreme_in_classification else "6x13",
                             ),
                         ),
                     ],


### PR DESCRIPTION
# Description
Fixes the font size if the classification contains 'extreme'. The font will be smaller to print all text.

@jondkelley, please approve.

# Copilot
<!-- please don't change the line below -->
copilot:all
