### PR TITLE
VercelDashboard -> Add support for teams with TeamID

### DIFF
--- a/apps/verceldashboard/README.md
+++ b/apps/verceldashboard/README.md
@@ -14,10 +14,13 @@ Currently, it shows:
 
 In order for it to work, you will need a Vercel API Token. You can read [Vercel's Documentation](https://vercel.com/docs/rest-api#creating-an-access-token) on how to create one.
 
+For team accounts, ensure the access token has the correct scope and include the Team Id [Vercel's Documentation](https://vercel.com/guides/how-do-i-use-a-vercel-api-access-token). Your team Id can be found in the team's Settings > General > Team Id
+
 ## Configuration
 
 | Title    | Description                    | Required | Default |
 | -------- | ------------------------------ | -------- | ------- |
 | API Key  | Your Vercel API Key            | Yes      | --      |
+| Team ID  | Your Vercel Team's ID          | No       | --      |
 | Timezone | Timezone to show build time at | No       | UTC     |
 | 24hr     | Show time as 24hr (13:04)      | No       | True    |

--- a/apps/verceldashboard/vercel_dashboard.star
+++ b/apps/verceldashboard/vercel_dashboard.star
@@ -176,8 +176,8 @@ def get_schema():
             ),
             schema.Text(
                 id = CONFIG_TEAM_ID,
-                name = "TEAM ID",
-                desc = "Your Vercel Team ID - required for team deployments. Leave blank for personal deployments.",
+                name = "Team ID",
+                desc = "Your Vercel Team ID - required for team deployments. Leave blank for personal deployments. Ensure scope is correct for the referenced team.",
                 icon = "peopleCarryBox",
             ),
             schema.Dropdown(

--- a/apps/verceldashboard/vercel_dashboard.star
+++ b/apps/verceldashboard/vercel_dashboard.star
@@ -45,7 +45,10 @@ def main(config):
 
         # TeamId is required for Team API Calls
         # https://vercel.com/guides/how-do-i-use-a-vercel-api-access-token 
-        url = BASE_DEPLOYMENT_URL + "?teamId=" + teamId
+        if teamId:
+            url = BASE_DEPLOYMENT_URL + "?teamId=" + teamId
+        else:
+            url = BASE_DEPLOYMENT_URL
         rep = http.get(
             url,
             headers = {"Authorization": "Bearer " + apikey, "Accept": "application/json"},

--- a/apps/verceldashboard/vercel_dashboard.star
+++ b/apps/verceldashboard/vercel_dashboard.star
@@ -19,11 +19,13 @@ SPACE = "   "
 
 # Config
 CONFIG_API_KEY = "api-key"
+CONFIG_TEAM_ID = "team-id"
 CONFIG_CLOCK_FORMAT = "time-format"
 CONFIG_TIMEZONE = "time-zone"
 
 def main(config):
     apikey = config.str(CONFIG_API_KEY)
+    teamId = config.str(CONFIG_TEAM_ID)
     showIn24hr = config.bool(CONFIG_CLOCK_FORMAT, True)
 
     if apikey == None:
@@ -40,8 +42,12 @@ def main(config):
         data = json.decode(cached_data)
     else:
         print("Miss cache! Calling Vercel")
+
+        # TeamId is required for Team API Calls
+        # https://vercel.com/guides/how-do-i-use-a-vercel-api-access-token 
+        url = BASE_DEPLOYMENT_URL + "?teamId=" + teamId
         rep = http.get(
-            BASE_DEPLOYMENT_URL,
+            url,
             headers = {"Authorization": "Bearer " + apikey, "Accept": "application/json"},
         )
 
@@ -164,6 +170,12 @@ def get_schema():
                 name = "API Key",
                 desc = "Your Vercel API key generated via the Vercel dashboard",
                 icon = "key",
+            ),
+            schema.Text(
+                id = CONFIG_TEAM_ID,
+                name = "TEAM ID",
+                desc = "Your Vercel Team ID - required for team deployments. Leave blank for personal deployments.",
+                icon = "people-group",
             ),
             schema.Dropdown(
                 id = CONFIG_TIMEZONE,

--- a/apps/verceldashboard/vercel_dashboard.star
+++ b/apps/verceldashboard/vercel_dashboard.star
@@ -178,7 +178,7 @@ def get_schema():
                 id = CONFIG_TEAM_ID,
                 name = "TEAM ID",
                 desc = "Your Vercel Team ID - required for team deployments. Leave blank for personal deployments.",
-                icon = "people-group",
+                icon = "peopleCarryBox",
             ),
             schema.Dropdown(
                 id = CONFIG_TIMEZONE,

--- a/apps/verceldashboard/vercel_dashboard.star
+++ b/apps/verceldashboard/vercel_dashboard.star
@@ -44,7 +44,7 @@ def main(config):
         print("Miss cache! Calling Vercel")
 
         # TeamId is required for Team API Calls
-        # https://vercel.com/guides/how-do-i-use-a-vercel-api-access-token 
+        # https://vercel.com/guides/how-do-i-use-a-vercel-api-access-token
         if teamId:
             url = BASE_DEPLOYMENT_URL + "?teamId=" + teamId
         else:


### PR DESCRIPTION
# Description
- Add optional property for `teamId` https://vercel.com/guides/how-do-i-use-a-vercel-api-access-token
- Works for personal account without teamId or with team account with team ID

![Screenshot 2024-03-19 at 18 53 07](https://github.com/tidbyt/community/assets/5768890/04313bfd-653c-4f30-a56c-51b723ce5c2a)


# Copilot
<!-- please don't change the line below -->
copilot:all
