### PR TITLE
Severe Weather Alerts: updating spacing for readability

### DIFF
--- a/apps/severewxalertsusa/severewxalertsusa.star
+++ b/apps/severewxalertsusa/severewxalertsusa.star
@@ -180,6 +180,7 @@ def render_alert(alert, alertIndex, totalAlerts):
         align = "center",
         font = "CG-pixel-4x5-mono",  # tiny
         color = "#FF0000",  # red
+        linespacing = 1,
     )
 
     mainAlertTextWrappedWidget = render.Box(
@@ -266,7 +267,7 @@ def render_summary_card_for_alerts(location, alerts):
     )
     alertsBox = render.Box(
         child = alertsText,
-        height = 17,
+        height = 16,
     )
 
     alertsRow = render.Row(
@@ -283,10 +284,11 @@ def render_summary_card_for_alerts(location, alerts):
         content = location["locality"],
         align = "center",
         font = "CG-pixel-3x5-mono",  # tiny
+        linespacing = 1,
     )
     locationBox = render.Box(
         child = locationText,
-        height = 10,
+        height = 11,
     )
     locationRow = render.Row(
         children = [locationBox],


### PR DESCRIPTION
# Description
Some of the text was a little mushed together in certain cases. I updated the spacing to fix it.

## Before
<img width="934" alt="Screenshot 2024-04-06 at 7 45 12 AM" src="https://github.com/tidbyt/community/assets/37538944/122106dc-8c0f-47cc-a054-f6872febbee9">

<img width="931" alt="Screenshot 2024-04-06 at 7 45 32 AM" src="https://github.com/tidbyt/community/assets/37538944/87634201-b2ff-4471-96d4-326cf3adf8b6">

## After
<img width="937" alt="Screenshot 2024-04-06 at 7 46 50 AM" src="https://github.com/tidbyt/community/assets/37538944/940e2db4-ceab-4895-87c4-3a7a45c99626">

<img width="925" alt="Screenshot 2024-04-06 at 7 46 26 AM" src="https://github.com/tidbyt/community/assets/37538944/b0f04d20-3271-4e82-b49d-a6270bf520f4">

Tagging a few people who might be interested:
contributor: @rs7q5 
original app author: @aschechter88 
bug reporter: @GITHUB-139

Addresses #2369 

# Copilot
<!-- please don't change the line below -->
copilot:all
