### PR TITLE
FIX: handling of event names was causing app to crash

### DIFF
--- a/apps/universalical/universal_ical.star
+++ b/apps/universalical/universal_ical.star
@@ -273,7 +273,7 @@ def build_event_frame(event):
 def get_event_summary(summary):
     if DEFAULT_TRUNCATE_EVENT_SUMMARY:
         splitSum = summary.split()
-        return " ".join(summary) if len(splitSum) <= 3 else " ".join(splitSum[:3]) + "..."
+        return " ".join(splitSum) if len(splitSum) <= 3 else " ".join(splitSum[:3]) + "..."
     else:
         return summary
 
@@ -300,13 +300,6 @@ def get_schema():
                 desc = "Show events outside of a 24 hour window.",
                 default = DEFAULT_SHOW_EXPANDED_TIME_WINDOW,
                 icon = "clock",
-            ),
-            schema.Toggle(
-                id = P_SHOW_FULL_NAMES,
-                name = "Show Full Names",
-                desc = "Show the full names of the days of the week.",
-                default = DEFAULT_SHOW_FULL_NAMES,
-                icon = "calendar",
             ),
             schema.Toggle(
                 id = P_SHOW_FULL_NAMES,


### PR DESCRIPTION
# Description
Fixes the handling of events with spaces in the name. The `join` function was being called with a string instead of an iterable.
```
universal_ical.star:278:24: in get_event_summary
Error in join: join: for parameter 1: got string, want iterable
```

Also removed a duplicate Toggle button in `get_schema`.

@quesurifn I took the liberty of making these fixes. A user in the forums wanted an Apple Calendar app and I know this one is compatible, but it was not working given the bug above.

# Copilot
<!-- please don't change the line below -->
copilot:all
