### PR TITLE
LastFM stats updated ID and API key

### DIFF
--- a/apps/lastfmstats/lastfmstats.star
+++ b/apps/lastfmstats/lastfmstats.star
@@ -37,7 +37,7 @@ DEMO_TRACK = {
 
 # Decrypt the default API Key
 # Encrypted with `pixlet encrypt lastfmstats <apikey>`
-DEFAULT_API_KEY = secret.decrypt("AV6+xWcE/lRuZeOAg799Gnyb3QnTiPTpnGe4qg2I7DOIvuBWRg8QUBzyosDMDzV7HDhmCbz5Kx2LCMrhGFa2mb+rpxsLL5yyucpHtXVWiX4Gj+KrSfnFA3h2kId1yoW5+Csp1AN1sEcdZ38qq+26ItrNXCd8FcdGKA2p/YG9FvoyL6aFX6w=")
+DEFAULT_API_KEY = secret.decrypt("AV6+xWcEMpic5Qa9aeMvuCkgUcDo+y8Ss5dDyiQPAQ7ulLP5TAWzms85w37wrjBimdEkp1lkVdBUwGt/gz1crVW7x1Z7LVCLCPCd5Cql/OofkaJeRDgYeCNKWPJtCRp22hER6a+CpFJShcjkVTEJVThJw9lK7ij0HrP5a3J9eHEXo10xv5M=")
 
 # Load default artwork
 DEFAULT_ARTWORK = base64.decode("iVBORw0KGgoAAAANSUhEUgAAABUAAAAVCAYAAACpF6WWAAAAZ0lEQVQ4T2O0sLD4z0BlwEg3Q9eJMpLt9qDX/xmwunToGQryCrEA5juC3h81lNggZRgNU3BQ0SdJoWdPYtIpNj3wvI8tvxMyFJcesKG4ChB8huLTQztDQbFGrfAEmUW/kp/ovIlDIQDgTH/J851RMQAAAABJRU5ErkJggg==")

--- a/apps/lastfmstats/lastfmstats.star
+++ b/apps/lastfmstats/lastfmstats.star
@@ -37,7 +37,7 @@ DEMO_TRACK = {
 
 # Decrypt the default API Key
 # Encrypted with `pixlet encrypt lastfmstats <apikey>`
-DEFAULT_API_KEY = secret.decrypt("AV6+xWcExxQCMGUycPsRYdeA7t7rOKr9SIvCfNyy+13/bcrin/XSYJOx5IqjoMsEe4LMS1x6tZz9cykLYglv5LPXIh9Lb2YKzIDZ4YqR3zOQLRH/ohMiocbld5kjCzXuSdDSSUwBXWgLJOm1yrW1IWrAGYPvvUID41LFuUzA7tZnKwUjpvg=")
+DEFAULT_API_KEY = secret.decrypt("AV6+xWcE/lRuZeOAg799Gnyb3QnTiPTpnGe4qg2I7DOIvuBWRg8QUBzyosDMDzV7HDhmCbz5Kx2LCMrhGFa2mb+rpxsLL5yyucpHtXVWiX4Gj+KrSfnFA3h2kId1yoW5+Csp1AN1sEcdZ38qq+26ItrNXCd8FcdGKA2p/YG9FvoyL6aFX6w=")
 
 # Load default artwork
 DEFAULT_ARTWORK = base64.decode("iVBORw0KGgoAAAANSUhEUgAAABUAAAAVCAYAAACpF6WWAAAAZ0lEQVQ4T2O0sLD4z0BlwEg3Q9eJMpLt9qDX/xmwunToGQryCrEA5juC3h81lNggZRgNU3BQ0SdJoWdPYtIpNj3wvI8tvxMyFJcesKG4ChB8huLTQztDQbFGrfAEmUW/kp/ovIlDIQDgTH/J851RMQAAAABJRU5ErkJggg==")

--- a/apps/lastfmstats/manifest.yaml
+++ b/apps/lastfmstats/manifest.yaml
@@ -1,5 +1,5 @@
 ---
-id: lastfmstats
+id: lastfm-stats
 name: LastFM Stats
 summary: Displays stats from Last.fm
 desc: Displays the top artist and track for a last.fm user over a given period of time.

--- a/apps/lastfmstats/manifest.yaml
+++ b/apps/lastfmstats/manifest.yaml
@@ -1,5 +1,5 @@
 ---
-id: lastfm-stats
+id: lastfmstats
 name: LastFM Stats
 summary: Displays stats from Last.fm
 desc: Displays the top artist and track for a last.fm user over a given period of time.


### PR DESCRIPTION
# Description
After the last API key update, the app was no longer listed. This PR updates the ID to match the folder name so I don't need to worry about any mismatch. Also regenerated the API key again just in case.

# Copilot
<!-- please don't change the line below -->
copilot:all
