### PR TITLE
Update: Chi-L-Track: add more fool-proof destination filtering

### DIFF
--- a/apps/chi-l-track/chi_l_track.star
+++ b/apps/chi-l-track/chi_l_track.star
@@ -30,13 +30,13 @@ def getPredictionSuffix(route, destinationName, destinationId, isScheduled):
     if isScheduled:
         return ""
     elif route == "Blue":
-        if destinationId == "30171" or destinationId == "30077":
+        if destinationId == "30171" or destinationId == "30077" or destinationName == "Forest Park" or destinationName == "O'Hare":
             return ""
-        elif destinationId == "30069":
+        elif destinationId == "30069" or destinationName == "UIC-Halsted":
             return "U"
-        elif destinationId == "Rosemont":
+        elif destinationId == "30159" or destinationName == "Rosemont":
             return "R"
-        elif destinationId == "30247":
+        elif destinationId == "30247" or destinationName == "Jefferson Park":
             return "J"
         else:
             return "!"
@@ -48,7 +48,7 @@ def getPredictionSuffix(route, destinationName, destinationId, isScheduled):
     elif route == "G":
         if destinationId == "30057" or destinationId == "30004":
             return ""
-        elif destinationId == "30139":
+        elif destinationId == "30139" or destinationName == "Cottage Grove":
             return "C"
         else:
             return "!"


### PR DESCRIPTION
# Description
Add better filtering for custom train destinations.

e.g.

Show "U" suffix for UIC trains instead of falling back to "!"

![image](https://github.com/tidbyt/community/assets/1450700/c9317240-5e32-484c-a901-63e4cfc906cb)


# Copilot
<!-- please don't change the line below -->
copilot:all
