### PR TITLE
change-default-latitude-planesoverhead

### DIFF
--- a/apps/planesoverhead/planes_overhead.star
+++ b/apps/planesoverhead/planes_overhead.star
@@ -25,7 +25,7 @@ def get_schema():
                 name = "Latitude",
                 desc = "Latitude to fetch planes overhead",
                 icon = "locationDot",
-                default = "32.023",
+                default = "34.023",
             ),
             schema.Text(
                 id = "lng",


### PR DESCRIPTION
# Description
This commit moves the default latitude from 32.023 to 34.023 so that the default location is set for Santa Monica, as intended, not an "empty" space of ocean.

The `planes-overhead` app has been running great in production - this is a simply an enhancement so that more data populates by default for users who do not manually configure their app.

**Old**

![Screenshot from 2024-04-16 22-30-44](https://github.com/tidbyt/community/assets/46361923/1809f535-be26-4f9e-af09-f605f2c6f739)

**New**

![Screenshot from 2024-04-16 22-31-15](https://github.com/tidbyt/community/assets/46361923/6c5abb0f-8e71-4013-9e80-ff4468398e5d)


# Copilot

<!-- please don't change the line below -->
copilot:all
