### PR TITLE
Update solaredge_monitor.star

### DIFF
--- a/apps/solaredgemonitor/solaredge_monitor.star
+++ b/apps/solaredgemonitor/solaredge_monitor.star
@@ -13,7 +13,8 @@ load("humanize.star", "humanize")
 load("render.star", "render")
 load("schema.star", "schema")
 
-URL = "https://monitoringapi.solaredge.com/site/{}/currentPowerFlow"
+#This URL is outdated per 'https://developers.solaredge.com/docs/monitoring/lpc9ijhyrc72l-migrating-from-v1-to-v2'. Therefore changing the old /currentPowerFlow
+URL = "https://api.solaredge.com/monitoring/sites/{}/power-flow"
 
 # SolarEdge API limit is 300 requests per day, which is about
 # one per 5 minutes


### PR DESCRIPTION
updated the URL for the api as it has changed in the last year since the app was initially developed.

# Description
Per the discussion, on-going 'https://discuss.tidbyt.com/t/solaredgemonitor-not-working/4926' - I updated the URL for the api call and added a comment out-linning in an attempt to rectify the app as it currently displaying the default 3.14/4.71/1.57 values, without change. Despite, like many, having generated new api keys and confirming their accuracy in the solaredge module of the tidbyt app.

# Copilot
<!-- please don't change the line below -->
copilot:all
