### PR TITLE
New App: Next Event

### DIFF
--- a/apps/nextevent/manifest.yaml
+++ b/apps/nextevent/manifest.yaml
@@ -2,7 +2,7 @@
 id: next-event
 name: Next Event Date
 summary: Displays next event only
-desc: Displays the next calendar event, no matter how far away, from iCal (.ics) files.
+desc: Displays the next calendar event, no matter how far away, from iCal (.ics) files. Note: This app will process your iCal data via an external service outside of the Tidbyt ecosystem.
 author: mattcaruso <Matt Caruso>
 fileName: next_event.star
 packageName: nextevent

--- a/apps/nextevent/manifest.yaml
+++ b/apps/nextevent/manifest.yaml
@@ -1,0 +1,8 @@
+---
+id: next-event
+name: Next Event Date
+summary: Displays next event only
+desc: Displays the next calendar event, no matter how far away, from iCal (.ics) files.
+author: mattcaruso <Matt Caruso>
+fileName: next_event.star
+packageName: nextevent

--- a/apps/nextevent/manifest.yaml
+++ b/apps/nextevent/manifest.yaml
@@ -2,7 +2,7 @@
 id: next-event
 name: Next Event Date
 summary: Displays next event only
-desc: Displays the next calendar event, no matter how far away, from iCal (.ics) files. Note: This app will process your iCal data via an external service outside of the Tidbyt ecosystem.
+desc: Displays the next calendar event, no matter how far away, from iCal (.ics) files. Note; This app will process your iCal data via an external service outside of the Tidbyt ecosystem.
 author: mattcaruso <Matt Caruso>
 fileName: next_event.star
 packageName: nextevent

--- a/apps/nextevent/next_event.star
+++ b/apps/nextevent/next_event.star
@@ -59,7 +59,7 @@ def render_top(config):
     return [
         render.Marquee(
             child = render.Text(
-                content = config.str("slug", DEFAULT_TITLE),
+                content = config.str("title", DEFAULT_TITLE),
                 color = "#ffea00",
             ),
             width = 64,

--- a/apps/nextevent/next_event.star
+++ b/apps/nextevent/next_event.star
@@ -1,0 +1,137 @@
+load("encoding/json.star", "json")
+load("http.star", "http")
+load("render.star", "render")
+load("schema.star", "schema")
+load("time.star", "time")
+
+DEFAULT_TIMEZONE = "America/New_York"
+LAMBDA_URL = "https://ozjgejjru4.execute-api.us-east-1.amazonaws.com/prod/"
+DEFAULT_ICS_URL = "https://ics.calendarlabs.com/76/8d23255e/US_Holidays.ics"
+DEFAULT_TITLE = "Next event"
+
+# Encrypted by Pixlet
+ENCRYPTED_LAMBDA_API_KEY = "AV6+xWcEtMbUpsRykZf6mtBgpjR026w2oTFDZT/Ff4wSVfdMcQrsIu82FTZoNIPAEHRDVWWkG44Jndgc5ap4ZNaJNtO0rlHoN58dUulNTgxtxIsxl3mYIjOxM34cVoUuevlGtyOEQtV3MHf7Q2O1QhxWpRGY+R/AFQ0OWFHf9qrfJ7vyJYDbrLHR9yJz6g=="
+
+def main(config):
+    location = config.str("loc")
+    location = json.decode(location) if location else {}
+    timezone = location.get(
+        "timezone",
+        config.get("$tz", DEFAULT_TIMEZONE),
+    )
+    ics_url = config.str("url", DEFAULT_ICS_URL)
+    if (ics_url == None):
+        fail("ICS_URL not set in config")
+
+    response = http.post(
+        url = LAMBDA_URL,
+        headers = {"x-api-key": secret.decrypt(ENCRYPTED_LAMBDA_API_KEY)},
+        json_body = {"ics_url": ics_url, "tz": timezone},
+    )
+
+    next_event = response.json()
+
+    return render.Root(
+        child = render.Column(
+            cross_align = "center",
+            main_align = "space_around",
+            children = render_top(config) + render_bottom(next_event),
+        ),
+    )
+
+def render_top(config):
+    return [
+        render.Marquee(
+            child = render.Text(
+                content = config.str("slug", DEFAULT_TITLE),
+                color = "#ffea00",
+            ),
+            width = 64,
+            align = "center",
+        ),
+        render.Box(
+            color = "#ffea00",
+            height = 1,
+        ),
+    ]
+
+def render_bottom(next_event):
+    has_next_event = next_event["has_next_event"]
+
+    if has_next_event:
+        is_today = next_event["is_today"]
+        is_tomorrow = next_event["is_tomorrow"]
+
+        # The Lambda API will calculate if the date is today or
+        # tomorrow so the frontend can display relative dates
+        if is_today:
+            pretty_date = "Today"
+        elif is_tomorrow:
+            pretty_date = "Tomorrow"
+        else:
+            display_month = time.parse_time(next_event["begin"]).format("Jan")
+            display_day = time.parse_time(next_event["begin"]).day
+            pretty_date = "{} {}".format(display_month, display_day)
+
+        return [
+            render.Box(
+                color = "#000",
+                height = 3,
+            ),
+            render.Marquee(
+                child = render.Text(
+                    content = next_event["title"],
+                ),
+                width = 64,  # Full width
+                align = "center",
+            ),
+            render.Box(
+                color = "#000",
+                height = 1,
+            ),
+            render.Text(
+                # Date
+                content = pretty_date,
+            ),
+        ]
+
+    else:
+        return [
+            render.Box(
+                color = "#000",
+                height = 3,
+            ),
+            render.Text(
+                content = "No more",
+            ),
+            render.Text(
+                content = "events",
+            ),
+        ]
+
+def get_schema():
+    return schema.Schema(
+        version = "1",
+        fields = [
+            schema.Location(
+                id = "loc",
+                name = "Location",
+                desc = "Location for timezone awareness",
+                icon = "locationDot",
+            ),
+            schema.Text(
+                id = "url",
+                name = "iCalendar URL",
+                desc = "The URL of the iCalendar file.",
+                icon = "calendar",
+                default = DEFAULT_ICS_URL,
+            ),
+            schema.Text(
+                id = "title",
+                name = "The title displayed above the next event",
+                desc = "What are the events on this calendar?",
+                icon = "calendar",
+                default = DEFAULT_TITLE,
+            ),
+        ],
+    )


### PR DESCRIPTION
# Description
This new app displays the next date in an iCalendar (ics) calendar when an event will occur. The other calendar options available from the community all focused on daily schedules and would often show "No more events today" (or similar) if there were no events in the connected calendar left on that day. For my use case, I want to display the next day when there's an event coming up, such as a calendar feed of concerts, shows, birthdays, or holidays!

![next_event](https://github.com/tidbyt/community/assets/6909800/1ad31782-6ff6-4f9b-bbd7-1bb7f6644b64)

Thanks to @quesurifn whose Universal iCal app heavily inspired the architecture of this app. 

(PS: The code for the Lambda function referenced in this Pixlet app will also be open sourced soon. I'll submit a new PR when I can link to it directly in the code comments for future creators to see how I'm handling the server-side functionality). 

# Copilot
<!-- please don't change the line below -->
copilot:all
