### PR TITLE
Fix time bug in San Diego Trolley app

### DIFF
--- a/apps/sandiegotrolley/san_diego_trolley.star
+++ b/apps/sandiegotrolley/san_diego_trolley.star
@@ -33,12 +33,11 @@ def none_str_to_none_val(maybe_none_str):
         return None
     return maybe_none_str
 
-now = time.now().unix
-
 def get_api_key():
     return secret.decrypt(API_KEY) or "NONE"
 
 def get_arrivals_for_stop(stop_id):
+    now = time.now().unix
     response = http.get("https://realtime.sdmts.com/api/api/where/arrivals-and-departures-for-stop/" + stop_id + ".json?key=" + get_api_key(), ttl_seconds = 30)
     if response.status_code != 200 or not response.body():
         print("Could not access transit data. HTTP Status: " + str(response.status_code))


### PR DESCRIPTION
The San Diego Trolley app has not been updating live arrival times as expected and instead arrival times keep increasing 🤦‍♂️ I suspect this is because `time.now` was previously being called at setup time rather than inside the `main()` function. This change moves the call to `time.now` inside one of the functions called from `main()` to resolve the bug.

It's worth noting that I'm not able to reproduce this bug locally, but based on the observed symptoms I'm pretty confident about this explanation. It makes sense that I wouldn't encounter this behavior with `pixlet render` but it's a little surprising that `pixlet serve` doesn't run the application code in the same way as the production environment. Maybe this is just a configuration issue on my end 🤷‍♂️ 

