### PR TITLE
chesscomelo: add support for unrated stats

### DIFF
--- a/apps/chesscomelo/chesscom_elo.star
+++ b/apps/chesscomelo/chesscom_elo.star
@@ -141,7 +141,7 @@ def main(config):
     diff = dict()
 
     for rating in resp:
-        if "rating" not in rating["stats"].keys():
+        if "rating" not in rating["stats"].keys() or rating["stats"]["rating"] == "Unrated":
             continue
         stats[rating["key"]] = int(rating["stats"]["rating"])
         if "rating_time_change_value" in rating["stats"].keys():


### PR DESCRIPTION
Fixes #2430

`pixlet render chesscom_elo.star username=nzdominic` if you need a test case that was failing before (but please excuse my poor chess skills 😆)