### PR TITLE
Update: MiLB Scores

### DIFF
--- a/apps/milbscores/milb_scores.star
+++ b/apps/milbscores/milb_scores.star
@@ -12,7 +12,10 @@ Added Double A leagues & team colors
 Added team logos for both Triple-A and Double-A teams
 
 v1.2
-Changed the names on the league selection dropdown 
+Changed the names on the league selection dropdown
+
+v1.3
+Changed date check to be Hawaii timezone - this will mean that the scores will not change to the following day until 6am ET, leaving the day's scores displayed on the Tidbyt for longer
 """
 
 load("encoding/json.star", "json")
@@ -32,6 +35,7 @@ LOGO_PREFIX = "https://milbpng.blob.core.windows.net/milb/"
 LOGO_SUFFIX = ".png"
 
 PT_TIMEZONE = "America/Los_Angeles"
+HAWAII_TIMEZONE = "Pacific/Honolulu"
 DEFAULT_TIMEZONE = "Australia/Adelaide"
 
 COLORS = """
@@ -131,15 +135,13 @@ def main(config):
         Title = "TEXAS"
         SportID = "12"
 
-    # Get the date on the West Coast of US
-    now = time.now().in_location(PT_TIMEZONE)
+    # Get the date in Hawaii
+    now = time.now().in_location(HAWAII_TIMEZONE)
     strnow = str(now)
     date = strnow[:10]
 
-    #date = "2023-08-27"
     APIDate = "startDate=" + date + "&endDate=" + date
     API = API_PREFIX + SportID + "&" + APIDate + API_SUFFIX + SelectedLeague + API_SUFFIX2
-    #print(API)
 
     teamFont = "Dina_r400-6"
     scoreFont = "Dina_r400-6"


### PR DESCRIPTION
Minor change to use Hawaii timezone to check what day it is. 

This means that the day's scores will remain on display until 6am Eastern the next day, before changing to that day's schedule

Good for those MiLB fans coming home late and wanting to see the day's scores :)