### PR TITLE
Fix infinite height

### DIFF
--- a/apps/houseofcommons/house_of_commons.star
+++ b/apps/houseofcommons/house_of_commons.star
@@ -170,6 +170,17 @@ def render_seats(predictions, source):
     opposition[-1] = [mps[None]] * (SEAT_HEIGHT - len(opposition[-1])) + opposition[-1]
 
     government = divmod(seats[0][0], SEAT_HEIGHT)
+    government_stragglers = None
+    if government[1] > 0:
+        government_stragglers = render.Padding(
+            pad = (government[0], 0, 0, 0),
+            child = render.Box(
+                width = 1,
+                height = government[1],
+                color = PARTY_COLOURS[seats[0][2]][0],
+            ),
+        )
+
     return render.Column(
         cross_align = "center",
         children = [
@@ -180,14 +191,7 @@ def render_seats(predictions, source):
                         height = SEAT_HEIGHT,
                         color = PARTY_COLOURS[seats[0][2]][0],
                     ),
-                    render.Padding(
-                        pad = (government[0], 0, 0, 0),
-                        child = render.Box(
-                            width = 1,
-                            height = government[1],
-                            color = PARTY_COLOURS[seats[0][2]][0],
-                        ),
-                    ),
+                    government_stragglers,
                 ] + [
                     render.Padding(
                         pad = (government[0] + 2 + i, 0, 0, 0),


### PR DESCRIPTION
If the government count is exactly divisible by 13 then there isn't a remainder. So we shouldn't add a remainder column to the picture. But currently, we are trying to add a very tall column (probably due to division by almost zero), which looks weird and means the seat counts don't get shown