### PR TITLE
Goodservice: Rebranding to The Weekendest, and fix destination name for Mets–Willets Point

### DIFF
--- a/apps/goodservice/goodservice.star
+++ b/apps/goodservice/goodservice.star
@@ -1,7 +1,7 @@
 """
-Applet: Goodservice
-Summary: Goodservice NYC subway
-Description: Projected New York City subway departure times, powered by goodservice.io.
+Applet: The Weekendest
+Summary: The Weekendest - NYC subway
+Description: Real-time New York City Subway projected departure times for a selected station, as seen on The Weekendest app. Takes into account of overnight and weekend service changes.
 Author: blahblahblah-
 """
 
@@ -27,6 +27,7 @@ NAME_OVERRIDE = {
     "Times Sq-42 St": "Times Sq",
     "Coney Island-Stillwell Av": "Coney Is",
     "South Ferry": "S Ferry",
+    "Mets-Willets Point": "Willets Pt",
 }
 
 STREET_ABBREVIATIONS = [

--- a/apps/goodservice/manifest.yaml
+++ b/apps/goodservice/manifest.yaml
@@ -1,8 +1,8 @@
 ---
 id: goodservice
-name: Goodservice
-summary: Goodservice - NYC Subway
-desc: Projected New York City Subway departure times, powered by goodservice.io.
+name: The Weekendest
+summary: The Weekendest - NYC Subway
+desc: Real-Time New York City Subway projected departure times for a selected station, as seen on The Weekendest app. Takes into account of overnight and weekend service changes.
 author: Sunny Ng
 fileName: goodservice.star
 packageName: goodservice


### PR DESCRIPTION
* Rebrand app to The Weekendest, to align with the newly launched iOS app. I kept the id and file names the same so that existing users won't be affected. Let me know if that's something I should change too.
* Fix name of Mets–Willets Point: It used to just say "Mets", now it'll say "Willets Pt" instead.

![ezgif-4-d436507ec2](https://github.com/tidbyt/community/assets/3004927/9c029f58-07ca-4986-a9ac-74dadd3b9808)