### PR TITLE
The Weekendest: Update station schema to use scheduled routes instead of routes

### DIFF
--- a/apps/goodservice/goodservice.star
+++ b/apps/goodservice/goodservice.star
@@ -276,7 +276,7 @@ def get_schema():
 
     for s in stops_req.json()["stops"]:
         stop_name = s["name"].replace(" - ", "-") + " - " + s["secondary_name"] if s["secondary_name"] else s["name"].replace(" - ", "-")
-        routes = sorted(s["routes"].keys())
+        routes = sorted(s["scheduled_routes"].keys())
         stops_options.append(
             schema.Option(
                 display = stop_name + " (" + ", ".join(routes) + ")",


### PR DESCRIPTION
* New `scheduled_routes` field is more relevant for the schema, since `routes` is completely dynamic, and can lead to no routes being listed due to service changes.