### PR TITLE
hass-solar: only show main frame in widget mode

### DIFF
--- a/apps/hasssolar/README.md
+++ b/apps/hasssolar/README.md
@@ -209,6 +209,24 @@ You can further customize the screen with the following options:
   - Tesla
   - VW
 
+If your SOC sensor can become unavailable (for example, when the car is sleeping), but you want to show the last known state, you can use a trigger-based template sensor like this:
+
+```
+template:
+  - trigger:
+      - platform: state
+        entity_id: sensor.ev_battery
+        not_to:
+          - unknown
+          - unavailable
+    sensor:
+      - name: EV SOC
+        state: '{{ trigger.to_state.state }}'
+        state_class: measurement
+        device_class: battery
+        unit_of_measurement: '%'
+```
+
 If you want to display multiple car screens, you need to add an additional Tidbyt instance for the additional car. Make sure you also always enter your token at the very top of the app details page.
 
 ## Important information about selecting multiple screens to be displayed

--- a/apps/hasssolar/hass_solar.star
+++ b/apps/hasssolar/hass_solar.star
@@ -310,7 +310,7 @@ def render_entity(entity, absolute_value = False, convert_to_kw = False, with_un
         value = value / 1000.0
 
     if dec == None:
-        if value < 10:
+        if value < 9.95:
             value_str = humanize.float("#,###.#", value)
         else:
             value_str = humanize.float("#,###.", value)
@@ -482,6 +482,9 @@ def main(config):
             ),
         ],
     )
+
+    if config.bool("$widget"):
+        return render.Root(main_frame)
 
     if config.bool("show_main", True):
         frames.append(main_frame)


### PR DESCRIPTION
This PR adds support for widget mode by only rendering the main frame.

It also includes a small formatting bugfix where values between 9950 and 9999 W were be displayed as "10.0 kW" which is too long for the main frame - those are now shown as "10 kW".