### PR TITLE
Vidiots: Add schema to control whether "show_full_animation" is used." Show "extra" text for movie times where available. Fix bug where same date is shown for movies with multiple dates.

### DIFF
--- a/apps/vidiotscalendar/vidiots_calendar.star
+++ b/apps/vidiotscalendar/vidiots_calendar.star
@@ -24,7 +24,7 @@ def main(config):
 
     movies = parse_movie_html(response.body())
 
-    return render_animation_for_movies(movies, config.bool("full_animation"))
+    return render_animation_for_movies(movies, config.bool("full_animation", False))
 
 def parse_movie_html(htmlBody):
     showList = html(htmlBody).find("#upcoming-films").children_filtered(".show-list").children_filtered(".show-details")

--- a/apps/vidiotscalendar/vidiots_calendar.star
+++ b/apps/vidiotscalendar/vidiots_calendar.star
@@ -79,8 +79,6 @@ def render_animation_for_movies(movies, full_animation):
             first_time = showtimes[0]
             additional_count = len(showtimes) - 1
 
-            print(first_time.extra)
-
             time_string = first_time.date
             if additional_count > 0:
                 time_string = time_string + " + " + str(additional_count) + " more"

--- a/apps/vidiotscalendar/vidiots_calendar.star
+++ b/apps/vidiotscalendar/vidiots_calendar.star
@@ -9,8 +9,8 @@ load("encoding/base64.star", "base64")
 load("html.star", "html")
 load("http.star", "http")
 load("render.star", "render")
-load("time.star", "time")
 load("schema.star", "schema")
+load("time.star", "time")
 
 VIDIOTS_URL = "https://vidiotsfoundation.org/coming-soon/"
 ANIMATION_DELAY = 50
@@ -95,17 +95,16 @@ def render_animation_for_movies(movies, full_animation):
                     children = [
                         render.Column(
                             children = [
-                                render.Text(time_string)
-                            ]
+                                render.Text(time_string),
+                            ],
                         ),
                         render.Column(
                             children = [
-                                render.Text(showtime_extra_text, color="#ed1c24")
-                            ]
-                        )
-                    ]
-                )
-
+                                render.Text(showtime_extra_text, color = "#ed1c24"),
+                            ],
+                        ),
+                    ],
+                ),
             )
 
         children.append(
@@ -130,7 +129,7 @@ def render_animation_for_movies(movies, full_animation):
 
     return render.Root(
         delay = ANIMATION_DELAY,
-        show_full_animation=full_animation,
+        show_full_animation = full_animation,
         child = render.Padding(
             pad = (0, 0, 0, 2),
             child = render.Column(

--- a/apps/vidiotscalendar/vidiots_calendar.star
+++ b/apps/vidiotscalendar/vidiots_calendar.star
@@ -74,7 +74,7 @@ def render_animation_for_movies(movies, full_animation):
 
         dates_count = len(current_movie.dates)
         for n in range(len(current_movie.dates)):
-            current_date = current_movie.dates.items()[0]
+            current_date = current_movie.dates.items()[n]
             showtimes = current_date[1]
             first_time = showtimes[0]
             additional_count = len(showtimes) - 1


### PR DESCRIPTION
Accidentally left the "extra" text functionality (e.g. showing things like "Walk Up Tickets Only" where available) in the initial version. Also, thought it would be a good idea to let people choose whether they want to request the full animation. Finally there was a bug where movies with multiple dates showed the same date for each date entry.

<img width="1299" alt="Screenshot 2024-08-21 at 11 23 31 PM" src="https://github.com/user-attachments/assets/843eaeb0-1268-4329-84b1-3a6651babb95">
