### PR TITLE
Fix description bug

### DIFF
--- a/apps/launchcountdown/launchcountdown.star
+++ b/apps/launchcountdown/launchcountdown.star
@@ -257,11 +257,10 @@ def display_instructions(config):
     )
 
 def replace_local_time_into_description(description, locallaunch, utclaunch):
-    utc_time_display = ("%s at %s (%s)") % (utclaunch.format("Thursday, January 2, 2006"), utclaunch.format("3:04 PM"), utclaunch.format("MST"))
-    local_time_display = ("%s at %s %s") % (locallaunch.format("Thursday, January 2, 2006"), locallaunch.format("3:04 PM"), locallaunch.format("MST"))
+    utc_time_display = ("%s at %s (%s)") % (utclaunch.format("January 2, 2006"), utclaunch.format("3:04 PM"), utclaunch.format("MST"))
+    local_time_display = ("%s at %s %s") % (locallaunch.format("January 2, 2006"), locallaunch.format("3:04 PM"), locallaunch.format("MST"))
 
-    description = description.replace("\u202f", "")
-    description = description.replace(" ", " ")
+    description = description.replace("\u202f", " ")
     description = description.replace(utc_time_display, local_time_display)
 
     return description


### PR DESCRIPTION
The description from the service generally includes the UTC time of launch. 
Since I've calculated the launch in the local time, I replace the UTC display with the local time display.
There was a bug as a fix I put in to replace a recurring oddball character (\u202f) with an empty string should have replaced it with a single space.