### PR TITLE
NightScout - Add Color Selectors

### DIFF
--- a/apps/nightscout/manifest.yaml
+++ b/apps/nightscout/manifest.yaml
@@ -2,7 +2,7 @@
 id: nightscout
 name: Nightscout
 summary: Shows Nightscout CGM Data
-desc: Displays Continuous Glucose Monitoring (CGM) blood sugar data (BG, Trend, Delta, IOB, COB) from Nightscout. Will display blood sugar as mg/dL or mmol/L. Optionally display historical readings on a graph. Also a clock. For support, join the Nightscout for Tidbyt Facebook group. (v2.5.4).
+desc: Displays Continuous Glucose Monitoring (CGM) blood sugar data (BG, Trend, Delta, IOB, COB) from Nightscout. Will display blood sugar as mg/dL or mmol/L. Optionally display historical readings on a graph. Also a clock. For support, join the Nightscout for Tidbyt Facebook group. (v2.6.0).
 author: Paul Murphy, Jason Hanson, Jeremy Tavener
 fileName: nightscout.star
 packageName: nightscout

--- a/apps/nightscout/nightscout.star
+++ b/apps/nightscout/nightscout.star
@@ -3,7 +3,7 @@ Applet: Nightscout
 Summary: Displays Nightscout CGM Data
 Description: Displays Continuous Glucose Monitoring (CGM) blood sugar data (BG, Trend, Delta, IOB, COB) from Nightscout. Will display blood sugar as mg/dL or mmol/L. Optionally display historical readings on a graph. Also a clock.
 For support, join the Nightscout for Tidbyt Facebook group.
-(v2.5.4)
+(v2.6.0)
 Authors: Paul Murphy, Jason Hanson, Jeremy Tavener
 """
 
@@ -29,7 +29,7 @@ COLOR_BRIGHT_GREEN = "#03FF20"
 COLOR_DARK_GREEN = "#087C15"
 COLOR_BLUE = "#00D0FF"
 COLOR_DARK_BLUE = "#0676FF"
-COLOR_PURPLE = "#009"
+COLOR_PURPLE = "#7701FF"
 COLOR_MAGENTA = "#FF00D0"
 COLOR_GREY = "#777"
 COLOR_WHITE = "#fff"
@@ -46,7 +46,13 @@ DEFAULT_SHOW_GRAPH = True
 DEFAULT_SHOW_GRAPH_HOUR_BARS = True
 DEFAULT_GRAPH_HEIGHT = 300
 DEFAULT_CLOCK_OPTION = "Clock"
+DEFAULT_CLOCK_COLOR = COLOR_ORANGE
 DEFAULT_ID_BORDER_COLOR = COLOR_BLACK
+DEFAULT_IN_RANGE_BG_COLOR = COLOR_GREEN
+DEFAULT_HIGH_BG_COLOR = COLOR_YELLOW
+DEFAULT_LOW_BG_COLOR = COLOR_YELLOW
+DEFAULT_URGENT_HIGH_COLOR = COLOR_RED
+DEFAULT_URGENT_LOW_COLOR = COLOR_RED
 DEFAULT_SHOW_24_HOUR_TIME = False
 DEFAULT_NIGHT_MODE = False
 GRAPH_BOTTOM = 40
@@ -98,7 +104,15 @@ def main(config):
 
     display_unit = config.get("display_unit", DEFAULT_DISPLAY_UNIT)
     clock_option = config.get("clock_option", DEFAULT_CLOCK_OPTION)
+    clock_color = config.get("clock_color", DEFAULT_CLOCK_COLOR)
+    iob_color = config.get("iob_color", DEFAULT_CLOCK_COLOR)
+    cob_color = config.get("cob_color", DEFAULT_CLOCK_COLOR)
     id_border_color = config.get("id_border_color", DEFAULT_ID_BORDER_COLOR)
+    in_range_color = config.get("in_range_color", DEFAULT_IN_RANGE_BG_COLOR)
+    high_color = config.get("high_color", DEFAULT_HIGH_BG_COLOR)
+    low_color = config.get("low_color", DEFAULT_LOW_BG_COLOR)
+    urgent_high_color = config.get("urgent_high_color", DEFAULT_URGENT_HIGH_COLOR)
+    urgent_low_color = config.get("urgent_low_color", DEFAULT_URGENT_LOW_COLOR)
     show_24_hour_time = config.bool("show_24_hour_time", DEFAULT_SHOW_24_HOUR_TIME)
     night_mode = config.bool("night_mode", DEFAULT_NIGHT_MODE)
     nightscout_iob = "n/a"
@@ -238,7 +252,7 @@ def main(config):
     print("oldest_reading_target:", OLDEST_READING_TARGET)
     print("reading_mins_ago:", reading_mins_ago)
 
-    #reading_mins_ago = 7
+    #reading_mins_ago = 5
     if (reading_mins_ago < 1):
         human_reading_ago = "<1 min ago"
     elif (reading_mins_ago == 1):
@@ -258,13 +272,15 @@ def main(config):
     color_delta = COLOR_YELLOW
     color_arrow = COLOR_YELLOW
     color_ago = COLOR_GREY
-    color_graph_urgent_high = COLOR_RED
-    color_graph_high = COLOR_YELLOW
-    color_graph_normal = COLOR_GREEN
-    color_graph_low = COLOR_YELLOW
-    color_graph_urgent_low = COLOR_RED
+    color_graph_urgent_high = urgent_high_color
+    color_graph_high = high_color
+    color_graph_normal = in_range_color
+    color_graph_low = low_color
+    color_graph_urgent_low = urgent_low_color
     color_graph_lines = COLOR_GREY
-    color_clock = COLOR_ORANGE
+    color_clock = clock_color
+    color_iob = iob_color
+    color_cob = cob_color
     color_id_border = id_border_color
 
     lg_clock_row = []
@@ -275,20 +291,37 @@ def main(config):
         color_delta = COLOR_GREY
         color_arrow = COLOR_GREY
         color_ago = COLOR_GREY
+        color_iob = COLOR_GREY
+        color_cob = COLOR_GREY
         direction = "None"
         str_delta = human_reading_ago
         ago_dashes = ">" + str(reading_mins_ago)
         full_ago_dashes = ""
-    elif (sgv_current_mgdl <= normal_high and sgv_current_mgdl >= normal_low):
-        # We're in the normal range, so use green.
-        color_reading = COLOR_GREEN
-        color_delta = COLOR_GREEN
-        color_arrow = COLOR_GREEN
-    elif (sgv_current_mgdl >= urgent_high or sgv_current_mgdl <= urgent_low):
-        # We're in the urgent range, so use red.
-        color_reading = COLOR_RED
-        color_delta = COLOR_RED
-        color_arrow = COLOR_RED
+    elif (sgv_current_mgdl < normal_high and sgv_current_mgdl > normal_low):
+        # We're in the normal range, so use in_range_color.
+        color_reading = in_range_color
+        color_delta = in_range_color
+        color_arrow = in_range_color
+    elif (sgv_current_mgdl >= normal_high and sgv_current_mgdl < urgent_high):
+        # We're in the  high range, so use high_color.
+        color_reading = high_color
+        color_delta = high_color
+        color_arrow = high_color
+    elif (sgv_current_mgdl >= urgent_high):
+        # We're in the urgent high range, so use urgent_high_color.
+        color_reading = urgent_high_color
+        color_delta = urgent_high_color
+        color_arrow = urgent_high_color
+    elif (sgv_current_mgdl <= normal_low and sgv_current_mgdl > urgent_low):
+        # We're in the  low range, so use low_color.
+        color_reading = low_color
+        color_delta = low_color
+        color_arrow = low_color
+    elif (sgv_current_mgdl <= urgent_low):
+        # We're in the urgent low range, so use urgent_low_color.
+        color_reading = urgent_low_color
+        color_delta = urgent_low_color
+        color_arrow = urgent_low_color
     print("night_mode:", night_mode)
     if (night_mode and (now > sun_set or now < sun_rise)):
         color_reading = COLOR_NIGHT
@@ -505,17 +538,25 @@ def main(config):
     else:
         if clock_option == "Clock":
             lg_clock_row = [
-                render.Animation(
+                render.Box(height = 1),
+                render.Row(
+                    cross_align = "center",
+                    main_align = "space_evenly",
+                    expanded = True,
                     children = [
-                        render.Text(
-                            content = now.format("15:04" if show_24_hour_time else "3:04 PM"),
-                            font = "6x13",
-                            color = color_clock,
-                        ),
-                        render.Text(
-                            content = now.format("15 04" if show_24_hour_time else "3 04 PM"),
-                            font = "6x13",
-                            color = color_clock,
+                        render.Animation(
+                            children = [
+                                render.Text(
+                                    content = now.format("15:04" if show_24_hour_time else "3:04 PM"),
+                                    font = "6x13",
+                                    color = color_clock,
+                                ),
+                                render.Text(
+                                    content = now.format("15 04" if show_24_hour_time else "3 04 PM"),
+                                    font = "6x13",
+                                    color = color_clock,
+                                ),
+                            ],
                         ),
                     ],
                 ),
@@ -542,10 +583,18 @@ def main(config):
 
         elif clock_option == "IOB" or clock_option == "COB":
             lg_clock_row = [
-                render.Text(
-                    content = nightscout_iob if clock_option == "IOB" else nightscout_cob,
-                    font = "6x13",
-                    color = color_reading,
+                render.Box(height = 14),
+                render.Row(
+                    cross_align = "center",
+                    main_align = "space_evenly",
+                    expanded = True,
+                    children = [
+                        render.Text(
+                            content = nightscout_iob if clock_option == "IOB" else nightscout_cob,
+                            font = "6x13",
+                            color = color_iob if clock_option == "IOB" else color_cob,
+                        ),
+                    ],
                 ),
             ]
 
@@ -553,7 +602,7 @@ def main(config):
                 render.WrappedText(
                     content = nightscout_iob if clock_option == "IOB" else nightscout_cob,
                     font = "tom-thumb",
-                    color = color_reading,
+                    color = color_iob if clock_option == "IOB" else color_cob,
                     width = left_col_width,
                     align = "center",
                     height = 6,
@@ -565,7 +614,7 @@ def main(config):
             one_column_delta_row = [
                 render.Box(
                     width = 2,
-                    height = 13,
+                    height = 14 if clock_option == "Clock" else 1,
                 ),
                 render.Row(
                     cross_align = "center",
@@ -584,17 +633,21 @@ def main(config):
                             align = "center",
                             height = 18,
                         ),
+                        render.Box(
+                            width = 4,
+                            height = 18,
+                        ),
                         render.WrappedText(
                             content = str_delta.replace("0", "O"),
                             font = "tom-thumb",
                             color = color_delta,
                             align = "center",
-                            width = 37,
+                            width = 30,
                             linespacing = 0,
-                            height = 12,
+                            height = 14,
                         ),
                         render.Box(
-                            width = 2,
+                            width = 5,
                             height = 18,
                         ),
                     ],
@@ -602,7 +655,7 @@ def main(config):
             ]
         else:
             one_column_delta_row = [
-                render.Box(height = 13),
+                render.Box(height = 14 if clock_option == "Clock" else 1),
                 render.Row(
                     cross_align = "center",
                     main_align = "center",
@@ -645,15 +698,7 @@ def main(config):
                     render.Column(
                         main_align = "start",
                         cross_align = "center",
-                        children = [
-                            render.Box(height = 1),
-                            render.Row(
-                                cross_align = "center",
-                                main_align = "space_evenly",
-                                expanded = True,
-                                children = lg_clock_row,
-                            ),
-                        ],
+                        children = lg_clock_row,
                     ),
                     render.Column(
                         main_align = "start",
@@ -664,7 +709,7 @@ def main(config):
                         main_align = "start",
                         cross_align = "center",
                         children = [
-                            render.Box(height = 26),
+                            render.Box(height = 27),
                             render.Row(
                                 cross_align = "center",
                                 main_align = "space_evenly",
@@ -1008,19 +1053,94 @@ def display_unit_options(display_unit):
             icon = "rulerVertical",
             default = str(graph_height),
         ),
+        schema.Color(
+            id = "in_range_color",
+            name = "In Range Color",
+            desc = "Color of readings when BG is in range (Between the High and Low values)",
+            icon = "brush",
+            default = DEFAULT_IN_RANGE_BG_COLOR,
+            palette = [
+                COLOR_BLACK,
+                COLOR_WHITE,
+                COLOR_GREY,
+                COLOR_RED,
+                COLOR_DARK_RED,
+                COLOR_PINK,
+                COLOR_ORANGE,
+                COLOR_YELLOW,
+                COLOR_BRIGHT_GREEN,
+                COLOR_GREEN,
+                COLOR_DARK_GREEN,
+                COLOR_BLUE,
+                COLOR_DARK_BLUE,
+                COLOR_PURPLE,
+                COLOR_MAGENTA,
+                COLOR_BRIGHT_RED,
+            ],
+        ),
         schema.Text(
             id = display_unit + "_normal_high",
-            name = "Normal High Threshold (in " + unit + ")",
-            desc = "Anything above this is displayed yellow unless it is above the Urgent High Threshold (default " + str(normal_high) + ")",
+            name = "High Threshold (in " + unit + ")",
+            desc = "High Readings Threshold (default " + str(normal_high) + ")",
             icon = "droplet",
             default = str(normal_high),
         ),
+        schema.Color(
+            id = "high_color",
+            name = "High BG Color",
+            desc = "Color of readings when BG is above the High Threshold and Below the Urgent High Threshold",
+            icon = "brush",
+            default = DEFAULT_HIGH_BG_COLOR,
+            palette = [
+                COLOR_BLACK,
+                COLOR_WHITE,
+                COLOR_GREY,
+                COLOR_RED,
+                COLOR_DARK_RED,
+                COLOR_PINK,
+                COLOR_ORANGE,
+                COLOR_YELLOW,
+                COLOR_BRIGHT_GREEN,
+                COLOR_GREEN,
+                COLOR_DARK_GREEN,
+                COLOR_BLUE,
+                COLOR_DARK_BLUE,
+                COLOR_PURPLE,
+                COLOR_MAGENTA,
+                COLOR_BRIGHT_RED,
+            ],
+        ),
         schema.Text(
             id = display_unit + "_normal_low",
-            name = "Normal Low Threshold (in " + unit + ")",
+            name = "Low Threshold (in " + unit + ")",
             desc = "Anything below this is displayed yellow unless it is below the Urgent Low Threshold (default " + str(normal_low) + ")",
             icon = "droplet",
             default = str(normal_low),
+        ),
+        schema.Color(
+            id = "low_color",
+            name = "Low BG Color",
+            desc = "Color of readings when BG is below the Low Threshold and Above the Urgent Low Threshold",
+            icon = "brush",
+            default = DEFAULT_LOW_BG_COLOR,
+            palette = [
+                COLOR_BLACK,
+                COLOR_WHITE,
+                COLOR_GREY,
+                COLOR_RED,
+                COLOR_DARK_RED,
+                COLOR_PINK,
+                COLOR_ORANGE,
+                COLOR_YELLOW,
+                COLOR_BRIGHT_GREEN,
+                COLOR_GREEN,
+                COLOR_DARK_GREEN,
+                COLOR_BLUE,
+                COLOR_DARK_BLUE,
+                COLOR_PURPLE,
+                COLOR_MAGENTA,
+                COLOR_BRIGHT_RED,
+            ],
         ),
         schema.Text(
             id = display_unit + "_urgent_high",
@@ -1029,12 +1149,62 @@ def display_unit_options(display_unit):
             icon = "droplet",
             default = str(urgent_high),
         ),
+        schema.Color(
+            id = "urgent_high_color",
+            name = "Urgent High BG Color",
+            desc = "Color of readings when BG is Above the Urgent High Threshold",
+            icon = "brush",
+            default = DEFAULT_URGENT_HIGH_COLOR,
+            palette = [
+                COLOR_BLACK,
+                COLOR_WHITE,
+                COLOR_GREY,
+                COLOR_RED,
+                COLOR_DARK_RED,
+                COLOR_PINK,
+                COLOR_ORANGE,
+                COLOR_YELLOW,
+                COLOR_BRIGHT_GREEN,
+                COLOR_GREEN,
+                COLOR_DARK_GREEN,
+                COLOR_BLUE,
+                COLOR_DARK_BLUE,
+                COLOR_PURPLE,
+                COLOR_MAGENTA,
+                COLOR_BRIGHT_RED,
+            ],
+        ),
         schema.Text(
             id = display_unit + "_urgent_low",
             name = "Urgent Low Threshold (in " + unit + ")",
             desc = "Anything below this is displayed red (Default " + str(urgent_low) + ")",
             icon = "droplet",
             default = str(urgent_low),
+        ),
+        schema.Color(
+            id = "urgent_low_color",
+            name = "Urgent Low BG Color",
+            desc = "Color of readings when BG is Below the Urgent Low Threshold",
+            icon = "brush",
+            default = DEFAULT_URGENT_LOW_COLOR,
+            palette = [
+                COLOR_BLACK,
+                COLOR_WHITE,
+                COLOR_GREY,
+                COLOR_RED,
+                COLOR_DARK_RED,
+                COLOR_PINK,
+                COLOR_ORANGE,
+                COLOR_YELLOW,
+                COLOR_BRIGHT_GREEN,
+                COLOR_GREEN,
+                COLOR_DARK_GREEN,
+                COLOR_BLUE,
+                COLOR_DARK_BLUE,
+                COLOR_PURPLE,
+                COLOR_MAGENTA,
+                COLOR_BRIGHT_RED,
+            ],
         ),
     ]
 
@@ -1095,7 +1265,7 @@ def get_schema():
                 name = "ID Border Color",
                 desc = "Color of the border. Used for differentiating between multiple T1D's in a household",
                 icon = "idBadge",
-                default = COLOR_BLACK,
+                default = DEFAULT_ID_BORDER_COLOR,
                 palette = [
                     COLOR_BLACK,
                     COLOR_WHITE,
@@ -1149,6 +1319,81 @@ def get_schema():
                 icon = "gear",
                 default = clock_options[1].value,
                 options = clock_options,
+            ),
+            schema.Color(
+                id = "clock_color",
+                name = "Clock Color",
+                desc = "Color of clock",
+                icon = "brush",
+                default = DEFAULT_CLOCK_COLOR,
+                palette = [
+                    COLOR_BLACK,
+                    COLOR_WHITE,
+                    COLOR_GREY,
+                    COLOR_RED,
+                    COLOR_DARK_RED,
+                    COLOR_PINK,
+                    COLOR_ORANGE,
+                    COLOR_YELLOW,
+                    COLOR_BRIGHT_GREEN,
+                    COLOR_GREEN,
+                    COLOR_DARK_GREEN,
+                    COLOR_BLUE,
+                    COLOR_DARK_BLUE,
+                    COLOR_PURPLE,
+                    COLOR_MAGENTA,
+                    COLOR_BRIGHT_RED,
+                ],
+            ),
+            schema.Color(
+                id = "iob_color",
+                name = "IOB Color",
+                desc = "Color of IOB display",
+                icon = "brush",
+                default = DEFAULT_CLOCK_COLOR,
+                palette = [
+                    COLOR_BLACK,
+                    COLOR_WHITE,
+                    COLOR_GREY,
+                    COLOR_RED,
+                    COLOR_DARK_RED,
+                    COLOR_PINK,
+                    COLOR_ORANGE,
+                    COLOR_YELLOW,
+                    COLOR_BRIGHT_GREEN,
+                    COLOR_GREEN,
+                    COLOR_DARK_GREEN,
+                    COLOR_BLUE,
+                    COLOR_DARK_BLUE,
+                    COLOR_PURPLE,
+                    COLOR_MAGENTA,
+                    COLOR_BRIGHT_RED,
+                ],
+            ),
+            schema.Color(
+                id = "cob_color",
+                name = "COB Color",
+                desc = "Color of COB display",
+                icon = "brush",
+                default = DEFAULT_CLOCK_COLOR,
+                palette = [
+                    COLOR_BLACK,
+                    COLOR_WHITE,
+                    COLOR_GREY,
+                    COLOR_RED,
+                    COLOR_DARK_RED,
+                    COLOR_PINK,
+                    COLOR_ORANGE,
+                    COLOR_YELLOW,
+                    COLOR_BRIGHT_GREEN,
+                    COLOR_GREEN,
+                    COLOR_DARK_GREEN,
+                    COLOR_BLUE,
+                    COLOR_DARK_BLUE,
+                    COLOR_PURPLE,
+                    COLOR_MAGENTA,
+                    COLOR_BRIGHT_RED,
+                ],
             ),
             schema.Toggle(
                 id = "show_24_hour_time",


### PR DESCRIPTION
Add color selectors and color display code for in-range, high, low, urgent high, urgent low readings. Also for Clock, IOB, COB display 
Moved IOB and COB below reading when no graph is shown 
Cleaned up spacing in no-graph mode
Cleaned up spacing for stale display with IOB or COB below reading