### PR TITLE
The Weekendest: Add option to only show certain lines

### DIFF
--- a/apps/goodservice/goodservice.star
+++ b/apps/goodservice/goodservice.star
@@ -92,6 +92,9 @@ def main(config):
     blocks = []
     min_estimated_arrival_time = ts + (travel_time_min * 60)
 
+    include_lines_str = config.str("include_lines", "").upper()
+    include_lines = include_lines_str.split(",")
+
     for dir in directions:
         upcoming_routes = {
             "north": [],
@@ -139,9 +142,7 @@ def main(config):
 
                 selected_route = routes_req.json()["routes"][r["route_id"]]
 
-                include_lines_str = config.str("include_lines", "").lower()
-                include_lines = include_lines_str.split(",")
-                route_name = selected_route["name"].lower()
+                route_name = selected_route["name"].upper()
 
                 if include_lines_str and len(include_lines) and route_name not in include_lines:
                     continue

--- a/apps/goodservice/goodservice.star
+++ b/apps/goodservice/goodservice.star
@@ -111,7 +111,6 @@ def main(config):
                 if r["route_id"] == trip["route_id"] and r["destination_stop"] == trip["destination_stop"]:
                     matching_route = r
                     break
-
             if matching_route:
                 if len(matching_route["times"]) < 3:
                     matching_route["times"].append(trip["estimated_current_stop_arrival_time"])
@@ -139,6 +138,14 @@ def main(config):
                         blocks.append(render.Box(width = 64, height = 1, color = "#333"))
 
                 selected_route = routes_req.json()["routes"][r["route_id"]]
+
+                include_lines_str = config.str("include_lines", "").lower()
+                include_lines = include_lines_str.split(',')
+                route_name = selected_route["name"].lower()
+
+                if include_lines_str and len(include_lines) and route_name not in include_lines:
+                    continue
+
                 route_color = selected_route["color"]
                 text_color = selected_route["text_color"] if selected_route["text_color"] else "#fff"
                 destination = None
@@ -372,6 +379,13 @@ def get_schema():
                         value = DISPLAY_ORDER_ALPHABETICAL,
                     ),
                 ],
+            ),
+            schema.Text(
+              id = "include_lines",
+              name = "Filter Lines",
+              desc = "Only show certain lines (comma separated)",
+              icon = "route",
+              default = "",
             ),
         ],
     )

--- a/apps/goodservice/goodservice.star
+++ b/apps/goodservice/goodservice.star
@@ -140,7 +140,7 @@ def main(config):
                 selected_route = routes_req.json()["routes"][r["route_id"]]
 
                 include_lines_str = config.str("include_lines", "").lower()
-                include_lines = include_lines_str.split(',')
+                include_lines = include_lines_str.split(",")
                 route_name = selected_route["name"].lower()
 
                 if include_lines_str and len(include_lines) and route_name not in include_lines:
@@ -381,11 +381,11 @@ def get_schema():
                 ],
             ),
             schema.Text(
-              id = "include_lines",
-              name = "Filter Lines",
-              desc = "Only show certain lines (comma separated)",
-              icon = "route",
-              default = "",
+                id = "include_lines",
+                name = "Filter Lines",
+                desc = "Only show certain lines (comma separated)",
+                icon = "route",
+                default = "",
             ),
         ],
     )


### PR DESCRIPTION
Allows you to set a comma-separated list of lines (e.g. `"A,C"`) to filter to show instead of all the lines of the station.
<img width="395" alt="image" src="https://github.com/user-attachments/assets/16b3d37e-d0f5-4967-8447-3da5ec9bb113">

## Before
<img width="791" alt="image" src="https://github.com/user-attachments/assets/37df5bb1-9145-4399-ba27-012c0c875120">

## After
<img width="788" alt="image" src="https://github.com/user-attachments/assets/a2a237e3-e70c-408d-81d4-0abc66023231">
