### PR TITLE
[pagerduty] handle more body-less responses

### DIFF
--- a/apps/pagerduty/pagerduty.star
+++ b/apps/pagerduty/pagerduty.star
@@ -85,7 +85,7 @@ def pagerduty_api_call(config, url, use_cache = True):
     )
     body = res.body()
 
-    if (res.status_code < 200 or res.status_code >= 300) and len(body) <= 0:
+    if len(body) <= 0:
         body = '{"status":%i}' % res.status_code
 
     return json.decode(body)


### PR DESCRIPTION
Hey @matslina, had a couple of folks on Discord ask about the PagerDuty app being broken. 

Testing with a free trial locally, I found that the `/abilities/teams` endpoint is returning 204 without a body, leading to a JSON parsing failure. This change ensures that a body will always be passed.