### PR TITLE
Adding FlyByWire Statistics app

### DIFF
--- a/apps/fbw-flight-stats/flybywire_flights.star
+++ b/apps/fbw-flight-stats/flybywire_flights.star
@@ -5,10 +5,10 @@ Description: Shows a count of the number of flights using the FlyByWire Simulati
 Author: Philippe Dellaert (pdellaert)
 """
 
+load("animation.star", "animation")
 load("encoding/base64.star", "base64")
 load("http.star", "http")
 load("render.star", "render")
-load("animation.star", "animation")
 
 FBW_ICON = base64.decode("iVBORw0KGgoAAAANSUhEUgAAACAAAAAeCAYAAABNChwpAAAABmJLR0QA/wD/AP+gvaeTAAACNklEQVRIibWWvW4TQRSFv7k2YEBCJB2ksKkoI/EGFKFzWiRAoqSIUtEgaBCKRAEFj0BJQ8MLpKPxelFcU9vvwI8Phb3O7M7sj9fLkVbyXu/e+831uTN2/A8lusI1XjvjOaYhhuFABmTXSot+58Ul52Z8Bca5sAOy61JTo2P1LniKY4xfMF4cpI4BzjUQnHkVwmd8CGeTTgHsNqc4hqWrL3YA0jDUVjPt2ZKfcuxvjGYCK5jvsuKckR101gH7wxtgv3L1/nLFFPyB2EWphhgn+WKR3z9H7LoDMHGGGAQlKyeABGD3fSDVIfCkrOWKmw8ghQ464JZ8CPPUjB/MGbnFzgD9RI+c46jWeGH7p9nH9gCSLeF9ljxmuVIbrg24E0Av4RnwAKhffYkB2wOcayDHu3ihmvFbKd0JwG5xCgyz+1zJ+u13Y8B2ADPtIV6VFvPHLybPgK0A7Nd6yy3JnlOsA54BtwdINQROcsm3Md+KMfFvtwKwv5wBgw0AW47fSql/0/w4TnVoS1Iy6PXxmjtqY8dvXnNGduAHGncgt+VG29xg/AoGbAzQm+jYwVGYL6MruYJqrgXAd12X41MuVjV+VbkKBmwEYFf5CNyrfsorW9kBfhRDlSbsTfVY4kvwRmBAhbEw84KR3Q2ZStRP9FDic9n3W49fpP2lAL2JjpfwjWzmfbXdgFAai+b/kiW6YeKtHC+jcNECjU4/MAsmYAVwoZv85r45xogXOO7U5VIRpnb1gAv3AIB/ckOaE1gXKjEAAAAASUVORK5CYII=")
 FBW_COUNT_API = "https://api.flybywiresim.com/txcxn/_count"
@@ -29,14 +29,14 @@ def main():
                 cross_align = "center",
                 main_align = "space_around",
                 children = [
-                        render.Padding(
-                            child = render.Image(
-                                src = FBW_ICON,
-                                width = 32,
-                                height = 30,
-                            ),
-                            pad = (0, 1, 0, 0),
+                    render.Padding(
+                        child = render.Image(
+                            src = FBW_ICON,
+                            width = 32,
+                            height = 30,
                         ),
+                        pad = (0, 1, 0, 0),
+                    ),
                     render.Text(
                         content = "%s" % getCount(),
                         font = "6x13",
@@ -52,8 +52,8 @@ def main():
                         animation.Translate(
                             x = 64,
                             y = 0,
-                        )
-                    ]
+                        ),
+                    ],
                 ),
                 animation.Keyframe(
                     percentage = 0.1,
@@ -61,7 +61,7 @@ def main():
                         animation.Translate(
                             x = 0,
                             y = 0,
-                        )
+                        ),
                     ],
                 ),
                 animation.Keyframe(
@@ -74,7 +74,7 @@ def main():
                         animation.Translate(
                             x = -64,
                             y = 0,
-                        )
+                        ),
                     ],
                 ),
             ],

--- a/apps/fbw-flight-stats/flybywire_flights.star
+++ b/apps/fbw-flight-stats/flybywire_flights.star
@@ -1,0 +1,85 @@
+"""
+Applet: FlyByWire Flights
+Summary: FlyByWire Number of Flights
+Description: Shows a count of the number of flights using the FlyByWire Simulations systems.
+Author: Philippe Dellaert (pdellaert)
+"""
+
+load("encoding/base64.star", "base64")
+load("http.star", "http")
+load("render.star", "render")
+load("animation.star", "animation")
+
+FBW_ICON = base64.decode("iVBORw0KGgoAAAANSUhEUgAAACAAAAAeCAYAAABNChwpAAAABmJLR0QA/wD/AP+gvaeTAAACNklEQVRIibWWvW4TQRSFv7k2YEBCJB2ksKkoI/EGFKFzWiRAoqSIUtEgaBCKRAEFj0BJQ8MLpKPxelFcU9vvwI8Phb3O7M7sj9fLkVbyXu/e+831uTN2/A8lusI1XjvjOaYhhuFABmTXSot+58Ul52Z8Bca5sAOy61JTo2P1LniKY4xfMF4cpI4BzjUQnHkVwmd8CGeTTgHsNqc4hqWrL3YA0jDUVjPt2ZKfcuxvjGYCK5jvsuKckR101gH7wxtgv3L1/nLFFPyB2EWphhgn+WKR3z9H7LoDMHGGGAQlKyeABGD3fSDVIfCkrOWKmw8ghQ464JZ8CPPUjB/MGbnFzgD9RI+c46jWeGH7p9nH9gCSLeF9ljxmuVIbrg24E0Av4RnwAKhffYkB2wOcayDHu3ihmvFbKd0JwG5xCgyz+1zJ+u13Y8B2ADPtIV6VFvPHLybPgK0A7Nd6yy3JnlOsA54BtwdINQROcsm3Md+KMfFvtwKwv5wBgw0AW47fSql/0/w4TnVoS1Iy6PXxmjtqY8dvXnNGduAHGncgt+VG29xg/AoGbAzQm+jYwVGYL6MruYJqrgXAd12X41MuVjV+VbkKBmwEYFf5CNyrfsorW9kBfhRDlSbsTfVY4kvwRmBAhbEw84KR3Q2ZStRP9FDic9n3W49fpP2lAL2JjpfwjWzmfbXdgFAai+b/kiW6YeKtHC+jcNECjU4/MAsmYAVwoZv85r45xogXOO7U5VIRpnb1gAv3AIB/ckOaE1gXKjEAAAAASUVORK5CYII=")
+FBW_COUNT_API = "https://api.flybywiresim.com/txcxn/_count"
+
+def getCount():
+    response = http.get(FBW_COUNT_API, ttl_seconds = 60)
+    if response.status_code == 200:
+        return response.body()
+    else:
+        print("Failed to fetch data from API. Status code:", response.status_code)
+        return "N/A"
+
+def main():
+    return render.Root(
+        child = animation.Transformation(
+            child = render.Row(
+                expanded = True,
+                cross_align = "center",
+                main_align = "space_around",
+                children = [
+                        render.Padding(
+                            child = render.Image(
+                                src = FBW_ICON,
+                                width = 32,
+                                height = 30,
+                            ),
+                            pad = (0, 1, 0, 0),
+                        ),
+                    render.Text(
+                        content = "%s" % getCount(),
+                        font = "6x13",
+                        color = "#00c2cc",
+                    ),
+                ],
+            ),
+            keyframes = [
+                animation.Keyframe(
+                    percentage = 0.0,
+                    curve = "ease_in",
+                    transforms = [
+                        animation.Translate(
+                            x = 64,
+                            y = 0,
+                        )
+                    ]
+                ),
+                animation.Keyframe(
+                    percentage = 0.1,
+                    transforms = [
+                        animation.Translate(
+                            x = 0,
+                            y = 0,
+                        )
+                    ],
+                ),
+                animation.Keyframe(
+                    percentage = 0.9,
+                    transforms = [],
+                ),
+                animation.Keyframe(
+                    percentage = 1.0,
+                    transforms = [
+                        animation.Translate(
+                            x = -64,
+                            y = 0,
+                        )
+                    ],
+                ),
+            ],
+            origin = animation.Origin(x = 1, y = 0),
+            duration = 250,
+            delay = 0,
+        ),
+    )

--- a/apps/fbw-flight-stats/manifest.yaml
+++ b/apps/fbw-flight-stats/manifest.yaml
@@ -1,0 +1,6 @@
+---
+id: flybywire-flights
+name: FlyByWire Flights
+summary: FlyByWire Number of Flights
+desc: Shows a count of the number of flights using the FlyByWire Simulations systems.
+author: Philippe Dellaert (pdellaert)


### PR DESCRIPTION
## Purpose

An app that tracks the number of flights using the [FlyByWire Simulations](https://flybywiresim.com/) systems, with a nice animation that works well for the Normal rate, but even for the Turbo speed. For Normal speed it will float the FlyByWire Logo and the count from the left, and exit the frame to the left. For other speeds, it will float in, then stay and be replaced with the next app. 

![flybywire_flights](https://github.com/user-attachments/assets/d0e855bd-ee12-4d99-bbff-52e23e18a86d)

### About FlyByWire Simulations

FlyByWire Simulations is a non-profit group of volunteers who build FOSS (GPL licensed) add-ons and infrastructure for Microsoft Flight Simulator 2020 (and 2024 in the future). Our current mainline add-on, called A32NX, is a representation of the A320Neo for MSFS and we are actively working on a representation of the A380 as well. All of this is done out of love and passion for the Flight Simulator Community and our interest in development in this field. 

Our goal is to provide not only high quality add-ons for free to the community, but also allow others to use our base systems and installer platform for their own add-ons (there are other organizations using our systems for their A330, A319, A321, ... aircraft for MSFS). By doing so we hope to enhance the quality and collaboration amongst the community, while enjoying ourselves, learning from each other and building strong friendships. 