### PR TITLE
Improve spacing sbb app

### DIFF
--- a/apps/sbbtimetable/sbb_timetable.star
+++ b/apps/sbbtimetable/sbb_timetable.star
@@ -162,10 +162,10 @@ def main(config):
                         color = trainCategoryColor,
                         padding = 0,
                         child = render.Row(
-                                children = [
+                            children = [
                                 render.Text(
-                                content = "%s" % trainCategory,
-                                font = FONT_TO_USE,
+                                    content = "%s" % trainCategory,
+                                    font = FONT_TO_USE,
                                 ),
                             ],
                         ),
@@ -181,10 +181,10 @@ def main(config):
                         color = trainCategoryColor,
                         padding = 0,
                         child = render.Row(
-                                children = [
+                            children = [
                                 render.Text(
-                                content = "%s" % trainCategoryLine,
-                                font = FONT_TO_USE,
+                                    content = "%s" % trainCategoryLine,
+                                    font = FONT_TO_USE,
                                 ),
                             ],
                         ),
@@ -203,9 +203,9 @@ def main(config):
                 render.Column(
                     children = [
                         render.Box(width = 1, height = 1),
-                        render.Box(width = 1, height = 1, color="#FFF"),
+                        render.Box(width = 1, height = 1, color = "#FFF"),
                         render.Box(width = 1, height = 1),
-                        render.Box(width = 1, height = 1, color="#FFF"),
+                        render.Box(width = 1, height = 1, color = "#FFF"),
                         render.Box(width = 1, height = 1),
                     ],
                 ),
@@ -215,19 +215,19 @@ def main(config):
                     font = FONT_TO_USE,
                 ),
             ]
-                
 
             if trainDelay == "+0":
-                renderTime = render.Row(children=renderTimeNormal)
+                renderTime = render.Row(children = renderTimeNormal)
             else:
                 renderTimeChild = []
-                renderTimeChild.extend([
-                    render.Box(
-                        width = 18,
-                        height = 5,
-                        padding = 0,
-                        child = render.Row(children=renderTimeNormal)
-                    ),
+                renderTimeChild.extend(
+                    [
+                        render.Box(
+                            width = 18,
+                            height = 5,
+                            padding = 0,
+                            child = render.Row(children = renderTimeNormal),
+                        ),
                     ] * NO_FRAMES_TOGGLE,
                 )
                 if trainDelay == "X":
@@ -235,31 +235,32 @@ def main(config):
                 else:
                     delayText = (time.parse_duration("%sm" % trainDelay) + time.parse_time(trainTime, format = "2006-01-02 15:04:05")).format("15:04")
                 hoursDelay, minutesDelay = delayText.split(":")
-                renderTimeChild.extend([
-                    render.Row(
-                        children = [
-                            render.Text(
-                                content = hoursDelay,
-                                font = FONT_TO_USE,
-                                color = COLOR_DELAY,
-                            ),
-                            render.Column(
-                                children = [
-                                    render.Box(width = 1, height = 1),
-                                    render.Box(width = 1, height = 1, color=COLOR_DELAY),
-                                    render.Box(width = 1, height = 1),
-                                    render.Box(width = 1, height = 1, color=COLOR_DELAY),
-                                    render.Box(width = 1, height = 1),
-                                ],
-                            ),
-                            render.Box(width = 1, height = 5),
-                            render.Text(
-                                content = minutesDelay,
-                                font = FONT_TO_USE,
-                                color = COLOR_DELAY,
-                            ),
-                        ],
-                    ),
+                renderTimeChild.extend(
+                    [
+                        render.Row(
+                            children = [
+                                render.Text(
+                                    content = hoursDelay,
+                                    font = FONT_TO_USE,
+                                    color = COLOR_DELAY,
+                                ),
+                                render.Column(
+                                    children = [
+                                        render.Box(width = 1, height = 1),
+                                        render.Box(width = 1, height = 1, color = COLOR_DELAY),
+                                        render.Box(width = 1, height = 1),
+                                        render.Box(width = 1, height = 1, color = COLOR_DELAY),
+                                        render.Box(width = 1, height = 1),
+                                    ],
+                                ),
+                                render.Box(width = 1, height = 5),
+                                render.Text(
+                                    content = minutesDelay,
+                                    font = FONT_TO_USE,
+                                    color = COLOR_DELAY,
+                                ),
+                            ],
+                        ),
                     ] * NO_FRAMES_TOGGLE,
                 )
                 renderTime = render.Animation(children = renderTimeChild)
@@ -276,7 +277,6 @@ def main(config):
                             color = COLOR_DELAY,
                             font = FONT_TO_USE,
                         ),
-                        
                         render.Box(width = 1, height = 5),
                         render.Marquee(
                             width = 37 if trainDelay == "+0" else 37 - len(trainDelay) * 4,

--- a/apps/sbbtimetable/sbb_timetable.star
+++ b/apps/sbbtimetable/sbb_timetable.star
@@ -215,15 +215,16 @@ def main(config):
                 render.Row(
                     children = [
                         render.Animation(children = renderCategory),
-                        render.Box(width = 1, height = 5),
+                        render.Box(width = 2, height = 5),
                         renderTime,
                         render.Text(
                             content = "" if trainDelay == "+0" else "%s" % trainDelay,
                             color = COLOR_DELAY,
                             font = FONT_TO_USE,
                         ),
+                        render.Box(width = 1, height = 5),
                         render.Marquee(
-                            width = 36 if trainDelay == "+0" else 36 - len(trainDelay) * 4,
+                            width = 34 if trainDelay == "+0" else 34 - len(trainDelay) * 4,
                             child = render.Text(
                                 content = "%s" % trainDest,
                                 font = FONT_TO_USE,

--- a/apps/sbbtimetable/sbb_timetable.star
+++ b/apps/sbbtimetable/sbb_timetable.star
@@ -157,13 +157,17 @@ def main(config):
             renderCategory.extend(
                 [
                     render.Box(
-                        width = 8,
+                        width = 7,
                         height = 5,
                         color = trainCategoryColor,
                         padding = 0,
-                        child = render.Text(
-                            content = "%s" % trainCategory,
-                            font = FONT_TO_USE,
+                        child = render.Row(
+                                children = [
+                                render.Text(
+                                content = "%s" % trainCategory,
+                                font = FONT_TO_USE,
+                                ),
+                            ],
                         ),
                     ),
                 ] * NO_FRAMES_TOGGLE,
@@ -172,40 +176,90 @@ def main(config):
             renderCategory.extend(
                 [
                     render.Box(
-                        width = 8,
+                        width = 7,
                         height = 5,
                         color = trainCategoryColor,
                         padding = 0,
-                        child = render.Text(
-                            content = "%s" % trainCategoryLine,
-                            font = FONT_TO_USE,
+                        child = render.Row(
+                                children = [
+                                render.Text(
+                                content = "%s" % trainCategoryLine,
+                                font = FONT_TO_USE,
+                                ),
+                            ],
                         ),
                     ),
                 ] * NO_FRAMES_TOGGLE,
             )
 
             # Render the train delay
-            renderTimeNormal = render.Text(
-                content = "%s" % time.parse_time(trainTime, format = "2006-01-02 15:04:05").format("15:04"),
-                font = FONT_TO_USE,
-            )
+            timeText = time.parse_time(trainTime, format = "2006-01-02 15:04:05").format("15:04")
+            hours, minutes = timeText.split(":")
+            renderTimeNormal = [
+                render.Text(
+                    content = hours,
+                    font = FONT_TO_USE,
+                ),
+                render.Column(
+                    children = [
+                        render.Box(width = 1, height = 1),
+                        render.Box(width = 1, height = 1, color="#FFF"),
+                        render.Box(width = 1, height = 1),
+                        render.Box(width = 1, height = 1, color="#FFF"),
+                        render.Box(width = 1, height = 1),
+                    ],
+                ),
+                render.Box(width = 1, height = 5),
+                render.Text(
+                    content = minutes,
+                    font = FONT_TO_USE,
+                ),
+            ]
+                
 
             if trainDelay == "+0":
-                renderTime = renderTimeNormal
+                renderTime = render.Row(children=renderTimeNormal)
             else:
                 renderTimeChild = []
-                renderTimeChild.extend([renderTimeNormal] * NO_FRAMES_TOGGLE)
+                renderTimeChild.extend([
+                    render.Box(
+                        width = 18,
+                        height = 5,
+                        padding = 0,
+                        child = render.Row(children=renderTimeNormal)
+                    ),
+                    ] * NO_FRAMES_TOGGLE,
+                )
                 if trainDelay == "X":
                     delayText = "--:--"
                 else:
                     delayText = (time.parse_duration("%sm" % trainDelay) + time.parse_time(trainTime, format = "2006-01-02 15:04:05")).format("15:04")
-                renderTimeChild.extend(
-                    [
-                        render.Text(
-                            content = delayText,
-                            font = FONT_TO_USE,
-                            color = COLOR_DELAY,
-                        ),
+                hoursDelay, minutesDelay = delayText.split(":")
+                renderTimeChild.extend([
+                    render.Row(
+                        children = [
+                            render.Text(
+                                content = hoursDelay,
+                                font = FONT_TO_USE,
+                                color = COLOR_DELAY,
+                            ),
+                            render.Column(
+                                children = [
+                                    render.Box(width = 1, height = 1),
+                                    render.Box(width = 1, height = 1, color=COLOR_DELAY),
+                                    render.Box(width = 1, height = 1),
+                                    render.Box(width = 1, height = 1, color=COLOR_DELAY),
+                                    render.Box(width = 1, height = 1),
+                                ],
+                            ),
+                            render.Box(width = 1, height = 5),
+                            render.Text(
+                                content = minutesDelay,
+                                font = FONT_TO_USE,
+                                color = COLOR_DELAY,
+                            ),
+                        ],
+                    ),
                     ] * NO_FRAMES_TOGGLE,
                 )
                 renderTime = render.Animation(children = renderTimeChild)
@@ -222,9 +276,10 @@ def main(config):
                             color = COLOR_DELAY,
                             font = FONT_TO_USE,
                         ),
+                        
                         render.Box(width = 1, height = 5),
                         render.Marquee(
-                            width = 34 if trainDelay == "+0" else 34 - len(trainDelay) * 4,
+                            width = 37 if trainDelay == "+0" else 37 - len(trainDelay) * 4,
                             child = render.Text(
                                 content = "%s" % trainDest,
                                 font = FONT_TO_USE,


### PR DESCRIPTION
This pull request optimizes the spacing of the SBB App, mainly for the Tidbyt Gen 2.

In short: 
- The char ':' in the time is drawn manually. This removes unnecessary empty spaces around that char.
- The box on the left side is reduced to 7px instead of 8px. The text was, anyway, only 7px wide.
- The spacing between the box and the time, as well as the time and the destination, is increased to two pixels.

Before:
![ezgif-3-6ec75a067b](https://github.com/user-attachments/assets/38a95b7c-c80b-47b8-85be-05f0ac77a042)

After:
![ezgif-3-79833be5ea](https://github.com/user-attachments/assets/17653cc0-5d3f-496b-9a0e-98993e38489d)

