### PR TITLE
Bug-Fix: Overwatch Meta App - Fixed Spelling for Reinhardt

### DIFF
--- a/apps/overwatch_meta/overwatch_meta.star
+++ b/apps/overwatch_meta/overwatch_meta.star
@@ -84,7 +84,7 @@ SKILL_TIERS = struct(
 SHORT_HERO_NAME_MAP = {
     "Wrecking Ball": "Ball",
     "Widowmaker": "Widow",
-    "Reinhard": "Rein",
+    "Reinhardt": "Rein",
     "Soldier: 76": "Soldier",
     "Zenyatta": "Zen",
     "Baptiste": "Bap",


### PR DESCRIPTION
## Changes

- The name of the character is spelled "Reinhardt" and not "Reinhard", source: https://www.overbuff.com/heroes/reinhardt
  - The full name of "Reinhardt" extends beyond the screen, so I needed to correct a dictionary that maps the full name of "Reinhardt", to the nickname "Rein".

### Before the Change

![overwatch_meta_before_fix](https://github.com/user-attachments/assets/827ff67a-7ecf-4e56-a42b-696bde749ce1)

## After the Change

![overwatch_meta_after_fix](https://github.com/user-attachments/assets/0865905c-14e3-4ca4-8aed-735cc88aebf1)
