### PR TITLE
HASS Solar: allow specifying raw values instead of entity IDs

### DIFF
--- a/apps/hasssolar/README.md
+++ b/apps/hasssolar/README.md
@@ -19,22 +19,29 @@ When fully set up, the following screens are displayed:
 
 ## Installation
 
-Just open the Tidbyt app, click on the “+” icon at the lower right and then search for "HASS Solar" in the search field.
+Just open the Tidbyt app, click on the “+” icon at the lower right and then
+search for "HASS Solar" in the search field.
 
 ## Setup
 
-The applet requires a Home Assistant installation reachable via the internet (either through Home Assistant Cloud or your own port forwarding setup).
+The applet requires a Home Assistant installation reachable via the internet
+(either through Home Assistant Cloud or your own port forwarding setup).
 
-The long-lived access token can be generated on the Profile / Security page (`${ha_url}/profile/security`).
+The long-lived access token can be generated on the Profile / Security page
+(`${ha_url}/profile/security`).
 
-The applet expects entities which represent solar power generation, energy consumption, etc. How you set up these entities depends on the integration providing access to the meter data.
+The applet expects entities which represent solar power generation, energy
+consumption, etc. How you set up these entities depends on the integration
+providing access to the meter data.
 
 For SolarEdge, there are some good examples here:
 
-- https://github.com/WillCodeForCats/solaredge-modbus-multi/wiki/Template-Sensors-for-Power-and-Energy                      
+- https://github.com/WillCodeForCats/solaredge-modbus-multi/wiki/Template-Sensors-for-Power-and-Energy
 - https://gist.github.com/thargy/f9713cd6c06bc77a22a4b323ed0f83af
 
-The daily, weekly, monthly, and yearly statistics can be modelled as [utility meters](https://www.home-assistant.io/integrations/utility_meter/), for example:
+The daily, weekly, monthly, and yearly statistics can be modelled as
+[utility meters](https://www.home-assistant.io/integrations/utility_meter/),
+for example:
 
 ```
 utility_meter:
@@ -44,7 +51,9 @@ utility_meter:
     always_available: true
 ```
 
-The autarky entities could be computed based on utility meters using [template sensors](https://www.home-assistant.io/integrations/template/), for example:
+The autarky entities could be computed based on utility meters using
+[template sensors](https://www.home-assistant.io/integrations/template/), for
+example:
 
 ```
 sensor:
@@ -63,15 +72,21 @@ sensor:
 This screen shows the following information:
 
 - Solar production on the left. Green animated flow moving from left to right.
-  - Value is always green or grey when it reaches zero. Once solar production reaches zero, the solar planel icon is replaced with a battery icon which displays the SOC status of the battery
-  - Battery discharge is shown with a yellow flow animation. If no discharge is happening, the flow animation disappears
+  - Value is always green or grey when it reaches zero. Once solar production
+    reaches zero, the solar planel icon is replaced with a battery icon which
+    displays the SOC status of the battery
+  - Battery discharge is shown with a yellow flow animation. If no discharge is
+    happening, the flow animation disappears
   - For installations without a battery, the solar icon is not replaced.
 - Consumption in the middle
 - From or to grid on the right
   - Red value with red animated flow when energy is consumed from the grid
   - Green value with green animated flow when energy is provided to the grid
 
-Be aware that power flowing from the solar panels directly to your battery will not be shown in the middle consumption value. So if you see a difference between the production and consumption value, your battery is likely charging. Details regarding the battery can be found on the "Battery" screen.
+Be aware that power flowing from the solar panels directly to your battery will
+not be shown in the middle consumption value. So if you see a difference
+between the production and consumption value, your battery is likely charging.
+Details regarding the battery can be found on the "Battery" screen.
 
 The main screen requires entities for the following configuration options:
 
@@ -92,8 +107,12 @@ The screen is shown by default but can be hidden with the `show_main` option.
 
 This screen shows the following information:
 
-- SOC state of the battery. Animation changes from red (0-25%) to orange (25-50%) to yellow (50-75%) and green (75-100%) depending on how full your battery is.
-- Charge / discharge state of the battery in Watts. Shows a green animation if the battery is being charged. Shows a red animation if the battery is being discharged.
+- SOC state of the battery. Animation changes from red (0-25%) to orange
+  (25-50%) to yellow (50-75%) and green (75-100%) depending on how full your
+  battery is.
+- Charge / discharge state of the battery in Watts. Shows a green animation if
+  the battery is being charged. Shows a red animation if the battery is being
+  discharged.
 
 The battery screen requires entities for the following configuration options:
 
@@ -108,7 +127,8 @@ The screen is hidden by default but can be shown with the `show_char` option.
 
 This screen shows the following information:
 
-- Current solar production in Watts. Value is always green until it reaches zero.
+- Current solar production in Watts. Value is always green until it reaches
+  zero.
 
 The production screen requires entities for the following configuration options:
 
@@ -124,7 +144,8 @@ This screen shows the following information:
 
 - Current consumption in Watts. Value is always red.
 
-The consumption screen requires entities for the following configuration options:
+The consumption screen requires entities for the following configuration
+options:
 
 - Current load power (consumption) (`entity_power_load`)
 
@@ -137,8 +158,10 @@ The screen is hidden by default but can be shown with the `show_cons` option.
 This screen shows the following information:
 
 - Daily summary of:
-  - Solar production so far in kWh. This value is rounded as there is no space for decimals.
-  - Consumptoin so far in kWh. This value is rounded as there is no space for decimals.
+  - Solar production so far in kWh. This value is rounded as there is no space
+    for decimals.
+  - Consumptoin so far in kWh. This value is rounded as there is no space for
+    decimals.
 
 The energy summary requires entities for the following configuration options:
 
@@ -171,7 +194,8 @@ The screen is shown automatically as soon as all options are configured.
 
 ![EV Energy](frame_6.png)
 
-This screen shows the energy used by a wallbox for charging an electric vehicle for today, this week, this month, and this year.
+This screen shows the energy used by a wallbox for charging an electric
+vehicle for today, this week, this month, and this year.
 
 It requires entities for the following configuration options:
 
@@ -209,7 +233,9 @@ You can further customize the screen with the following options:
   - Tesla
   - VW
 
-If your SOC sensor can become unavailable (for example, when the car is sleeping), but you want to show the last known state, you can use a trigger-based template sensor like this:
+If your SOC sensor can become unavailable (for example, when the car is
+sleeping), but you want to show the last known state, you can use a
+trigger-based template sensor like this:
 
 ```
 template:
@@ -227,16 +253,38 @@ template:
         unit_of_measurement: '%'
 ```
 
-If you want to display multiple car screens, you need to add an additional Tidbyt instance for the additional car. Make sure you also always enter your token at the very top of the app details page.
+If you want to display multiple car screens, you need to add an additional
+Tidbyt instance for the additional car. Make sure you also always enter your
+token at the very top of the app details page.
 
 ## Important information about selecting multiple screens to be displayed
 
-Each screen comes with animations that show what is going on. These animations only work if not more than one screen is selected from the main menu. If you select more than one, all screens will be displayed, but animations will not show.
+Each screen comes with animations that show what is going on. These animations
+only work if not more than one screen is selected from the main menu. If you
+select more than one, all screens will be displayed, but animations will not
+show.
 
-If you like to have each screen animated, you need to run a separate instance for each screen. You do this by just adding the app again in your Tidbyt app, pasting the URL and token information again and then selecting the screen you would like to have displayed.
+If you like to have each screen animated, you need to run a separate instance
+for each screen. You do this by just adding the app again in your Tidbyt app,
+pasting the URL and token information again and then selecting the screen you
+would like to have displayed.
 
-This is a little tedious, but you only need to do this once per individual screen.
+This is a little tedious, but you only need to do this once per individual
+screen.
 
 ## Other settings
 
-At the very bottom of the app settings you can also choose how long each screen will be displayed on your Tidbyt. You can chose between 1-5 seconds.
+At the bottom of the app settings you can also choose how long each screen
+will be displayed on your Tidbyt. You can chose between 1-5 seconds.
+
+## Self-hosting
+
+The `raw_values` setting at the very bottom of the app setting can be useful
+when rendering the app from within Home Assistant. In this mode, you can pass
+the actual values instead of entity IDs in the respective settings. The ap
+will then not call the Home Assistant API and does not require an access token.
+
+The units used are `kWh` (energy), `W` (power), and `%` (state-of-charge).
+
+Whenever you want to display fresh values, you'll need to render this app
+(`pixlet render`) and upload it to the Tidbyt cloud (`pixlet push`).

--- a/apps/hasssolar/hass_solar.star
+++ b/apps/hasssolar/hass_solar.star
@@ -231,51 +231,62 @@ def render_fail(rep):
     content = json.decode(rep.body())
     return render.Root(render.Box(render.WrappedText(str(rep.status_code) + " : " + content["String"], color = RED)))
 
-def fetch_entity(entity_id, config):
-    if DEBUG or config.get(HA_URL) == None:
-        if entity_id.startswith("entity_energy"):
-            return {
-                "entity_id": "{}".format(entity_id),
-                "state": "130.12",
-                "attributes": {
-                    "state_class": "total_increasing",
-                    "unit_of_measurement": "kWh",
-                    "device_class": "energy",
-                },
-            }
-        elif entity_id.startswith("entity_soc"):
-            return {
-                "entity_id": "{}".format(entity_id),
-                "state": "80",
-                "attributes": {
-                    "raw_soc": 80,
-                    "state_class": "measurement",
-                    "unit_of_measurement": "%",
-                    "device_class": "energy",
-                },
-            }
-        elif entity_id.startswith("entity_autarky"):
-            return {
-                "entity_id": "{}".format(entity_id),
-                "state": "97",
-                "attributes": {
-                    "state_class": "measurement",
-                    "unit_of_measurement": "%",
-                },
-            }
-        else:
-            return {
-                "entity_id": "{}".format(entity_id),
-                "state": "9886.0",
-                "attributes": {
-                    "state_class": "measurement",
-                    "unit_of_measurement": "W",
-                    "device_class": "power",
-                },
-            }
+def dummy_entity(entity_id):
+    if entity_id.startswith("entity_energy"):
+        return {
+            "entity_id": "{}".format(entity_id),
+            "state": "130.12",
+            "attributes": {
+                "state_class": "total_increasing",
+                "unit_of_measurement": "kWh",
+                "device_class": "energy",
+            },
+        }
+    elif entity_id.startswith("entity_soc"):
+        return {
+            "entity_id": "{}".format(entity_id),
+            "state": "80",
+            "attributes": {
+                "raw_soc": 80,
+                "state_class": "measurement",
+                "unit_of_measurement": "%",
+                "device_class": "energy",
+            },
+        }
+    elif entity_id.startswith("entity_autarky"):
+        return {
+            "entity_id": "{}".format(entity_id),
+            "state": "97",
+            "attributes": {
+                "state_class": "measurement",
+                "unit_of_measurement": "%",
+            },
+        }
+    else:
+        return {
+            "entity_id": "{}".format(entity_id),
+            "state": "9886.0",
+            "attributes": {
+                "state_class": "measurement",
+                "unit_of_measurement": "W",
+                "device_class": "power",
+            },
+        }
 
-    entity_id = config.get(entity_id)
+def fetch_entity(entity_key, config, default_unit):
+    raw_values = config.bool("raw_values", False)
+    if DEBUG or (config.get(HA_URL) == None and not raw_values):
+        return dummy_entity(entity_key)
+
+    entity_id = config.get(entity_key)
     if entity_id:
+        if raw_values:
+            return {
+                "state": "{}".format(entity_id),
+                "attributes": {
+                    "unit_of_measurement": default_unit,
+                },
+            }
         rep = http.get(config.get(HA_URL) + "/api/states/" + entity_id, ttl_seconds = 10, headers = {
             "Authorization": "Bearer " + config.get(HA_TOKEN),
         })
@@ -334,21 +345,21 @@ def main(config):
     lang = config.get("lang", "en")
 
     # fetch data from HA
-    energy_consumption = fetch_entity(ENTITY_ENERGY_CONSUMPTION, config)
-    energy_production = fetch_entity(ENTITY_ENERGY_PRODUCTION, config)
-    energy_ev_day = fetch_entity(ENTITY_ENERGY_EV_DAY, config)
-    energy_ev_week = fetch_entity(ENTITY_ENERGY_EV_WEEK, config)
-    energy_ev_month = fetch_entity(ENTITY_ENERGY_EV_MONTH, config)
-    power_solar = fetch_entity(ENTITY_POWER_SOLAR, config)
-    power_grid = fetch_entity(ENTITY_POWER_GRID, config)
-    power_load = fetch_entity(ENTITY_POWER_LOAD, config)
-    power_battery = fetch_entity(ENTITY_POWER_BATTERY, config)
-    soc_battery = fetch_entity(ENTITY_SOC_BATTERY, config)
-    soc_ev = fetch_entity(ENTITY_SOC_EV, config)
-    autarky_day = fetch_entity(ENTITY_AUTARKY_DAY, config)
-    autarky_week = fetch_entity(ENTITY_AUTARKY_WEEK, config)
-    autarky_month = fetch_entity(ENTITY_AUTARKY_MONTH, config)
-    autarky_year = fetch_entity(ENTITY_AUTARKY_YEAR, config)
+    energy_consumption = fetch_entity(ENTITY_ENERGY_CONSUMPTION, config, "kWh")
+    energy_production = fetch_entity(ENTITY_ENERGY_PRODUCTION, config, "kWh")
+    energy_ev_day = fetch_entity(ENTITY_ENERGY_EV_DAY, config, "kWh")
+    energy_ev_week = fetch_entity(ENTITY_ENERGY_EV_WEEK, config, "kWh")
+    energy_ev_month = fetch_entity(ENTITY_ENERGY_EV_MONTH, config, "kWh")
+    power_solar = fetch_entity(ENTITY_POWER_SOLAR, config, "W")
+    power_grid = fetch_entity(ENTITY_POWER_GRID, config, "W")
+    power_load = fetch_entity(ENTITY_POWER_LOAD, config, "W")
+    power_battery = fetch_entity(ENTITY_POWER_BATTERY, config, "W")
+    soc_battery = fetch_entity(ENTITY_SOC_BATTERY, config, "%")
+    soc_ev = fetch_entity(ENTITY_SOC_EV, config, "%")
+    autarky_day = fetch_entity(ENTITY_AUTARKY_DAY, config, "%")
+    autarky_week = fetch_entity(ENTITY_AUTARKY_WEEK, config, "%")
+    autarky_month = fetch_entity(ENTITY_AUTARKY_MONTH, config, "%")
+    autarky_year = fetch_entity(ENTITY_AUTARKY_YEAR, config, "%")
 
     frames = []
 
@@ -1133,6 +1144,13 @@ def get_schema():
                     schema.Option(display = "Deutsch", value = "de"),
                     schema.Option(display = "English", value = "en"),
                 ],
+            ),
+            schema.Toggle(
+                id = "raw_values",
+                name = "Entity IDs as raw values",
+                desc = "Don't call the HA API and use entity IDs as raw values.",
+                icon = "globe",
+                default = False,
             ),
         ],
     )


### PR DESCRIPTION
This allows rendering the app from within Home Assistant without using the Home Assistant REST API.