### PR TITLE
bug fix to moretransit app's min minutes feature

### DIFF
--- a/apps/moretransit/moretransit.star
+++ b/apps/moretransit/moretransit.star
@@ -132,7 +132,7 @@ def main(config):
 
         for (eta, color, name) in all_arrivals_to_stop:
             min_minutes = config.get("minTime")
-            min_minutes = int(min_minutes) if min_minutes.isdigit() else MIN_MINUTES
+            min_minutes = int(min_minutes) if min_minutes is not None and min_minutes.isdigit() else MIN_MINUTES
             if eta > min_minutes and len(renderable_subways) < MAX_SUBWAYS:
                 renderer = overlay_subway
                 if config.bool("useStacked"):

--- a/apps/moretransit/moretransit.star
+++ b/apps/moretransit/moretransit.star
@@ -132,7 +132,7 @@ def main(config):
 
         for (eta, color, name) in all_arrivals_to_stop:
             min_minutes = config.get("minTime")
-            if min_minutes is None or not min_minutes.isdigit():
+            if min_minutes == None or not min_minutes.isdigit():
                 min_minutes = MIN_MINUTES
             else:
                 min_minutes = int(min_minutes)

--- a/apps/moretransit/moretransit.star
+++ b/apps/moretransit/moretransit.star
@@ -131,7 +131,9 @@ def main(config):
         all_arrivals_to_stop = sorted(all_arrivals_to_stop, key = lambda x: x[0])
 
         for (eta, color, name) in all_arrivals_to_stop:
-            if eta > MIN_MINUTES and len(renderable_subways) < MAX_SUBWAYS:
+            min_minutes = config.get("minTime")
+            min_minutes = int(min_minutes) if min_minutes.isdigit() else MIN_MINUTES
+            if eta > min_minutes and len(renderable_subways) < MAX_SUBWAYS:
                 renderer = overlay_subway
                 if config.bool("useStacked"):
                     renderer = stack_subway

--- a/apps/moretransit/moretransit.star
+++ b/apps/moretransit/moretransit.star
@@ -132,7 +132,10 @@ def main(config):
 
         for (eta, color, name) in all_arrivals_to_stop:
             min_minutes = config.get("minTime")
-            min_minutes = int(min_minutes) if min_minutes is not None and min_minutes.isdigit() else MIN_MINUTES
+            if min_minutes is None or not min_minutes.isdigit():
+                min_minutes = MIN_MINUTES
+            else:
+                min_minutes = int(min_minutes)
             if eta > min_minutes and len(renderable_subways) < MAX_SUBWAYS:
                 renderer = overlay_subway
                 if config.bool("useStacked"):


### PR DESCRIPTION
the moretransit app has a min minutes config property to show trains only that are >= min_minutes away. However, the app currently uses the hardcoded value of 10. 

This fix replaces it with the min_minutes config property