### PR TITLE
Fix incorrect label on us_electoral_forecast

### DIFF
--- a/apps/us_electoral_forecast/us_electoral_forecast.star
+++ b/apps/us_electoral_forecast/us_electoral_forecast.star
@@ -30,6 +30,11 @@ PARTY_COLORS = {
     "REP_BG": "#f77272",
 }
 
+PARTY_LEADERS = {
+    "DEM": "HARRIS",
+    "REP": "TRUMP"
+}
+
 def main(config):
     period = config.get(PERIOD, DEFAULT_PERIOD)
     type = config.get(TYPE, DEFAULT_TYPE)
@@ -77,15 +82,15 @@ def main(config):
                             render.Column(
                                 main_align = "start",
                                 children = [
-                                    render.Text("HARRIS", font = FONT, color = PARTY_COLORS["DEM"]),
+                                    render.Text(PARTY_LEADERS["DEM"], font = FONT, color = PARTY_COLORS["DEM"]),
                                     render.Text(print_num(latest_data["dem"]), font = FONT, color = PARTY_COLORS["DEM"]),
                                     render.Text(print_num(latest_data["rep"]), font = FONT, color = PARTY_COLORS["REP"]),
-                                    render.Text("TRUMP", font = FONT, color = PARTY_COLORS["REP"]),
+                                    render.Text(PARTY_LEADERS["REP"], font = FONT, color = PARTY_COLORS["REP"]),
                                 ] if dem_leading_rep else [
-                                    render.Text("HARRIS", font = FONT, color = PARTY_COLORS["REP"]),
+                                    render.Text(PARTY_LEADERS["REP"], font = FONT, color = PARTY_COLORS["REP"]),
                                     render.Text(print_num(latest_data["rep"]), font = FONT, color = PARTY_COLORS["REP"]),
                                     render.Text(print_num(latest_data["dem"]), font = FONT, color = PARTY_COLORS["DEM"]),
-                                    render.Text("TRUMP", font = FONT, color = PARTY_COLORS["DEM"]),
+                                    render.Text(PARTY_LEADERS["DEM"], font = FONT, color = PARTY_COLORS["DEM"]),
                                 ],
                             ),
                     ),

--- a/apps/us_electoral_forecast/us_electoral_forecast.star
+++ b/apps/us_electoral_forecast/us_electoral_forecast.star
@@ -32,7 +32,7 @@ PARTY_COLORS = {
 
 PARTY_LEADERS = {
     "DEM": "HARRIS",
-    "REP": "TRUMP"
+    "REP": "TRUMP",
 }
 
 def main(config):


### PR DESCRIPTION
Fixes swapped Harris/Trump labels on us_electoral_forecast.

Before:
<img width="1398" alt="image" src="https://github.com/user-attachments/assets/5c3e3b1a-cbc6-435c-9d78-e2abb9c391e4">


After:
<img width="1357" alt="image" src="https://github.com/user-attachments/assets/1b882195-e224-4e3e-b9f9-fea04506fb05">

