### PR TITLE
Ensure energy and percentages are always >= 0

### DIFF
--- a/apps/hasssolar/hass_solar.star
+++ b/apps/hasssolar/hass_solar.star
@@ -312,13 +312,14 @@ def render_entity(entity, absolute_value = False, convert_to_kw = False, with_un
         return ""
 
     value = float(state)
-    if absolute_value:
-        value = abs(value)
 
     unit = unit_for_entity(entity)
     if unit == "W" and convert_to_kw:
         unit = "kW"
         value = value / 1000.0
+
+    if absolute_value or unit == "%" or unit == "kWh":
+        value = abs(value)
 
     if dec == None:
         if value < 9.95:


### PR DESCRIPTION
This is to avoid cases where the app could display "-0%"