### PR TITLE
Remove version pin in devcontainer

### DIFF
--- a/.devcontainer/install_pixlet.sh
+++ b/.devcontainer/install_pixlet.sh
@@ -7,7 +7,7 @@ set -e
 # This script will install the latest released version of pixlet,
 # Unless this argument is set to a specific version tag
 # e.g. v0.22.7
-PIN_VERSION_TAG="v0.22.7"
+# PIN_VERSION_TAG="v0.34.0"
 
 cd /tmp
 


### PR DESCRIPTION
The version pin in the devcontainer means that `pixlet create` and `pixlet check` are unavailable. I removed the pinned version so that by default we install the latest pixlet.