### PR TITLE
Add "\r" to string match to prevent false negative

### DIFF
--- a/apps/airbnbcalendar/airbnb_calendar.star
+++ b/apps/airbnbcalendar/airbnb_calendar.star
@@ -86,7 +86,7 @@ def listing(url, height):
         offset = math.ceil((start - now).hours)
         duration = math.ceil((end - now).hours - offset)
 
-        status = "BLOCKED" if summary[1] == "Airbnb (Not available)" else "PAST" if now > end else "FUTURE" if now < start else "PRESENT"
+        status = "BLOCKED" if summary[1] == "Airbnb (Not available)\r" else "PAST" if now > end else "FUTURE" if now < start else "PRESENT"
 
         left = offset // DEFAULT_HOURS_PER_PIXEL
         if left > SCREEN_WIDTH:

--- a/apps/airbnbcalendar/airbnb_calendar.star
+++ b/apps/airbnbcalendar/airbnb_calendar.star
@@ -74,7 +74,7 @@ def listing(url, height):
 
     dtstart_list = re.match(r"DTSTART;VALUE=DATE:(.{4})(.{2})(.{2})", ical)
     dtend_list = re.match(r"DTEND;VALUE=DATE:(.{4})(.{2})(.{2})", ical)
-    summary_list = re.match(r"SUMMARY:(.+)", ical)
+    summary_list = re.match(r"SUMMARY:([^\r\n]+)", ical)
     event_list = zip(dtstart_list, dtend_list, summary_list)
     now = time.now()
 
@@ -86,7 +86,7 @@ def listing(url, height):
         offset = math.ceil((start - now).hours)
         duration = math.ceil((end - now).hours - offset)
 
-        status = "BLOCKED" if summary[1] == "Airbnb (Not available)\r" else "PAST" if now > end else "FUTURE" if now < start else "PRESENT"
+        status = "BLOCKED" if summary[1] == "Airbnb (Not available)" else "PAST" if now > end else "FUTURE" if now < start else "PRESENT"
 
         left = offset // DEFAULT_HOURS_PER_PIXEL
         if left > SCREEN_WIDTH:


### PR DESCRIPTION
I'm not sure what happened, either Airbnb's ical format changing or Starlark's regular expression matching changing, but sometime in the last month or so blocked Airbnb dates started being displayed as normal reservations due to a string mismatch caused by an extra carriage return. This corrects the issue.

Before the change, note how incoming reservation is incorrectly gray for "FUTURE".

![image](https://github.com/user-attachments/assets/610eb458-f5db-4c8f-b482-8d03d6880445)

After the change, note how incoming reservation is correctly black for "BLOCKED".

![image](https://github.com/user-attachments/assets/8ded756e-68ab-4d3d-874f-bc81220bf23d)

