### PR TITLE
Simplify app description to explain what kind of google sheet it accepts

### DIFF
--- a/apps/customquotes/custom_quotes.star
+++ b/apps/customquotes/custom_quotes.star
@@ -1,7 +1,7 @@
 """
 Applet: Custom Quotes
 Summary: Display custom quotes
-Description: Display quotes from a Gsheet like this https://docs.google.com/spreadsheets/d/1zDiMWjzZQqB6QRMhde0dOoptTjwdv6GalNHHYkUytAI/edit?usp=sharing
+Description: Display quotes from a Google sheet with a quote and author column
 Author: vipulchhajer
 """
 

--- a/apps/thingswifesays/things_wife_says.star
+++ b/apps/thingswifesays/things_wife_says.star
@@ -59,8 +59,8 @@ def main(config):
                     render.Box(
                         color = "#333333",  #remove color background if picture is used
                         child = render.Image(src = WIFE),
-                        width = 28,
-                        height = 28,
+                        width = 22,
+                        height = 30,
                     ),
                     render.Box(
                         child = render.Marquee(
@@ -69,14 +69,14 @@ def main(config):
                             offset_end = 6,
                             child = render.WrappedText(
                                 content = phrase,
-                                width = 30,
+                                width = 40,
                                 # color="#f44336"
                             ),
                             scroll_direction = "vertical",
                         ),
-                        width = 34,
+                        width = 42,
                         height = 32,
-                        padding = 2,
+                        padding = 1,
                     ),
                 ],
             ),


### PR DESCRIPTION
Instead of displaying url to a sample google sheet, explaining the type of google sheet that's needed. Easier for users to understand. 