### PR TITLE
Update PurpleAir app to use the newest calculations

### DIFF
--- a/apps/purpleair/manifest.yaml
+++ b/apps/purpleair/manifest.yaml
@@ -1,8 +1,8 @@
 ---
 id: purpleair
 name: PurpleAir
-summary: Displays local air quality
-desc: Displays the local air quality index from a nearby PurpleAir sensor. Choose a sensor close to you or provide a specific sensor id.
+summary: Display local air quality
+desc: Displays a (partial) air quality index (AQI) from a PurpleAir sensor. Due to limitations of the PurpleAir devices, only the PM2.5 component of AQI is reported.
 author: posburn
 fileName: purpleair.star
 packageName: purpleair


### PR DESCRIPTION
As of September 2024, PurpleAir has updated their (default) conversion/correction algorithms. This change updates to align the defaults used by this app with the defaults used by PurpleAir.

Different organizations define different "AQI" metrics so this change adds support for selecting your preferred metric. At this time, only the US EPA AQI is implemented.

Researchers have determined the underlying sensors are inaccurate in systematic ways, and have developed correction algorithms/formulas to address these issues. This change adds a mechanism for selecting a preferred correction algorithm. Only 3 of 8 correction algorithms are implemented.