### PR TITLE
Create WSJ.star

### DIFF
--- a/apps/WSJ/WSJ.star
+++ b/apps/WSJ/WSJ.star
@@ -71,7 +71,7 @@ def render_article(news):
             render.WrappedText(
                 content = article[0],
                 color = ARTICLE_SUB_TITLE_COLOR,
-                font = ARTICLE_SUB_TITLE_FONT,
+                font = ARTICLE_SUB_TITLE_FONT
             )
         )
         news_text.append(render.Box(width = 64, height = 8, color = SPACER_COLOR))
@@ -126,15 +126,16 @@ def get_cacheable_data(url, articlecount):
     articles = []
     res = http.get(RSS_STUB.format(url), ttl_seconds = CACHE_TTL_SECONDS)
     if res.status_code != 200:
-        fail("Request to %s failed with status code: %d - %s" % (RSS_STUB.format(url), res.status_code, res.body()))
-    
+        fail("Request to %s failed with status code: %d - %s" % (
+        RSS_STUB.format(url), 
+        res.status_code, 
+        res.body(),
+))
     data = res.body()
     data_xml = xpath.loads(data)
-
     # Get all item elements and limit to articlecount
     items = data_xml.query_all("//item")
     total_items = min(articlecount, len(items) if items else 0)
-    
     # Fetch articles
     for i in range(total_items):
         title_query = "//item[{}]/title".format(i + 1)
@@ -142,9 +143,7 @@ def get_cacheable_data(url, articlecount):
         title = data_xml.query(title_query) or "No Title"
         desc = data_xml.query(desc_query) or ""
         articles.append((title, str(desc).replace("None", "")))
-    
     # Fallback if no articles
     if not articles:
         articles.append(("No news available", ""))
-    
     return articles

--- a/apps/WSJ/WSJ.star
+++ b/apps/WSJ/WSJ.star
@@ -1,0 +1,150 @@
+"""
+Applet: WSJ News
+Summary: Wall Street Journal News
+Description: Display Wall Street Journal news headlines from various RSS feeds.
+Author: Shimmy Savitsky
+"""
+
+load("http.star", "http")
+load("render.star", "render")
+load("schema.star", "schema")
+load("xpath.star", "xpath")
+
+VERSION = 23132
+
+# Cache data for 15 minutes
+CACHE_TTL_SECONDS = 900
+
+DEFAULT_NEWS = "RSSWorldNews"
+DEFAULT_ARTICLE_COUNT = "3"
+TEXT_COLOR = "#fff"
+TITLE_TEXT_COLOR = "#fff"
+TITLE_BKG_COLOR = "#cccccc33"
+TITLE_FONT = "tom-thumb"
+TITLE_HEIGHT = 7
+TITLE_WIDTH = 64
+
+ARTICLE_SUB_TITLE_FONT = "tom-thumb"
+ARTICLE_SUB_TITLE_COLOR = "#65d0e6"
+ARTICLE_FONT = "tb-8"
+ARTICLE_COLOR = "#65d0e6"
+SPACER_COLOR = "#000"
+ARTICLE_LINESPACING = 0
+ARTICLE_AREA_HEIGHT = 24
+
+RSS_STUB = "https://feeds.content.dowjones.io/public/rss/{}"
+
+def main(config):
+    edition = config.get("news_edition", DEFAULT_NEWS)
+    articlecount = int(config.get("articlecount", DEFAULT_ARTICLE_COUNT))
+    articles = get_cacheable_data(edition, articlecount)
+
+    return render.Root(
+        delay = 100,
+        show_full_animation = True,
+        child = render.Column(
+            children = [
+                render.Box(
+                    width = TITLE_WIDTH,
+                    height = TITLE_HEIGHT,
+                    padding = 0,
+                    color = TITLE_BKG_COLOR,
+                    child = render.Text("Wall St. Journal", color = TITLE_TEXT_COLOR, font = TITLE_FONT, offset = -1),
+                ),
+                render.Marquee(
+                    height = ARTICLE_AREA_HEIGHT,
+                    scroll_direction = "vertical",
+                    offset_start = 24,
+                    child = render.Column(
+                        main_align = "space_between",
+                        children = render_article(articles),
+                    ),
+                ),
+            ],
+        ),
+    )
+
+def render_article(news):
+    news_text = []
+    for article in news:
+        news_text.append(
+            render.WrappedText(
+                content = article[0],
+                color = ARTICLE_SUB_TITLE_COLOR,
+                font = ARTICLE_SUB_TITLE_FONT,
+            )
+        )
+        news_text.append(render.Box(width = 64, height = 8, color = SPACER_COLOR))
+    return news_text
+
+def get_schema():
+    return schema.Schema(
+        version = "1",
+        fields = [
+            schema.Dropdown(
+                id = "news_edition",
+                name = "News Section",
+                desc = "Select which section to display",
+                icon = "newspaper",
+                default = DEFAULT_NEWS,
+                options = [
+                    schema.Option(display = "World News", value = "RSSWorldNews"),
+                    schema.Option(display = "U.S. Business", value = "WSJcomUSBusiness"),
+                    schema.Option(display = "Markets", value = "RSSMarketsMain"),
+                    schema.Option(display = "Technology", value = "RSSWSJD"),
+                    schema.Option(display = "Lifestyle", value = "RSSLifestyle"),
+                    schema.Option(display = "Opinion", value = "RSSOpinion"),
+                    schema.Option(display = "U.S. News", value = "RSSUSnews"),
+                    schema.Option(display = "Politics", value = "socialpoliticsfeed"),
+                    schema.Option(display = "Economy", value = "socialeconomyfeed"),
+                    schema.Option(display = "Arts & Culture", value = "RSSArtsCulture"),
+                    schema.Option(display = "Real Estate", value = "latestnewsrealestate"),
+                    schema.Option(display = "Personal Finance", value = "RSSPersonalFinance"),
+                    schema.Option(display = "Health", value = "socialhealth"),
+                    schema.Option(display = "Style", value = "RSSStyle"),
+                    schema.Option(display = "Sports", value = "rsssportsfeed"),
+                ],
+            ),
+            schema.Dropdown(
+                id = "articlecount",
+                name = "Article Count",
+                desc = "Select number of articles to display",
+                icon = "hashtag",
+                default = DEFAULT_ARTICLE_COUNT,
+                options = [
+                    schema.Option(display = "1", value = "1"),
+                    schema.Option(display = "2", value = "2"),
+                    schema.Option(display = "3", value = "3"),
+                    schema.Option(display = "4", value = "4"),
+                    schema.Option(display = "5", value = "5"),
+                ],
+            ),
+        ],
+    )
+
+def get_cacheable_data(url, articlecount):
+    articles = []
+    res = http.get(RSS_STUB.format(url), ttl_seconds = CACHE_TTL_SECONDS)
+    if res.status_code != 200:
+        fail("Request to %s failed with status code: %d - %s" % (RSS_STUB.format(url), res.status_code, res.body()))
+    
+    data = res.body()
+    data_xml = xpath.loads(data)
+
+    # Get all item elements and limit to articlecount
+    items = data_xml.query_all("//item")
+    total_items = min(articlecount, len(items) if items else 0)
+    
+    # Fetch articles
+    for i in range(total_items):
+        title_query = "//item[{}]/title".format(i + 1)
+        desc_query = "//item[{}]/description".format(i + 1)
+        title = data_xml.query(title_query) or "No Title"
+        desc = data_xml.query(desc_query) or ""
+        articles.append((title, str(desc).replace("None", "")))
+    
+    # Fallback if no articles
+    if not articles:
+        articles.append(("No news available", ""))
+    
+    return articles

--- a/apps/WSJ/manifest.yaml
+++ b/apps/WSJ/manifest.yaml
@@ -1,0 +1,7 @@
+id: wsj-news
+name: WSJ News
+summary: Wall Street Journal News
+desc: Display Wall Street Journal news headlines from various RSS feeds. Choose from sections like World News, Markets, and more, with configurable article counts.
+author: Shimmy Savitsky
+file: WSJ.star
+package: wsjnews

--- a/apps/WSJ/manifest.yaml
+++ b/apps/WSJ/manifest.yaml
@@ -1,5 +1,5 @@
-id: wsj-news
-name: WSJ News
+id: wsj
+name: WSJ
 summary: Wall Street Journal News
 desc: Display Wall Street Journal news headlines from various RSS feeds. Choose from sections like World News, Markets, and more, with configurable article counts.
 author: Shimmy Savitsky


### PR DESCRIPTION
This app displays Wall Street Journal news headlines from various RSS feeds. Users can select from multiple news sections (e.g., World News, Markets, Technology) and configure the number of articles (1-5). Built using standard Pixlet libraries (http, render, schema, xpath).