### PR TITLE
Update `chicago_tribune` App to Correct RSS Feed

### DIFF
--- a/apps/chicagotribune/README.md
+++ b/apps/chicagotribune/README.md
@@ -2,8 +2,7 @@
 
 Display the latest headlines or the latest article from the Chicago Tribune's RSS feed.
 
-News Feed: [Chicago Tribune.com RSS Feeds](https://www.chicagotribune.com/about/ct-chicago-tribune-rss-feeds-20220922-jub4o6cwwza4xd3d7ybqi7qz3i-htmlstory.html)
-
+News Feed: [Chicago Tribune.com RSS Feeds](https://www.chicagotribune.com/news/feed/)
 
 ## Configuration
 
@@ -15,7 +14,9 @@ News Feed: [Chicago Tribune.com RSS Feeds](https://www.chicagotribune.com/about/
 ## Screenshots
 
 ### Latest Headlines
+
 ![Latest Headlines](chicago_tribune_headlines.gif)
 
 ### Latest Article
+
 ![Latest Article](chicago_tribune_article.gif)

--- a/apps/chicagotribune/manifest.yaml
+++ b/apps/chicagotribune/manifest.yaml
@@ -1,8 +1,8 @@
 ---
 id: chicago-tribune
 name: Chicago Tribune
-summary: Chicago News
-desc: Latest headlines from the Chicago Tribune.
+summary: Chicago Tribune News
+desc: Latest news, sports and other topics from the Chicago Tribune. Choose from either the latest headlines or the latest story.
 author: sgomez72
 fileName: chicago_tribune.star
 packageName: chicagotribune


### PR DESCRIPTION
# Summary of Changes

Hi, I've opened a PR to fix the Chicago Tribunes News Application with the following changes below:

- Updated the `chicago_tribune.star` app to pull from the corrected RSS Feed. It appears the Tribune website was updated a year ago and the original RSS Feeds were deprecated
- The app will still pull either the latest three headlines of a specific category or the latest headline of a specific category and a brief description of the article

## Screenshots

### Latest Headline

![chicago_tribune_headlines](https://github.com/user-attachments/assets/d5837373-c7fc-4d2f-a1ea-38fac12c9086)

### Latest Article

![chicago_tribune_article](https://github.com/user-attachments/assets/ca642765-1c0c-45a6-aba2-6b82625ecd44)

Please let me know if anything else is needed. Thank you!
