### PR TITLE
[animeNextEpisode] Search anime by name instead of ID

### DIFF
--- a/apps/anime_next_ep/anime_next_ep.star
+++ b/apps/anime_next_ep/anime_next_ep.star
@@ -11,15 +11,19 @@ load("re.star", "re")
 load("render.star", "render")
 load("schema.star", "schema")
 load("time.star", "time")
+load("encoding/json.star", "json")
 
 ANILIST_ENDPOINT = "https://graphql.anilist.co"
 DEFAULT_ANIME_ID = 21  # One Piece
 
 def main(config):
-    unsanitized_anime_id = config.str("anime_id", str(DEFAULT_ANIME_ID))
     id = DEFAULT_ANIME_ID
-    if is_numeric(unsanitized_anime_id):
-        id = int(unsanitized_anime_id)
+    selection = config.get("anime_name")
+    if selection != None:
+        parsed_selection = json.decode(selection)["value"]
+        unsanitized_anime_id = parsed_selection
+        if is_numeric(unsanitized_anime_id):
+            id = int(unsanitized_anime_id)
 
     airing_info = fetch_airing_info(id)
 
@@ -106,6 +110,20 @@ def next_episode_info(next_episode, status):
         )
     )
 
+def search(pattern):
+    results = search_possible_anime(pattern)
+    if results == None:
+        return []
+
+    result_list = results["data"]["Page"]["media"]
+
+    def format_search_result(media):
+        return schema.Option(display = media["title"]["romaji"], value = str(int(media["id"])))
+    
+
+    return [format_search_result(media) for media in result_list]
+
+
 def fetch_airing_info(anime_id):
     query = {
         "query": """
@@ -140,15 +158,45 @@ def fetch_airing_info(anime_id):
 
     return response.json()
 
+def search_possible_anime(pattern):
+    query = {
+        "query": """
+        query ($pattern: String) {
+            Page(perPage: 10) { 
+                media(search: $pattern, type: ANIME, sort: [TRENDING_DESC, SEARCH_MATCH]) {
+                    id
+                    title {
+                        romaji
+                    }
+                }
+            }
+        }
+        """,
+        "variables": {"pattern": pattern},
+    }
+
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+
+    response = http.post(ANILIST_ENDPOINT, headers = headers, json_body = query)
+
+    if response.status_code != 200:
+        return None
+
+    return response.json()
+
 def get_schema():
     return schema.Schema(
         version = "1",
         fields = [
-            schema.Text(
-                id = "anime_id",
-                name = "id",
-                desc = "Anilist Anime ID ex. 21",
+            schema.Typeahead(
+                id = "anime_name",
+                name = "name",
+                desc = "Anime name",
                 icon = "tv",
+                handler = search,
             ),
         ],
     )

--- a/apps/anime_next_ep/anime_next_ep.star
+++ b/apps/anime_next_ep/anime_next_ep.star
@@ -5,13 +5,13 @@ Description: Tells when the next episode of an anime is via anilist.
 Author: brianmakesthings
 """
 
+load("encoding/json.star", "json")
 load("http.star", "http")
 load("humanize.star", "humanize")
 load("re.star", "re")
 load("render.star", "render")
 load("schema.star", "schema")
 load("time.star", "time")
-load("encoding/json.star", "json")
 
 ANILIST_ENDPOINT = "https://graphql.anilist.co"
 DEFAULT_ANIME_ID = 21  # One Piece
@@ -119,10 +119,8 @@ def search(pattern):
 
     def format_search_result(media):
         return schema.Option(display = media["title"]["romaji"], value = str(int(media["id"])))
-    
 
     return [format_search_result(media) for media in result_list]
-
 
 def fetch_airing_info(anime_id):
     query = {


### PR DESCRIPTION
original PR https://github.com/tidbyt/community/pull/2935

As suggested by @danielsitnik instead of searching for anime by ID, search by name

### Screenshot

<img width="532" alt="image" src="https://github.com/user-attachments/assets/fe8e00df-be8f-465f-b205-3fa3f92fc3d7" />


Note: [pixlet typeahead](https://github.com/tidbyt/pixlet/blob/c29059778792f1731822098aeb71f9bf5567b38b/src/features/schema/fields/Typeahead.jsx#L42-L54) is slightly broken in that if the result is not a substring of the options, then it won't be shown.

ex. if I search "Solo Leveling" the api will return "Ore dake Level Up na Ken" but there no options are shown because the Autocomplete component from mui filters this out.

I hope this is not the case in the mobile app