### PR TITLE
News Mix - Remove NYT RSS feeds

### DIFF
--- a/apps/newsmix/news_mix.star
+++ b/apps/newsmix/news_mix.star
@@ -66,7 +66,7 @@ def main(config):
     selected_feeds = {
         config.str("feed1", "WSJ US News"): AVAILABLE_FEEDS[config.str("feed1", "WSJ US News")],
         config.str("feed2", "WSJ World News"): AVAILABLE_FEEDS[config.str("feed2", "WSJ World News")],
-        config.str("feed3", "NYT Home Page"): AVAILABLE_FEEDS[config.str("feed3", "NYT Home Page")],
+        config.str("feed3", "BBC Top Stories"): AVAILABLE_FEEDS[config.str("feed3", "BBC Top Stories")],
     }
 
     feed_names = list(selected_feeds.keys())
@@ -260,7 +260,7 @@ def get_schema():
                     schema.Option(display = name, value = name)
                     for name in AVAILABLE_FEEDS.keys()
                 ],
-                default = "NYT Home Page",
+                default = "BBC Top Stories",
             ),
             schema.Color(
                 id = "header_color",

--- a/apps/newsmix/news_mix.star
+++ b/apps/newsmix/news_mix.star
@@ -23,15 +23,14 @@ AVAILABLE_FEEDS = {
     "WSJ US Business": "https://feeds.content.dowjones.io/public/rss/WSJcomUSBusiness",
     "WSJ Economy": "https://feeds.content.dowjones.io/public/rss/socialeconomyfeed",
     "WSJ Politics": "https://feeds.content.dowjones.io/public/rss/socialpoliticsfeed",
-    # NYT feeds
-    "NYT Home Page": "https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml",
-    "NYT World": "https://rss.nytimes.com/services/xml/rss/nyt/World.xml",
-    "NYT Politics": "https://rss.nytimes.com/services/xml/rss/nyt/Politics.xml",
-    "NYT Technology": "https://rss.nytimes.com/services/xml/rss/nyt/Technology.xml",
-    "NYT Business": "https://rss.nytimes.com/services/xml/rss/nyt/Business.xml",
-    "NYT Science": "https://rss.nytimes.com/services/xml/rss/nyt/Science.xml",
+    # Washington Post feeds
+    "WaPo National": "https://feeds.washingtonpost.com/rss/national",
+    "WaPo World": "https://feeds.washingtonpost.com/rss/world",
+    "WaPo Business": "https://feeds.washingtonpost.com/rss/business",
+    "WaPo Technology": "https://feeds.washingtonpost.com/rss/business/technology",
     # Other news sources...
     "BBC Top Stories": "http://feeds.bbci.co.uk/news/rss.xml",
+    "BBC World News": "https://feeds.bbci.co.uk/news/world/rss.xml",
     "CNN Top Stories": "http://rss.cnn.com/rss/cnn_topstories.rss",
     "NPR News": "https://feeds.npr.org/1001/rss.xml",
     "The Guardian": "https://www.theguardian.com/international/rss",


### PR DESCRIPTION
Per https://github.com/tidbyt/community/pull/2931#issuecomment-2704796981, remove NYT RSS feeds from the app