### PR TITLE
fix: address off-by-one error

### DIFF
--- a/apps/gw2_fractals/gw2_fractals.star
+++ b/apps/gw2_fractals/gw2_fractals.star
@@ -230,10 +230,11 @@ THEME = {
 
 FRAMES_PER_SCREEN = 125
 
-def is_leap_year(year):
-    return (math.mod(year, 400) == 0 or
-            (math.mod(year, 4) == 0 and
-             math.mod(year, 100) != 0))
+# The length of the months, in days. We use this for calculating the DOY index.
+# The DOY index is static -- March 1 is always 60, whether it's a leap year or
+# not. When not in a leap year, the index skips from 58 -> 60. Therefore, for
+# the purposes of calculating our index, February always has 29 days.
+CALENDAR_MONTH_DURATIONS_FOR_INDICES = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
 
 # Returns a day of year index (0-365) that is fixed to a given month and day. Meaning that for every combination
 # of month and day the index will be the same in both leap and non leap years. Notably this will skip the index
@@ -243,17 +244,9 @@ def is_leap_year(year):
 def get_day_of_year_index():
     utc = time.now().in_location("UTC")
 
-    common_calendar = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
-    leap_calendar = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
-
-    if is_leap_year(utc.year):
-        calendar = leap_calendar
-    else:
-        calendar = common_calendar
-
     index = 0
     for month in range(utc.month - 1):
-        index += calendar[month]
+        index += CALENDAR_MONTH_DURATIONS_FOR_INDICES[month]
     index += utc.day - 1
 
     return index


### PR DESCRIPTION
~~I'm not fully sure what changed, but an off-by-one error suddenly started showing up this month in my GW2 Fractals app. This addresses it and brings it in line with the values found in the referenced script [here](https://wiki.guildwars2.com/wiki/Template:Day_of_year_index#Return_values).~~

EDIT: Just kidding, it was a leap year/non-leap year issue. The previous implementation wasn't skipping 59 on non-leap years like expected. I've compared the results of this function with the values from the tab [here](https://wiki.guildwars2.com/wiki/Template:Day_of_year_index#Return_values) for various dates in leap years and non-leap years to confirm it's working.