### PR TITLE
Update PiHole app to support both v5 and v6 API versions

### DIFF
--- a/apps/pihole/pihole.star
+++ b/apps/pihole/pihole.star
@@ -13,27 +13,65 @@ load("schema.star", "schema")
 
 HOST = ""
 API_KEY = ""
+VERSION = "V5"
 GREEN = "#00cc00"
 RED = "#ff4136"
 PIHOLE_LOGO = base64.decode("""
 iVBORw0KGgoAAAANSUhEUgAAAAoAAAAPCAYAAADd/14OAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAhGVYSWZNTQAqAAAACAAFARIAAwAAAAEAAQAAARoABQAAAAEAAABKARsABQAAAAEAAABSASgAAwAAAAEAAgAAh2kABAAAAAEAAABaAAAAAAAAAEgAAAABAAAASAAAAAEAA6ABAAMAAAABAAEAAKACAAQAAAABAAAACqADAAQAAAABAAAADwAAAAAAolqGAAAACXBIWXMAAAsTAAALEwEAmpwYAAACymlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iWE1QIENvcmUgNi4wLjAiPgogICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPgogICAgICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAgICAgICAgICB4bWxuczp0aWZmPSJodHRwOi8vbnMuYWRvYmUuY29tL3RpZmYvMS4wLyIKICAgICAgICAgICAgeG1sbnM6ZXhpZj0iaHR0cDovL25zLmFkb2JlLmNvbS9leGlmLzEuMC8iPgogICAgICAgICA8dGlmZjpZUmVzb2x1dGlvbj43MjwvdGlmZjpZUmVzb2x1dGlvbj4KICAgICAgICAgPHRpZmY6UmVzb2x1dGlvblVuaXQ+MjwvdGlmZjpSZXNvbHV0aW9uVW5pdD4KICAgICAgICAgPHRpZmY6WFJlc29sdXRpb24+NzI8L3RpZmY6WFJlc29sdXRpb24+CiAgICAgICAgIDx0aWZmOk9yaWVudGF0aW9uPjE8L3RpZmY6T3JpZW50YXRpb24+CiAgICAgICAgIDxleGlmOlBpeGVsWERpbWVuc2lvbj4xMDA8L2V4aWY6UGl4ZWxYRGltZW5zaW9uPgogICAgICAgICA8ZXhpZjpDb2xvclNwYWNlPjE8L2V4aWY6Q29sb3JTcGFjZT4KICAgICAgICAgPGV4aWY6UGl4ZWxZRGltZW5zaW9uPjE0NzwvZXhpZjpQaXhlbFlEaW1lbnNpb24+CiAgICAgIDwvcmRmOkRlc2NyaXB0aW9uPgogICA8L3JkZjpSREY+CjwveDp4bXBtZXRhPgr+qcsGAAABt0lEQVQoFU2QvWtUURDFf+++t5t1s4/nipEYVAixsRL8QEGw879IIQFRLBbBwlRqFe0sREzEwjQpBFuNjSuCH8UqaMDKWIgoQVldk7ju7tuM5964mIG5M3PPmXNnLtWH1fnsSdZMG+n1sQZlZIcbFHzcai5y0TtXdVUSLv0cKtcx3Osj9FgvHIpzzqiOfUNUeTY6kuTtD51hc0mal45BbTTrvn0wxvN2r79M0faLHG2qP81OjbxK8/Gl8gpfS7dpFj/vtsT29jgZCEFVT4ViKZtgOZ1aeJxMz7xJFrFt+/x9va6hvBma4V+h/LL8j/zHOswEgo77njMwG2fOdmL9Cl3bRa7a5kvMDvAQW3BDKmYxHUsUi9gv+HYvwmYdtzwpeuSY1pDXvkBbGy8c2Ah/ubroKH+EyR0ircKV6I6j/RsKFc3Rinhxsc8Jr3Az5uV247iwnn/N9dUwLFJR4FDYzdOEbrAiJToS0SYtF0fUREAzcdT4pO6G/P2k0d0Dawd1PxFxQQHmHGfvOmxNAmEpv9h/PxdIDUn7RNud3wIOiDWPXWXz050I4fe/w2nlTXlLPuVJdWHK3V/RlKiIvdMq6AAAAABJRU5ErkJggg==
 """)
 
-def get_pihole_stats(endpoint, api_key):
-    resp = http.get("http://%s/admin/api.php" % endpoint, params = {"summaryRaw": "", "auth": api_key})
-    if resp.status_code != 200:
-        fail("PiHole request failed with status %d", resp.status_code)
-    summary = resp.json()
+version_options = [
+    schema.Option(
+        display = "V5",
+        value = "v5",
+    ),
+    schema.Option(
+        display = "V6",
+        value = "v6",
+    ),
+]
 
-    resp = http.get("http://%s/admin/api.php" % endpoint, params = {"overTimeData10mins": "", "auth": api_key})
+def get_pihole_stats(endpoint, api_key):
+    resp = http.get("http://%s/admin/api.php" % endpoint, params = {"summaryRaw": "", "auth": api_key}, ttl_seconds = 360)
     if resp.status_code != 200:
-        fail("PiHole request failed with status %d", resp.status_code)
-    plot_data = resp.json()
+        print("PiHole request failed with status %d", resp.status_code)
+        summary = None
+    else:
+        summary = resp.json()
+
+    resp = http.get("http://%s/admin/api.php" % endpoint, params = {"overTimeData10mins": "", "auth": api_key}, ttl_seconds = 360)
+    if resp.status_code != 200:
+        print("PiHole request failed with status %d", resp.status_code)
+        plot_data = None
+    else:
+        plot_data = resp.json()
+    return summary, plot_data
+
+def get_pihole_v6_stats(endpoint, api_key):
+    resp = http.post("http://%s/api/auth" % endpoint, json_body = {"password": api_key}, ttl_seconds = 360)
+    if resp.status_code != 200:
+        print("PiHole request failed with status %d", resp.status_code)
+    sid = resp.json()["session"]["sid"]
+
+    resp = http.get("http://%s/api/stats/summary" % endpoint, params = {"sid": sid}, ttl_seconds = 360)
+    if resp.status_code != 200:
+        print("PiHole request failed with status %d", resp.status_code)
+        summary = None
+    else:
+        summary = resp.json()
+
+    resp = http.get("http://%s/api/history" % endpoint, params = {"sid": sid}, ttl_seconds = 360)
+    if resp.status_code != 200:
+        print("PiHole request failed with status %d", resp.status_code)
+        plot_data = None
+    else:
+        plot_data = resp.json()
     return summary, plot_data
 
 def main(config):
     host = config.str("host", HOST)
     api_key = config.str("api_key", API_KEY)
+    version = config.str("version", VERSION)
     total_queries = 0
     total_ads = 0
     query_plot = []
@@ -71,23 +109,42 @@ def main(config):
         )
 
     else:
-        summary, plot_data = get_pihole_stats(host, api_key)
-        total_queries = summary["dns_queries_today"]
-        total_ads = summary["ads_blocked_today"]
-        ads_percentage = summary["ads_percentage_today"]
+        summary, plot_data = get_pihole_stats(host, api_key) if version == "v5" else get_pihole_v6_stats(host, api_key)
 
-        query_plot_time_buckets = sorted(plot_data["domains_over_time"].keys())
-        for idx, time_bucket in enumerate(query_plot_time_buckets):
-            if idx >= len(query_plot):
-                query_plot.append(plot_data["domains_over_time"][time_bucket])
-            else:
-                query_plot[idx] = plot_data["domains_over_time"][time_bucket]
-        ad_plot_time_buckets = sorted(plot_data["ads_over_time"].keys())
-        for idx, time_bucket in enumerate(ad_plot_time_buckets):
-            if idx >= len(ad_plot):
-                ad_plot.append(plot_data["ads_over_time"][time_bucket])
-            else:
-                ad_plot[idx] = plot_data["ads_over_time"][time_bucket]
+        if not summary or not plot_data:
+            return render.Root(
+                render.Column(
+                    expanded = True,
+                    main_align = "space_around",
+                    children = [
+                        render.Marquee (
+                            width = 64,
+                            child = render.Text("Error! Check APP config.", color = RED),
+                        ),
+                    ],
+                ),
+            )
+
+        total_queries = summary["dns_queries_today"] if version == "v5" else summary["queries"]["total"]
+        total_ads = summary["ads_blocked_today"] if version == "v5" else summary["queries"]["blocked"]
+        ads_percentage = summary["ads_percentage_today"] if version == "v5" else summary["queries"]["percent_blocked"]
+
+        if version == "v5":
+            query_plot_time_buckets = sorted(plot_data["domains_over_time"].keys())
+            for idx, time_bucket in enumerate(query_plot_time_buckets):
+                if idx >= len(query_plot):
+                    query_plot.append(plot_data["domains_over_time"][time_bucket])
+                else:
+                    query_plot[idx] = plot_data["domains_over_time"][time_bucket]
+            ad_plot_time_buckets = sorted(plot_data["ads_over_time"].keys())
+            for idx, time_bucket in enumerate(ad_plot_time_buckets):
+                if idx >= len(ad_plot):
+                    ad_plot.append(plot_data["ads_over_time"][time_bucket])
+                else:
+                    ad_plot[idx] = plot_data["ads_over_time"][time_bucket]
+        else:
+            query_plot = [x["total"] for x in plot_data["history"]]
+            ad_plot = [x["blocked"] for x in plot_data["history"]]
 
         return render.Root(
             render.Column(
@@ -112,7 +169,7 @@ def main(config):
                                         render.Row(
                                             children = [
                                                 render.Text(humanize.comma(int(total_ads)), color = RED),
-                                                render.Text(" (" + humanize.ftoa(ads_percentage, 1) + "%)", color = RED),
+                                                render.Text(" ("+ humanize.ftoa(ads_percentage, 0) + "%)", color = RED),
                                             ],
                                         ),
                                     ],
@@ -165,6 +222,14 @@ def get_schema():
                 name = "API Key",
                 desc = "Pi-hole API Key",
                 icon = "key",
+            ),
+            schema.Dropdown(
+                id = "version",
+                name = "Version",
+                desc = "Pi-hole Version",
+                icon = "v",
+                default = version_options[0].value,
+                options = version_options,
             ),
         ],
     )

--- a/apps/pihole/pihole.star
+++ b/apps/pihole/pihole.star
@@ -117,7 +117,7 @@ def main(config):
                     expanded = True,
                     main_align = "space_around",
                     children = [
-                        render.Marquee (
+                        render.Marquee(
                             width = 64,
                             child = render.Text("Error! Check APP config.", color = RED),
                         ),
@@ -169,7 +169,7 @@ def main(config):
                                         render.Row(
                                             children = [
                                                 render.Text(humanize.comma(int(total_ads)), color = RED),
-                                                render.Text(" ("+ humanize.ftoa(ads_percentage, 0) + "%)", color = RED),
+                                                render.Text(" (" + humanize.ftoa(ads_percentage, 0) + "%)", color = RED),
                                             ],
                                         ),
                                     ],


### PR DESCRIPTION
## Changes Made
- Added support for both PiHole v5 and v6 API versions through version selection dropdown
- Implemented separate API handling functions for each version:
  - `get_pihole_stats()` for v5 using `/admin/api.php` endpoints
  - `get_pihole_v6_stats()` for v6 using session-based authentication and newer REST API endpoints
- Updated schema to include version selection dropdown
- Maintained backward compatibility with existing v5 installations

## API Details
- V5: Uses token-based auth with `auth` parameter
  - `/admin/api.php?summaryRaw` for statistics
  - `/admin/api.php?overTimeData10mins` for graph data
- V6: Uses session-based auth with `/api/auth` endpoint
  - `/api/stats/summary` for statistics
  - `/api/history` for graph data

## Testing
- Tested with both PiHole v5 and v6 instances
- Verified graph plotting works correctly with both API versions
- Confirmed statistics display is consistent between versions

## Notes
Users need to select their PiHole version in the app configuration. Defaults to v5 for compatibility with existing installations.