### PR TITLE
Add Events List app to community apps

### DIFF
--- a/apps/upcoming_events/manifest.yaml
+++ b/apps/upcoming_events/manifest.yaml
@@ -1,0 +1,6 @@
+---
+id: upcoming-events
+name: Events List
+summary: List of upcoming events
+desc: Displays a list of upcoming events from a Google Calendar iCal URL.
+author: jblaker

--- a/apps/upcoming_events/upcoming_events.star
+++ b/apps/upcoming_events/upcoming_events.star
@@ -37,7 +37,8 @@ def main(config):
 
         if line.startswith("END:VEVENT"):
             creatingEvent = False
-            events.append(event)
+            if event["date"] >= time.now():
+                events.append(event)
 
         if creatingEvent:
             if line.startswith("SUMMARY:"):
@@ -59,7 +60,8 @@ def main(config):
 
                 parsedTime = time.parse_time(adjustedTimestamp)
                 timezone = config.get("timezone") or "America/New_York"
-                event["date"] = parsedTime.in_location(timezone).format("01/02")
+                event["date"] = parsedTime
+                event["formattedDate"] = parsedTime.in_location(timezone).format("01/02")
 
     maxEvents = int(config.get("number_of_events", "5"))
     events = sorted(events, key = lambda x: x["date"])[:maxEvents]
@@ -85,7 +87,7 @@ def main(config):
                                 children = [
                                     render.Padding(
                                         pad = (1, 0, 0, 0),
-                                        child = render.Text(content = event["date"], font = "tom-thumb"),
+                                        child = render.Text(content = event["formattedDate"], font = "tom-thumb"),
                                     ),
                                 ],
                             ),

--- a/apps/upcoming_events/upcoming_events.star
+++ b/apps/upcoming_events/upcoming_events.star
@@ -38,8 +38,6 @@ def main(config):
         if line.startswith("END:VEVENT"):
             creatingEvent = False
             events.append(event)
-            if len(events) == int(config.get("number_of_events", "5")):
-                break
 
         if creatingEvent:
             if line.startswith("SUMMARY:"):
@@ -62,6 +60,9 @@ def main(config):
                 parsedTime = time.parse_time(adjustedTimestamp)
                 timezone = config.get("timezone") or "America/New_York"
                 event["date"] = parsedTime.in_location(timezone).format("01/02")
+
+    maxEvents = int(config.get("number_of_events", "5"))
+    events = sorted(events,  key = lambda x: x["date"])[:maxEvents]
 
     layout = []
 
@@ -139,7 +140,7 @@ def get_schema():
                 name = "Number of Events",
                 desc = "The number of events you want to see.",
                 icon = "gear",
-                default = "1",
+                default = "5",
             ),
             schema.Dropdown(
                 id = "speed",

--- a/apps/upcoming_events/upcoming_events.star
+++ b/apps/upcoming_events/upcoming_events.star
@@ -1,0 +1,153 @@
+"""
+Applet: Events List
+Summary: List of upcoming events
+Description: Displays a list of upcoming events from a Google Calendar iCal URL.
+Author: jblaker
+"""
+
+load("http.star", "http")
+load("render.star", "render")
+load("schema.star", "schema")
+load("time.star", "time")
+
+DEBUG_URL = ""
+
+def main(config):
+    url = config.str("calendar_url", "")
+    if url == "":
+        return render.Root(
+            render.Padding(
+                pad = (1, 1, 1, 1),
+                child = render.WrappedText("Enter a Google Calender iCal URL", font = "tom-thumb"),
+            ),
+        )
+    rep = http.get(url)
+    if rep.status_code != 200:
+        fail("Google Calender request failed with status %d", rep.status_code)
+    lines = rep.body().split("\n")
+
+    events = []
+    event = {}
+    creatingEvent = False
+
+    for line in lines:
+        if line.startswith("BEGIN:VEVENT"):
+            creatingEvent = True
+            event = {}
+
+        if line.startswith("END:VEVENT"):
+            creatingEvent = False
+            events.append(event)
+            if len(events) == int(config.get("number_of_events", "5")):
+                break
+
+        if creatingEvent:
+            if line.startswith("SUMMARY:"):
+                event["name"] = line.split(":")[1]
+
+            if line.startswith("DTSTART:"):
+                # 20250426T000000Z
+                # YYYYMMDDTHHMMSSZ
+
+                timestamp = line.split(":")[1]
+                year = timestamp[0:4]
+                month = timestamp[4:6]
+                day = timestamp[6:8]
+                hour = timestamp[9:11]
+                minutes = timestamp[11:13]
+
+                # 2021-03-22T23:20:50.52Z
+                adjustedTimestamp = year + "-" + month + "-" + day + "T" + hour + ":" + minutes + ":00.00Z"
+
+                parsedTime = time.parse_time(adjustedTimestamp)
+                timezone = config.get("timezone") or "America/New_York"
+                event["date"] = parsedTime.in_location(timezone).format("01/02")
+
+    layout = []
+
+    counter = 0
+
+    if len(events) > 0:
+        for event in events:
+            rowColor = "#ffc300" if ((counter % 2) == 0) else "#a2d9ce"
+            layout.append(
+                render.Padding(
+                    pad = (0, 0, 0, 3),
+                    child = render.Row(
+                        children = [
+                            render.Column(
+                                children = [
+                                    render.WrappedText(content = event["name"], font = "tom-thumb", color = str(rowColor), width = 42),
+                                ],
+                            ),
+                            render.Column(
+                                children = [
+                                    render.Padding(
+                                        pad = (1, 0, 0, 0),
+                                        child = render.Text(content = event["date"], font = "tom-thumb"),
+                                    ),
+                                ],
+                            ),
+                        ],
+                    ),
+                ),
+            )
+            counter += 1
+
+    else:
+        return render.Root(
+            render.Padding(
+                pad = (1, 1, 1, 1),
+                child = render.WrappedText("Could not parse calender data.", font = "tom-thumb"),
+            ),
+        )
+
+    scroll_opt = config.str("speed", "100")
+    return render.Root(
+        delay = int(scroll_opt),  #speed up scroll text
+        show_full_animation = True,
+        child = render.Padding(
+            pad = (1, 1, 1, 1),
+            child = render.Marquee(
+                scroll_direction = "vertical",
+                width = 60,
+                height = 30,
+                child = render.Column(
+                    children = layout,
+                ),
+            ),
+        ),
+    )
+
+def get_schema():
+    scroll_speed = [
+        schema.Option(display = "Slow", value = "200"),
+        schema.Option(display = "Normal (Default)", value = "100"),
+        schema.Option(display = "Fast", value = "30"),
+    ]
+    return schema.Schema(
+        version = "1",
+        fields = [
+            schema.Text(
+                id = "calendar_url",
+                name = "Calendar URL",
+                desc = "Your Google Calendar iCal URL",
+                icon = "calendar",
+            ),
+            schema.Text(
+                id = "number_of_events",
+                name = "Number of Events",
+                desc = "The number of events you want to see.",
+                icon = "gear",
+                default = "1",
+            ),
+            schema.Dropdown(
+                id = "speed",
+                name = "Scroll Speed",
+                desc = "Change speed that text scrolls.",
+                icon = "gear",
+                default = scroll_speed[1].value,
+                options = scroll_speed,
+            ),
+        ],
+    )

--- a/apps/upcoming_events/upcoming_events.star
+++ b/apps/upcoming_events/upcoming_events.star
@@ -62,7 +62,7 @@ def main(config):
                 event["date"] = parsedTime.in_location(timezone).format("01/02")
 
     maxEvents = int(config.get("number_of_events", "5"))
-    events = sorted(events,  key = lambda x: x["date"])[:maxEvents]
+    events = sorted(events, key = lambda x: x["date"])[:maxEvents]
 
     layout = []
 


### PR DESCRIPTION
This app accepts an iCal URL from a public Google Calendar and can display multiple events along with their dates. 

I put this together because we had been using multiple tidbyt calendar apps for upcoming events and sometimes forgetting to add them. Now this can pull from our shared events calendar without to worry about adding another calendar app for each upcoming event.