### PR TITLE
Fix NYC ASP Status App

### DIFF
--- a/apps/nycaspstatus/manifest.yaml
+++ b/apps/nycaspstatus/manifest.yaml
@@ -1,5 +1,5 @@
 ---
-id: nyc-asp-status
+id: nycaspstatus
 name: NYC ASP Status
 summary: NYC alt side parking status
 desc: Displays whether New York City alternate side parking (street cleaning) rules are in effect today (or next day after 3PM).

--- a/apps/nycaspstatus/manifest.yaml
+++ b/apps/nycaspstatus/manifest.yaml
@@ -1,6 +1,6 @@
 ---
-id: nycaspstatus
+id: nyc-asp-status
 name: NYC ASP Status
-summary: Daily NYC ASP updates
-desc: Displays whether New York City alternate side parking (street cleaning) rules are in effect today (or tomorrow after 3PM).
+summary: NYC alt side parking status
+desc: Displays whether New York City alternate side parking (street cleaning) rules are in effect today (or next day after 3PM).
 author: Adam Wojciechowski

--- a/apps/nycaspstatus/nyc_asp_status.star
+++ b/apps/nycaspstatus/nyc_asp_status.star
@@ -16,7 +16,7 @@ months = ["", "Jan.", "Feb.", "Mar.", "Apr.", "May", "Jun.", "Jul.", "Aug.", "Se
 days = ["", "1st", "2nd", "3rd", "4th", "5th", "6th", "7th", "8th", "9th", "10th", "11th", "12th", "13th", "14th", "15th", "16th", "17th", "18th", "19th", "20th", "21st", "22nd", "23rd", "24th", "25th", "26th", "27th", "28th", "29th", "30th", "31st"]
 
 URL = "https://api.nyc.gov/public/api/GetCalendar?"
-API_KEY = "AV6+xWcEuiZgzuPTF40pWIq39rK6Mr6N65j+exjA9ObCPDe+amX/8pM8RgWoPlhp5MsOJrgye6MjoJB0sp0aAj0IN9ux7Z6HuBrNJ9wfMIfg+UzETCcHWfpwFrlfQ9ZqsfLihVzy3u401/0ujVLOXq1keO4="
+API_KEY = "AV6+xWcE+YMm4G7gYV3hsgC6XO9XBxoNBMw1B4gG84iLo24VAPx3tG0tmCSyzMglcBeNT5LFENVoEmi5foVQ6S85R4uYaVTr/Cl8FTs98wIoh9DVpW7ixeguWF/T9hoLgNrhEp201IbPBYkeOWUBV9Lofm8m2k6KTVvQrZAKM49tKUP3iao="
 
 TTL_SECONDS = 300
 

--- a/apps/nycaspstatus/nyc_asp_status.star
+++ b/apps/nycaspstatus/nyc_asp_status.star
@@ -1,7 +1,7 @@
 """
 Applet: NYC ASP Status
-Summary: Daily NYC ASP status update
-Description: Shows if New York City alternate side parking (street cleaning) rules are in effect for today (and next day after 3PM).
+Summary: NYC alt side parking status
+Description: Displays whether New York City alternate side parking (street cleaning) rules are in effect today (or next day after 3PM).
 Author: Adam Wojciechowski
 """
 
@@ -16,7 +16,7 @@ months = ["", "Jan.", "Feb.", "Mar.", "Apr.", "May", "Jun.", "Jul.", "Aug.", "Se
 days = ["", "1st", "2nd", "3rd", "4th", "5th", "6th", "7th", "8th", "9th", "10th", "11th", "12th", "13th", "14th", "15th", "16th", "17th", "18th", "19th", "20th", "21st", "22nd", "23rd", "24th", "25th", "26th", "27th", "28th", "29th", "30th", "31st"]
 
 URL = "https://api.nyc.gov/public/api/GetCalendar?"
-API_KEY = "AV6+xWcEmWCuOJrV+1l+H3+fCswazDOlfYCGy5lRbbmhDu1YNfUlw54m62mJJ95yl3EUTy0BH8OsD895GSvqASyRF8MTY9e1vW4TB+w6AXDt9RzBf7kMUtaZ4Vyal1HA85WXA0v2eSEb5IXmIe8T8dzwKO7VRrOaBJ8xVH6xI0U9uQ948f8="
+API_KEY = "AV6+xWcEuiZgzuPTF40pWIq39rK6Mr6N65j+exjA9ObCPDe+amX/8pM8RgWoPlhp5MsOJrgye6MjoJB0sp0aAj0IN9ux7Z6HuBrNJ9wfMIfg+UzETCcHWfpwFrlfQ9ZqsfLihVzy3u401/0ujVLOXq1keO4="
 
 TTL_SECONDS = 300
 


### PR DESCRIPTION
NYC ASP Status app is not rendering on the community hub, nor in the Tidbyt cloud. This is probably caused by a mismatched app id, when I originally uploaded the manifest and .star files.

So, I created a new pixlet app and generated a new encrypted key using its id. Everything should match now.

I updated the manifest to reflect the new id, and updated the .star file with the updated encrypted key.