### PR TITLE
fix: clean up nycaspstatus manifest

### DIFF
--- a/apps/nycaspstatus/manifest.yaml
+++ b/apps/nycaspstatus/manifest.yaml
@@ -4,3 +4,5 @@ name: NYC ASP Status
 summary: Daily NYC ASP updates
 desc: Displays whether New York City alternate side parking (street cleaning) rules are in effect today (or tomorrow after 3PM).
 author: Adam Wojciechowski
+fileName: nyc_asp_status.star
+packageName: nycaspstatus


### PR DESCRIPTION
This pull request includes a small change to the `apps/nycaspstatus/manifest.yaml` file. The change adds the `fileName` and `packageName` fields to the manifest to provide additional metadata about the NYC ASP Status application.

* [`apps/nycaspstatus/manifest.yaml`](diffhunk://#diff-ed940dad8acaff758ac2cad07400143b096548c7657a3a24a5fbacf652bd50b5R7-R8): Added `fileName` and `packageName` fields to the manifest.