### PR TITLE
Update pinball_map.star ttl_seconds from 30 to 600

### DIFF
--- a/apps/pinballmap/pinball_map.star
+++ b/apps/pinballmap/pinball_map.star
@@ -8,7 +8,7 @@ load("http.star", "http")
 load("render.star", "render")
 load("schema.star", "schema")
 
-CACHE_TIME_IN_SECONDS = 30
+CACHE_TIME_IN_SECONDS = 600
 DEFAULT_MAX_DISTANCE = 10
 DEFAULT_LOCATION = json.encode({
     "lat": "40.6781784",


### PR DESCRIPTION
I am a developer of the API that this app uses. Due to the apparent popularity of it, the endpoint is getting hit over 30k times a day when using a ttl_seconds of 30. This PR is an update to the Pinball Map Tidbyt app that increases the ttl to 10 minutes. This seems like a reasonable amount of time.

I await @scottwainstock 's review.