### PR TITLE
Oscar's Custard: Correct spelling, fix HTML parsing

### DIFF
--- a/apps/oscarscustard/manifest.yaml
+++ b/apps/oscarscustard/manifest.yaml
@@ -1,7 +1,7 @@
 ---
 id: oscars-custard
-name: Oscars's Custard
-summary: Today's Oscars's flavors
+name: Oscar's Custard
+summary: Today's Oscar's flavors
 desc: Get today's flavors at Oscar's Frozen Custard.
 author: Josiah Winslow
 fileName: oscars_custard.star

--- a/apps/oscarscustard/oscars_custard.star
+++ b/apps/oscarscustard/oscars_custard.star
@@ -1,5 +1,5 @@
 """
-Applet: Oscars's Custard
+Applet: Oscar's Custard
 Summary: Today's Oscar's flavors
 Description: Get today's flavors at Oscar's Frozen Custard.
 Author: Josiah Winslow
@@ -138,13 +138,13 @@ PALETTE_HINTS = {
     "COOKIE": PEACH,
     "CUSTARD": WHITE,
     "GRAND": RED,
-    "OL'": WHITE,
     "HEATH": ORANGE,
     "HOG": PINK,
     "MINT": LIGHT_GREEN,
     "MONKEY": BROWN,
     "MUDD": BEIGE,
     "-N-": WHITE,
+    "OL'": WHITE,
     "OSCAR'S": PEACH,
     "PEANUTBUTTER": TAN,
     "PISTACHIO": GREEN,
@@ -382,8 +382,8 @@ def main():
         ),
     ] * 86)
 
-    # Calculate RNG seed based on flavor(s) of the day
     for flavor in items["flavors"]:
+        # Calculate RNG seed based on flavor(s) of the day
         flavor_seed = 0x600df00d ^ hash(flavor)
         random.seed(flavor_seed)
         bg_color, fg_color = palette_from_name(flavor)

--- a/apps/oscarscustard/oscars_custard.star
+++ b/apps/oscarscustard/oscars_custard.star
@@ -6,6 +6,7 @@ Author: Josiah Winslow
 """
 
 load("encoding/base64.star", "base64")
+load("html.star", "html")
 load("http.star", "http")
 load("math.star", "math")
 load("random.star", "random")
@@ -281,7 +282,7 @@ def get_featured_items():
         return {
             "error": "Oscar's status code: %s" % rep.status_code,
         }
-    text = rep.json()["excerpt"]["rendered"]
+    text = html(rep.json()["excerpt"]["rendered"]).text()
 
     # Extract the sandwich of the month
     sandwich_match = re.match(


### PR DESCRIPTION
- Apparently when creating the app, I inadvertently spelled "Oscar's" as "Oscars's". This PR changes it to the correct spelling.
- This PR also fixes an issue where HTML entities aren't converted to their proper characters (e.g. `FUNKEEE… MONKEY` is instead shown as `FUNKEEE&8230 MONKEY`). This app went through many iterations back when the time limit for running apps was stricter; it looks like I had simply missed this.