### PR TITLE
Improve Literature Clock

### DIFF
--- a/apps/literatureclock/literature_clock.star
+++ b/apps/literatureclock/literature_clock.star
@@ -5,8 +5,6 @@ Description: Displays the time using a quote from a piece of literature. Based o
 Author: Alysha Kwok
 """
 
-load("cache.star", "cache")
-load("encoding/json.star", "json")
 load("http.star", "http")
 load("random.star", "random")
 load("render.star", "render")


### PR DESCRIPTION
After looking at the code for Literature Clock, I found a few things that could be improved.

- The source of the data was [the author's fork](https://github.com/alyshakwok/literature-clock/) of a "Literature Clock" repo, and said fork doesn't appear to have been updated since then. ([The original repo](https://github.com/JohannesNE/literature-clock/) has had many updates, changes, and corrections in that time period.)
- The caching feature of the HTTP module was not yet used, even though it evidently existed at the time.
- An `offset_start` is set on the marquee, but not an `offset_end`, making the scrolling loop improperly.

This PR addresses all of these issues.