### PR TITLE
Oscar's Custard: Update flavor regex

### DIFF
--- a/apps/oscarscustard/oscars_custard.star
+++ b/apps/oscarscustard/oscars_custard.star
@@ -301,7 +301,7 @@ def get_featured_items():
 
     # Extract the flavor of the day
     flavor_match = re.match(
-        r"Flavor of the Day.+:\s+(.+)(?:January|February|March|April|May|" +
+        r"FLAVOR OF THE DAY.+:\s+(.+)(?:January|February|March|April|May|" +
         r"June|July|August|September|October|November|December) ",
         text,
     )


### PR DESCRIPTION
The Oscar's Custard app currently shows "Unrecognized flavor"; this change fixes this by updating the regex used to parse the flavor.