### PR TITLE
The Weekendest: Update manifest for renaming to Subway Now

### DIFF
--- a/apps/goodservice/manifest.yaml
+++ b/apps/goodservice/manifest.yaml
@@ -1,8 +1,8 @@
 ---
 id: goodservice
-name: The Weekendest
-summary: The Weekendest - NYC Subway
-desc: Real-Time New York City Subway projected departure times for a selected station, as seen on The Weekendest app. Takes into account of overnight and weekend service changes.
+name: Subway Now
+summary: Subway Now - NYC Subway
+desc: More accurate realtime New York City Subway arrival times for a selected station, as seen on Subway Now app. Shows actual train destinations including overnight and weekend service changes.
 author: Sunny Ng
 fileName: goodservice.star
 packageName: goodservice


### PR DESCRIPTION
Follow-up to #3111, I forgot to update the manifest.yaml, which is where the renaming should actually happen.