### PR TITLE
Fix metar

### DIFF
--- a/apps/metar/metar.star
+++ b/apps/metar/metar.star
@@ -12,7 +12,7 @@ load("render.star", "render")
 load("schema.star", "schema")
 
 ADDS_URL = "https://aviationweather.gov/api/data/metar?ids=%s&format=json&hours=2"
-DEFAULT_AIRPORT = "KJFK, KLGA, KBOS, KDCA, KBJC, KLMO, KGXY, KAPA"
+DEFAULT_AIRPORT = "KJFK, KLGA, KBOS, KDCA"
 
 # encryption, schema
 # fail expired, add timeout to Root


### PR DESCRIPTION
Updated the `metar` app to utilize the new Data API from Aviation Weather. The old API was deprecated and fully decommissioned in Sept 2025. 

This update also implements the HTTP module native caching mechanism. Tested with local render. 

@avalys is the original author and may want to comment/approve this PR. 