### PR TITLE
Add sun, lightning bolt, and battery icons to hassgraph

### DIFF
--- a/apps/hassgraph/hass_graph.star
+++ b/apps/hassgraph/hass_graph.star
@@ -29,6 +29,15 @@ PHN2ZyB2ZXJzaW9uPSIxLjEiIGlkPSJMYXllcl8xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAw
     "car": """
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="#ffffff"><!--!Font Awesome Free 6.6.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M135.2 117.4L109.1 192l293.8 0-26.1-74.6C372.3 104.6 360.2 96 346.6 96L165.4 96c-13.6 0-25.7 8.6-30.2 21.4zM39.6 196.8L74.8 96.3C88.3 57.8 124.6 32 165.4 32l181.2 0c40.8 0 77.1 25.8 90.6 64.3l35.2 100.5c23.2 9.6 39.6 32.5 39.6 59.2l0 144 0 48c0 17.7-14.3 32-32 32l-32 0c-17.7 0-32-14.3-32-32l0-48L96 400l0 48c0 17.7-14.3 32-32 32l-32 0c-17.7 0-32-14.3-32-32l0-48L0 256c0-26.7 16.4-49.6 39.6-59.2zM128 288a32 32 0 1 0 -64 0 32 32 0 1 0 64 0zm288 32a32 32 0 1 0 0-64 32 32 0 1 0 0 64z"/></svg>
 """,
+    "sun": """
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10" fill="#FFD000" shape-rendering="crispEdges"><rect x="3" y="3" width="4" height="4"/><rect x="4" y="1" width="2" height="1"/><rect x="4" y="8" width="2" height="1"/><rect x="1" y="4" width="1" height="2"/><rect x="8" y="4" width="1" height="2"/><rect x="2" y="2" width="1" height="1"/><rect x="7" y="2" width="1" height="1"/><rect x="2" y="7" width="1" height="1"/><rect x="7" y="7" width="1" height="1"/></svg>
+""",
+    "bolt": """
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10" fill="#FFD000" shape-rendering="crispEdges"><rect x="5" y="0" width="2" height="1"/><rect x="4" y="1" width="2" height="1"/><rect x="3" y="2" width="2" height="1"/><rect x="2" y="3" width="5" height="1"/><rect x="5" y="4" width="2" height="1"/><rect x="4" y="5" width="2" height="1"/><rect x="3" y="6" width="2" height="1"/><rect x="2" y="7" width="2" height="1"/></svg>
+""",
+    "battery": """
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10" shape-rendering="crispEdges"><g fill="#FFFFFF"><rect x="1" y="3" width="7" height="1"/><rect x="1" y="7" width="7" height="1"/><rect x="1" y="4" width="1" height="3"/><rect x="7" y="4" width="1" height="3"/><rect x="8" y="4" width="1" height="3"/></g><rect x="2" y="4" width="5" height="3" fill="#37AD1A"/></svg>
+""",
 }
 
 PLACEHOLDER_DATA = [
@@ -306,6 +315,18 @@ def get_schema():
         schema.Option(
             display = "Car",
             value = "car",
+        ),
+        schema.Option(
+            display = "Sun",
+            value = "sun",
+        ),
+        schema.Option(
+            display = "Lightning Bolt",
+            value = "bolt",
+        ),
+        schema.Option(
+            display = "Battery",
+            value = "battery",
         ),
         schema.Option(
             display = "Home Assistant Icon",


### PR DESCRIPTION
Add three pixel-art icons (sun, lightning bolt, battery) to the icon set and expose them as Icon dropdown options, matching the blocky style of the existing thermometer/wind/drop icons. Useful for solar, power, and battery-level entities.